### PR TITLE
Add video version stacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # QuickCut
 
-Collaborative video review, built on Cloudflare. Upload up to 5GB, share a link, and collect timestamped feedback from your team or clients — no account required for reviewers.
+Collaborative video review, built on Cloudflare. Upload up to 5GB, stack new versions, share a link, and collect timestamped feedback from your team or clients — no account required for reviewers.
 
 > Think Frame.io, but small, focused, and running entirely on the edge.
 
 ## Features
 
 - **Resumable 5GB uploads** — drag-drop with TUS-resumable direct uploads to Cloudflare Stream
+- **Version stacking** — upload new cuts into an ordered stack while keeping review history version-specific
 - **Timestamped comments** — feedback pinned to the exact frame
 - **Threaded replies + resolve** — keep review discussions organized
 - **Review statuses** — `Needs Review` → `In Progress` → `Approved`
@@ -41,14 +42,14 @@ Serverless SQLite backs every persistent record. The `DB` binding gives the Work
 Tables (see `src/db/schema.ts`):
 - `users` — accounts (PBKDF2-hashed passwords)
 - `sessions` — server-side sessions tied to `quickcut_session` cookie
-- `videos` — Stream UID, status, review status, metadata
+- `videos` — Stream UID, status, review status, metadata, version group fields
 - `share_links` — token, status, view count
 - `comments` — timestamped, threaded (`parentId`), resolvable
 
 Migrations are managed via `drizzle-kit` and applied with `wrangler d1 migrations apply`.
 
 ### Durable Objects
-A `VideoRoom` Durable Object — one instance per video, routed deterministically with `getByName(videoId)` — fans out new comments to every connected reviewer in real time.
+A `VideoRoom` Durable Object — one instance per video version, routed deterministically with `getByName(videoId)` — fans out new comments to every connected reviewer in real time.
 
 - The Astro app upgrades `/api/videos/[id]/live` into a WebSocket forwarded to the per-video DO
 - Hibernatable WebSockets (`ctx.acceptWebSocket`) keep idle rooms at zero duration cost
@@ -95,7 +96,7 @@ src/
 │   ├── upload.astro     Upload (auth)
 │   ├── videos/[id].astro    Authenticated review view
 │   ├── s/[token].astro      Public share view (no auth)
-│   └── api/             Auth, videos, comments, share-links, webhooks, /live (WS upgrade)
+│   └── api/             Auth, videos, versions, comments, share-links, webhooks, /live (WS upgrade)
 └── styles/          Tailwind + design tokens
 migrations/          D1 migrations
 wrangler.jsonc       Worker + bindings config (DB, Durable Objects, vars)

--- a/migrations/0005_add_video_versioning.sql
+++ b/migrations/0005_add_video_versioning.sql
@@ -1,0 +1,11 @@
+ALTER TABLE `videos` ADD `version_group_id` text;
+--> statement-breakpoint
+UPDATE `videos` SET `version_group_id` = `id` WHERE `version_group_id` IS NULL;
+--> statement-breakpoint
+ALTER TABLE `videos` ADD `version_number` integer DEFAULT 1 NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `videos` ADD `is_current_version` integer DEFAULT 1 NOT NULL;
+--> statement-breakpoint
+CREATE INDEX `videos_version_group_idx` ON `videos` (`version_group_id`, `version_number`);
+--> statement-breakpoint
+CREATE INDEX `videos_current_version_idx` ON `videos` (`user_id`, `folder_id`, `is_current_version`);

--- a/src/components/ShareView.tsx
+++ b/src/components/ShareView.tsx
@@ -16,17 +16,19 @@ interface Video {
   status: string;
   streamVideoId: string | null;
   duration: number | null;
+  versionNumber: number;
 }
 
 interface ShareViewProps {
   video: Video;
+  versionCount: number;
   initialComments: Comment[];
   shareToken: string;
 }
 
 const ANON_NAME_KEY = "quickcut_anonymous_name";
 
-export function ShareView({ video, initialComments, shareToken }: ShareViewProps) {
+export function ShareView({ video, versionCount, initialComments, shareToken }: ShareViewProps) {
   const [anonymousName, setAnonymousName] = useState<string | null>(() => {
     if (typeof window === "undefined") return null;
     return localStorage.getItem(ANON_NAME_KEY);
@@ -118,6 +120,11 @@ export function ShareView({ video, initialComments, shareToken }: ShareViewProps
       )}
 
       <div>
+        {versionCount > 1 && (
+          <div className="mb-2 inline-flex rounded-full border border-border-default bg-bg-secondary px-2.5 py-1 text-xs font-medium text-text-secondary">
+            V{video.versionNumber} of {versionCount}
+          </div>
+        )}
         <h1 className="text-xl font-bold text-text-primary sm:text-2xl">{video.title}</h1>
         {video.description && (
           <p className="mt-2 text-sm text-text-secondary">{video.description}</p>

--- a/src/components/UploadForm.tsx
+++ b/src/components/UploadForm.tsx
@@ -75,6 +75,7 @@ export function UploadForm({ folderId = null }: UploadFormProps) {
           fileName: file.name,
           fileSize: file.size,
           title: title.trim() || undefined,
+          description: description.trim() || undefined,
           folderId,
         }),
       });

--- a/src/components/UploadVersionModal.tsx
+++ b/src/components/UploadVersionModal.tsx
@@ -1,0 +1,250 @@
+import { useId, useRef, useState } from "react";
+import { Modal } from "./Modal";
+
+const ALLOWED_EXTENSIONS = ["mp4", "mov", "webm", "avi", "mkv"];
+const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024;
+
+type UploadState = "idle" | "selected" | "uploading" | "processing" | "error";
+
+interface UploadVersionModalProps {
+  videoId: string;
+  title: string;
+  description: string;
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+export function UploadVersionModal({ videoId, title: initialTitle, description: initialDescription }: UploadVersionModalProps) {
+  const headingId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [open, setOpen] = useState(false);
+  const [state, setState] = useState<UploadState>("idle");
+  const [file, setFile] = useState<File | null>(null);
+  const [title, setTitle] = useState(initialTitle);
+  const [description, setDescription] = useState(initialDescription);
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState("");
+  const [dragOver, setDragOver] = useState(false);
+
+  const reset = () => {
+    setState("idle");
+    setFile(null);
+    setTitle(initialTitle);
+    setDescription(initialDescription);
+    setProgress(0);
+    setError("");
+    setDragOver(false);
+  };
+
+  const close = () => {
+    if (state === "uploading") return;
+    setOpen(false);
+    reset();
+  };
+
+  const validateFile = (selectedFile: File): string | null => {
+    const ext = selectedFile.name.split(".").pop()?.toLowerCase();
+    if (!ext || !ALLOWED_EXTENSIONS.includes(ext)) {
+      return "Unsupported file type. Please upload MP4, MOV, WebM, AVI, or MKV.";
+    }
+    if (selectedFile.size > MAX_FILE_SIZE) return "File exceeds the 5GB limit.";
+    return null;
+  };
+
+  const selectFile = (selectedFile: File) => {
+    const validationError = validateFile(selectedFile);
+    if (validationError) {
+      setError(validationError);
+      setState("error");
+      return;
+    }
+    setFile(selectedFile);
+    setError("");
+    setState("selected");
+  };
+
+  const upload = async () => {
+    if (!file) return;
+
+    setState("uploading");
+    setError("");
+    setProgress(0);
+
+    try {
+      const res = await fetch(`/api/videos/${videoId}/versions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          fileName: file.name,
+          fileSize: file.size,
+          title: title.trim() || undefined,
+          description: description.trim(),
+        }),
+      });
+
+      const data = (await res.json().catch(() => null)) as
+        | { videoId?: string; uploadUrl?: string; error?: string }
+        | null;
+
+      if (!res.ok || !data?.videoId || !data.uploadUrl) {
+        throw new Error(data?.error || "Failed to create upload");
+      }
+
+      const xhr = new XMLHttpRequest();
+      xhr.open("PATCH", data.uploadUrl);
+      xhr.setRequestHeader("Tus-Resumable", "1.0.0");
+      xhr.setRequestHeader("Upload-Offset", "0");
+      xhr.setRequestHeader("Content-Type", "application/offset+octet-stream");
+
+      xhr.upload.onprogress = (event) => {
+        if (event.lengthComputable) setProgress(Math.round((event.loaded / event.total) * 100));
+      };
+
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          setState("processing");
+          window.location.href = `/videos/${data.videoId}`;
+          return;
+        }
+        setError("Upload failed. Please try again.");
+        setState("error");
+      };
+
+      xhr.onerror = () => {
+        setError("Upload failed. Please try again.");
+        setState("error");
+      };
+
+      xhr.send(file);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Upload failed");
+      setState("error");
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded-lg border border-border-default px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-tertiary"
+      >
+        Upload new version
+      </button>
+
+      <Modal
+        isOpen={open}
+        onClose={close}
+        closeOnBackdropClick={state !== "uploading"}
+        closeOnEscape={state !== "uploading"}
+        showCloseButton={state !== "uploading"}
+        ariaLabelledBy={headingId}
+        size="md"
+      >
+        <h2 id={headingId} className="text-lg font-semibold text-text-primary">Upload new version</h2>
+        <p className="mt-1 text-sm text-text-secondary">
+          This creates the next version in the stack. Existing comments stay on their original version.
+        </p>
+
+        <div className="mt-5 space-y-4">
+          {!file && (
+            <div
+              onDrop={(event) => {
+                event.preventDefault();
+                setDragOver(false);
+                const selectedFile = event.dataTransfer.files[0];
+                if (selectedFile) selectFile(selectedFile);
+              }}
+              onDragOver={(event) => {
+                event.preventDefault();
+                setDragOver(true);
+              }}
+              onDragLeave={() => setDragOver(false)}
+              onClick={() => inputRef.current?.click()}
+              className={`cursor-pointer rounded-xl border-2 border-dashed p-8 text-center transition-colors ${dragOver ? "border-accent-primary bg-accent-primary/5" : "border-border-default hover:border-border-hover"}`}
+            >
+              <p className="text-sm font-medium text-text-primary">Drop the next cut here</p>
+              <p className="mt-1 text-xs text-text-tertiary">or click to browse</p>
+              <input
+                ref={inputRef}
+                type="file"
+                accept=".mp4,.mov,.webm,.avi,.mkv"
+                className="hidden"
+                onChange={(event) => {
+                  const selectedFile = event.target.files?.[0];
+                  if (selectedFile) selectFile(selectedFile);
+                }}
+              />
+            </div>
+          )}
+
+          {file && (
+            <div className="rounded-xl border border-border-default bg-bg-tertiary p-3">
+              <p className="truncate text-sm font-medium text-text-primary">{file.name}</p>
+              <p className="text-xs text-text-tertiary">{formatFileSize(file.size)}</p>
+            </div>
+          )}
+
+          <div>
+            <label className="mb-1 block text-sm font-medium text-text-secondary">Title</label>
+            <input
+              type="text"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              disabled={state === "uploading"}
+              className="w-full rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary focus:border-accent-primary focus:outline-none disabled:opacity-50"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm font-medium text-text-secondary">Description</label>
+            <textarea
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              disabled={state === "uploading"}
+              rows={3}
+              className="w-full resize-none rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary focus:border-accent-primary focus:outline-none disabled:opacity-50"
+            />
+          </div>
+
+          {state === "uploading" && (
+            <div>
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-text-secondary">Uploading...</span>
+                <span className="font-mono text-text-primary">{progress}%</span>
+              </div>
+              <div className="mt-2 h-2 overflow-hidden rounded-full bg-bg-tertiary">
+                <div className="h-full rounded-full bg-accent-primary transition-all duration-300" style={{ width: `${progress}%` }} />
+              </div>
+            </div>
+          )}
+
+          {error && <div className="rounded-lg bg-accent-danger/15 px-4 py-2 text-sm text-accent-danger">{error}</div>}
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={close}
+              disabled={state === "uploading"}
+              className="flex-1 rounded-lg border border-border-default px-4 py-2 text-sm text-text-primary transition-colors hover:bg-bg-tertiary disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={upload}
+              disabled={!file || !title.trim() || state === "uploading"}
+              className="flex-1 rounded-lg bg-accent-primary px-4 py-2 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover disabled:opacity-50"
+            >
+              {state === "uploading" ? "Uploading..." : "Upload version"}
+            </button>
+          </div>
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/src/components/VersionSwitcher.tsx
+++ b/src/components/VersionSwitcher.tsx
@@ -76,7 +76,7 @@ export function VersionSwitcher({ videoId }: VersionSwitcherProps) {
       {open && (
         <div
           role="menu"
-          className="absolute right-0 z-30 mt-2 w-80 max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-border-default bg-bg-secondary p-2 shadow-xl"
+          className="fixed left-1/2 top-24 z-50 max-h-[70vh] w-[calc(100vw-2rem)] max-w-sm -translate-x-1/2 overflow-y-auto rounded-xl border border-border-default bg-bg-secondary p-2 shadow-xl sm:absolute sm:left-auto sm:right-0 sm:top-auto sm:mt-2 sm:w-80 sm:max-w-[calc(100vw-2rem)] sm:translate-x-0"
         >
           <div className="px-2 pb-2 pt-1 text-xs font-medium uppercase tracking-wide text-text-tertiary">
             Versions

--- a/src/components/VersionSwitcher.tsx
+++ b/src/components/VersionSwitcher.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useRef, useState } from "react";
+
+interface VersionSummary {
+  id: string;
+  title: string;
+  status: string;
+  thumbnailUrl: string | null;
+  versionNumber: number;
+  isCurrentVersion: boolean;
+  createdAt: string;
+  commentCount: number;
+}
+
+interface VersionSwitcherProps {
+  videoId: string;
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function VersionSwitcher({ videoId }: VersionSwitcherProps) {
+  const [versions, setVersions] = useState<VersionSummary[]>([]);
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch(`/api/videos/${videoId}/versions`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: { versions?: VersionSummary[] } | null) => {
+        if (!cancelled && data?.versions) setVersions(data.versions);
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+  }, [videoId]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  if (versions.length <= 1) return null;
+
+  const currentVersion = versions.find((version) => version.id === videoId) || versions[0];
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="inline-flex h-9 items-center gap-2 rounded-lg border border-border-default bg-bg-secondary px-3 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        V{currentVersion.versionNumber} of {versions.length}
+        <svg className="h-4 w-4 text-text-tertiary" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fillRule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clipRule="evenodd" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 z-30 mt-2 w-80 max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-border-default bg-bg-secondary p-2 shadow-xl"
+        >
+          <div className="px-2 pb-2 pt-1 text-xs font-medium uppercase tracking-wide text-text-tertiary">
+            Versions
+          </div>
+          {versions.map((version) => (
+            <a
+              key={version.id}
+              role="menuitem"
+              href={`/videos/${version.id}`}
+              className={`flex gap-3 rounded-lg p-2 transition-colors hover:bg-bg-tertiary ${version.id === videoId ? "bg-bg-tertiary" : ""}`}
+            >
+              <div className="flex h-12 w-20 shrink-0 items-center justify-center overflow-hidden rounded bg-bg-primary">
+                {version.thumbnailUrl ? (
+                  <img src={version.thumbnailUrl} alt="" className="h-full w-full object-cover" />
+                ) : (
+                  <span className="text-xs text-text-tertiary">V{version.versionNumber}</span>
+                )}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-semibold text-text-primary">V{version.versionNumber}</span>
+                  {version.isCurrentVersion && (
+                    <span className="rounded-full bg-accent-secondary/15 px-2 py-0.5 text-[10px] font-medium text-accent-secondary">
+                      Current
+                    </span>
+                  )}
+                </div>
+                <p className="truncate text-xs text-text-secondary">{version.title}</p>
+                <p className="mt-0.5 text-xs text-text-tertiary">
+                  {formatDate(version.createdAt)} - {version.commentCount} comment{version.commentCount === 1 ? "" : "s"}
+                </p>
+              </div>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/VideoCard.astro
+++ b/src/components/VideoCard.astro
@@ -10,10 +10,23 @@ interface Props {
   status: "processing" | "ready" | "failed";
   createdAt: string;
   commentCount: number;
+  versionNumber?: number;
+  versionCount?: number;
   folderId?: string | null;
 }
 
-const { id, title, thumbnailUrl, duration, status, createdAt, commentCount, folderId = null } = Astro.props;
+const {
+  id,
+  title,
+  thumbnailUrl,
+  duration,
+  status,
+  createdAt,
+  commentCount,
+  versionNumber = 1,
+  versionCount = 1,
+  folderId = null,
+} = Astro.props;
 
 function formatDuration(seconds: number | null): string {
   if (!seconds) return "";
@@ -43,6 +56,11 @@ function formatDate(dateStr: string): string {
       {status !== "ready" && (
         <div class="absolute left-2 top-2">
           <StatusBadge status={status} />
+        </div>
+      )}
+      {versionCount > 1 && (
+        <div class="absolute left-2 bottom-2 rounded bg-black/75 px-1.5 py-0.5 text-xs font-medium text-white">
+          V{versionNumber}
         </div>
       )}
       {duration && (

--- a/src/components/VideoDetailView.tsx
+++ b/src/components/VideoDetailView.tsx
@@ -5,6 +5,7 @@ import { InlineEditor } from "./InlineEditor";
 import { VideoPlayer } from "./VideoPlayer";
 import { VideoPageLayout } from "./VideoPageLayout";
 import { AnnotationOverlay } from "./AnnotationOverlay";
+import { UploadVersionModal } from "./UploadVersionModal";
 import { useStreamPlayer } from "../hooks/useStreamPlayer";
 import type { Annotation, Comment } from "../types";
 import type { AnnotationTool } from "./AnnotationOverlay";
@@ -186,6 +187,11 @@ export function VideoDetailView({
           <span className="inline-flex w-full items-center gap-1 truncate sm:w-auto sm:max-w-[260px]">
             <svg className="h-3.5 w-3.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" /><polyline points="14 2 14 8 20 8" /></svg>
             {fileName}
+          </span>
+        )}
+        {isOwner && (
+          <span className="w-full sm:w-auto">
+            <UploadVersionModal videoId={videoId} title={title} description={description} />
           </span>
         )}
       </div>

--- a/src/components/VideoHeader.tsx
+++ b/src/components/VideoHeader.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { StatusDropdown, type ReviewStatus } from "./StatusDropdown";
 import { ConfirmDialog } from "./ConfirmDialog";
+import { VersionSwitcher } from "./VersionSwitcher";
 
 interface ShareLink {
   id: string;
@@ -82,7 +83,10 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl, reviewSta
     try {
       const res = await fetch(`/api/videos/${videoId}`, { method: "DELETE" });
       if (res.ok) {
-        window.location.href = "/dashboard";
+        const data = (await res.json().catch(() => null)) as
+          | { redirectVideoId?: string | null }
+          | null;
+        window.location.href = data?.redirectVideoId ? `/videos/${data.redirectVideoId}` : "/dashboard";
         return;
       }
       const data = (await res.json().catch(() => null)) as
@@ -168,6 +172,7 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl, reviewSta
       </a>
 
       <div className="ml-auto flex items-center gap-2">
+        <VersionSwitcher videoId={videoId} />
         <StatusDropdown videoId={videoId} initialStatus={reviewStatus} />
 
         <div className="relative" ref={moreMenuRef}>

--- a/src/components/VideoHeader.tsx
+++ b/src/components/VideoHeader.tsx
@@ -192,7 +192,7 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl, reviewSta
           {moreMenuOpen && (
             <div
               role="menu"
-              className="absolute right-0 z-30 mt-2 w-44 max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-border-default bg-bg-secondary py-1 shadow-lg"
+              className="fixed left-1/2 top-24 z-50 w-44 max-w-[calc(100vw-2rem)] -translate-x-1/2 overflow-hidden rounded-lg border border-border-default bg-bg-secondary py-1 shadow-lg sm:absolute sm:left-auto sm:right-0 sm:top-auto sm:mt-2 sm:translate-x-0"
             >
               <button
                 role="menuitem"
@@ -223,7 +223,7 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl, reviewSta
           <div
             role="dialog"
             aria-label="Share video"
-            className="absolute right-0 z-20 mt-2 w-[calc(100vw-2rem)] rounded-xl border border-border-default bg-bg-secondary p-4 shadow-xl sm:w-80"
+            className="fixed left-1/2 top-24 z-50 max-h-[70vh] w-[calc(100vw-2rem)] -translate-x-1/2 overflow-y-auto rounded-xl border border-border-default bg-bg-secondary p-4 shadow-xl sm:absolute sm:left-auto sm:right-0 sm:top-auto sm:mt-2 sm:w-80 sm:translate-x-0"
           >
             <div className="mb-3 flex items-center justify-between">
               <h3 className="text-sm font-semibold text-text-primary">Share for review</h3>
@@ -296,7 +296,7 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl, reviewSta
                     {menuOpen && (
                       <div
                         role="menu"
-                        className="absolute right-0 z-30 mt-1 w-44 max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-border-default bg-bg-secondary py-1 shadow-lg"
+                        className="fixed left-1/2 top-40 z-[60] w-44 max-w-[calc(100vw-2rem)] -translate-x-1/2 overflow-hidden rounded-lg border border-border-default bg-bg-secondary py-1 shadow-lg sm:absolute sm:left-auto sm:right-0 sm:top-auto sm:mt-1 sm:translate-x-0"
                       >
                         <button
                           role="menuitem"

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -57,6 +57,11 @@ export const videos = sqliteTable("videos", {
   })
     .notNull()
     .default("no_status"),
+  versionGroupId: text("version_group_id"),
+  versionNumber: integer("version_number").notNull().default(1),
+  isCurrentVersion: integer("is_current_version", { mode: "boolean" })
+    .notNull()
+    .default(true),
   streamVideoId: text("stream_video_id"),
   streamPlaybackUrl: text("stream_playback_url"),
   thumbnailUrl: text("thumbnail_url"),

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -35,6 +35,7 @@ export const uploadSchema = z.object({
   fileName: z.string().min(1, "File name is required"),
   fileSize: z.number().positive().max(5 * 1024 * 1024 * 1024, "File exceeds 5GB limit"),
   title: z.string().optional(),
+  description: z.string().max(2000).optional(),
   folderId: z.string().uuid().nullable().optional(),
 });
 

--- a/src/pages/api/videos/[id]/index.ts
+++ b/src/pages/api/videos/[id]/index.ts
@@ -2,7 +2,7 @@ import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
 import { createDb } from "../../../../db";
 import { videos, shareLinks, comments, folders } from "../../../../db/schema";
-import { and, eq, count } from "drizzle-orm";
+import { and, desc, eq, count } from "drizzle-orm";
 import { deleteVideo as deleteStreamVideo } from "../../../../lib/stream";
 import { videoUpdateSchema } from "../../../../lib/validation";
 
@@ -60,11 +60,18 @@ export const GET: APIRoute = async ({ params, locals }) => {
     .from(comments)
     .where(eq(comments.videoId, id));
 
+  const versionGroupId = video.versionGroupId || video.id;
+  const versionCountResult = await db
+    .select({ count: count() })
+    .from(videos)
+    .where(and(eq(videos.userId, locals.user.id), eq(videos.versionGroupId, versionGroupId)));
+
   return new Response(
     JSON.stringify({
       video,
       shareLink: shareLinkResult[0] || null,
       commentCount: commentCountResult[0]?.count || 0,
+      versionCount: versionCountResult[0]?.count || 1,
     }),
     { headers: { "Content-Type": "application/json" } },
   );
@@ -117,7 +124,8 @@ export const PATCH: APIRoute = async ({ params, locals, request }) => {
     });
   }
 
-  const updates: { title?: string; description?: string; folderId?: string | null } = {};
+  const updates: { title?: string; description?: string } = {};
+  let folderUpdate: string | null | undefined;
 
   if (parsed.data.title !== undefined) updates.title = parsed.data.title.trim();
   if (parsed.data.description !== undefined) updates.description = parsed.data.description.trim();
@@ -139,20 +147,32 @@ export const PATCH: APIRoute = async ({ params, locals, request }) => {
       }
     }
 
-    updates.folderId = folderId;
+    folderUpdate = folderId;
   }
 
-  if (Object.keys(updates).length === 0) {
+  if (Object.keys(updates).length === 0 && folderUpdate === undefined) {
     return new Response(JSON.stringify({ error: "No updates provided" }), {
       status: 400,
       headers: { "Content-Type": "application/json" },
     });
   }
 
-  await db
-    .update(videos)
-    .set({ ...updates, updatedAt: new Date().toISOString() })
-    .where(eq(videos.id, id));
+  const now = new Date().toISOString();
+
+  if (Object.keys(updates).length > 0) {
+    await db
+      .update(videos)
+      .set({ ...updates, updatedAt: now })
+      .where(eq(videos.id, id));
+  }
+
+  if (folderUpdate !== undefined) {
+    const versionGroupId = videoResult[0].versionGroupId || videoResult[0].id;
+    await db
+      .update(videos)
+      .set({ folderId: folderUpdate, updatedAt: now })
+      .where(and(eq(videos.userId, locals.user.id), eq(videos.versionGroupId, versionGroupId)));
+  }
 
   const updated = await db
     .select()
@@ -219,10 +239,26 @@ export const DELETE: APIRoute = async ({ params, locals }) => {
     }
   }
 
+  const versionGroupId = video.versionGroupId || video.id;
+  const remainingVersions = await db
+    .select({ id: videos.id, versionNumber: videos.versionNumber })
+    .from(videos)
+    .where(and(eq(videos.userId, locals.user.id), eq(videos.versionGroupId, versionGroupId)))
+    .orderBy(desc(videos.versionNumber));
+
+  const replacement = remainingVersions.find((version) => version.id !== id) || null;
+
   // Delete the video row. share_links and comments cascade via FK constraints.
   await db.delete(videos).where(eq(videos.id, id));
 
-  return new Response(JSON.stringify({ success: true }), {
+  if (video.isCurrentVersion && replacement) {
+    await db
+      .update(videos)
+      .set({ isCurrentVersion: true, updatedAt: new Date().toISOString() })
+      .where(eq(videos.id, replacement.id));
+  }
+
+  return new Response(JSON.stringify({ success: true, redirectVideoId: replacement?.id || null }), {
     headers: { "Content-Type": "application/json" },
   });
 };

--- a/src/pages/api/videos/[id]/versions.ts
+++ b/src/pages/api/videos/[id]/versions.ts
@@ -1,0 +1,145 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { and, count, desc, eq, sql } from "drizzle-orm";
+import { createDb } from "../../../../db";
+import { comments, videos } from "../../../../db/schema";
+import { createDirectUpload } from "../../../../lib/stream";
+import { uploadSchema } from "../../../../lib/validation";
+
+const ALLOWED_EXTENSIONS = ["mp4", "mov", "webm", "avi", "mkv"];
+const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024;
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const GET: APIRoute = async ({ params, locals }) => {
+  if (!locals.user) return json({ error: "Unauthorized" }, 401);
+
+  const { id } = params;
+  if (!id) return json({ error: "Video ID required" }, 400);
+
+  const db = createDb(env.DB);
+  const videoResult = await db.select().from(videos).where(eq(videos.id, id)).limit(1);
+  const video = videoResult[0];
+
+  if (!video) return json({ error: "Video not found" }, 404);
+  if (video.userId !== locals.user.id) return json({ error: "Forbidden" }, 403);
+
+  const versionGroupId = video.versionGroupId || video.id;
+  const versionRows = await db
+    .select()
+    .from(videos)
+    .where(and(eq(videos.userId, locals.user.id), eq(videos.versionGroupId, versionGroupId)))
+    .orderBy(desc(videos.versionNumber));
+
+  const versionIds = versionRows.map((version) => version.id);
+  let commentCounts: Record<string, number> = {};
+
+  if (versionIds.length > 0) {
+    const counts = await db
+      .select({ videoId: comments.videoId, count: count() })
+      .from(comments)
+      .where(sql`${comments.videoId} IN (${sql.join(versionIds.map((versionId) => sql`${versionId}`), sql`, `)})`)
+      .groupBy(comments.videoId);
+
+    commentCounts = Object.fromEntries(counts.map((row) => [row.videoId, row.count]));
+  }
+
+  return json({
+    versions: versionRows.map((version) => ({
+      id: version.id,
+      title: version.title,
+      status: version.status,
+      thumbnailUrl: version.thumbnailUrl,
+      duration: version.duration,
+      versionNumber: version.versionNumber,
+      isCurrentVersion: version.isCurrentVersion,
+      createdAt: version.createdAt,
+      commentCount: commentCounts[version.id] || 0,
+    })),
+  });
+};
+
+export const POST: APIRoute = async ({ params, locals, request }) => {
+  if (!locals.user) return json({ error: "Unauthorized" }, 401);
+
+  const { id } = params;
+  if (!id) return json({ error: "Video ID required" }, 400);
+
+  const parsed = uploadSchema.omit({ folderId: true }).safeParse(await request.json());
+  if (!parsed.success) {
+    return json({ error: parsed.error.issues[0]?.message || "Invalid input" }, 400);
+  }
+
+  const { fileName, fileSize, title, description } = parsed.data;
+  const ext = fileName.split(".").pop()?.toLowerCase();
+
+  if (!ext || !ALLOWED_EXTENSIONS.includes(ext)) {
+    return json({ error: "Unsupported file type. Please upload MP4, MOV, WebM, AVI, or MKV." }, 400);
+  }
+
+  if (fileSize > MAX_FILE_SIZE) {
+    return json({ error: "File exceeds the 5GB limit." }, 400);
+  }
+
+  const db = createDb(env.DB);
+  const baseResult = await db.select().from(videos).where(eq(videos.id, id)).limit(1);
+  const baseVideo = baseResult[0];
+
+  if (!baseVideo) return json({ error: "Video not found" }, 404);
+  if (baseVideo.userId !== locals.user.id) return json({ error: "Forbidden" }, 403);
+
+  const versionGroupId = baseVideo.versionGroupId || baseVideo.id;
+  const latestResult = await db
+    .select({ versionNumber: videos.versionNumber })
+    .from(videos)
+    .where(and(eq(videos.userId, locals.user.id), eq(videos.versionGroupId, versionGroupId)))
+    .orderBy(desc(videos.versionNumber))
+    .limit(1);
+
+  const nextVersionNumber = (latestResult[0]?.versionNumber || 1) + 1;
+
+  try {
+    const { uploadUrl, streamVideoId } = await createDirectUpload(
+      env.STREAM_ACCOUNT_ID,
+      env.STREAM_API_TOKEN,
+      fileName,
+      fileSize,
+    );
+
+    const videoId = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    await db
+      .update(videos)
+      .set({ isCurrentVersion: false, updatedAt: now })
+      .where(and(eq(videos.userId, locals.user.id), eq(videos.versionGroupId, versionGroupId)));
+
+    await db.insert(videos).values({
+      id: videoId,
+      userId: locals.user.id,
+      folderId: baseVideo.folderId,
+      title: title?.trim() || baseVideo.title,
+      description: description !== undefined ? description.trim() || null : baseVideo.description,
+      status: "processing",
+      reviewStatus: "no_status",
+      versionGroupId,
+      versionNumber: nextVersionNumber,
+      isCurrentVersion: true,
+      streamVideoId,
+      fileName,
+      fileSize,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return json({ videoId, uploadUrl });
+  } catch (error) {
+    console.error("Version upload error:", error);
+    return json({ error: "Upload service is temporarily unavailable. Please try again." }, 500);
+  }
+};

--- a/src/pages/api/videos/index.ts
+++ b/src/pages/api/videos/index.ts
@@ -18,9 +18,9 @@ export const GET: APIRoute = async ({ locals, url }) => {
   const folderId = url.searchParams.get("folderId");
   const where = folderId
     ? folderId === "root"
-      ? and(eq(videos.userId, locals.user.id), isNull(videos.folderId))
-      : and(eq(videos.userId, locals.user.id), eq(videos.folderId, folderId))
-    : eq(videos.userId, locals.user.id);
+      ? and(eq(videos.userId, locals.user.id), isNull(videos.folderId), eq(videos.isCurrentVersion, true))
+      : and(eq(videos.userId, locals.user.id), eq(videos.folderId, folderId), eq(videos.isCurrentVersion, true))
+    : and(eq(videos.userId, locals.user.id), eq(videos.isCurrentVersion, true));
 
   const userVideos = await db
     .select()
@@ -52,9 +52,23 @@ export const GET: APIRoute = async ({ locals, url }) => {
     commentCounts = Object.fromEntries(counts.map((c) => [c.videoId, c.count]));
   }
 
+  const versionGroupIds = userVideos.map((v) => v.versionGroupId || v.id);
+  let versionCounts: Record<string, number> = {};
+
+  if (versionGroupIds.length > 0) {
+    const counts = await db
+      .select({ versionGroupId: videos.versionGroupId, count: count() })
+      .from(videos)
+      .where(sql`${videos.versionGroupId} IN (${sql.join(versionGroupIds.map((id) => sql`${id}`), sql`, `)})`)
+      .groupBy(videos.versionGroupId);
+
+    versionCounts = Object.fromEntries(counts.map((c) => [c.versionGroupId || "", c.count]));
+  }
+
   const videosWithCounts = userVideos.map((v) => ({
     ...v,
     commentCount: commentCounts[v.id] || 0,
+    versionCount: versionCounts[v.versionGroupId || v.id] || 1,
   }));
 
   return new Response(

--- a/src/pages/api/videos/upload.ts
+++ b/src/pages/api/videos/upload.ts
@@ -25,7 +25,7 @@ export const POST: APIRoute = async ({ locals, request }) => {
     });
   }
 
-  const { fileName, fileSize, title, folderId } = parsed.data;
+  const { fileName, fileSize, title, description, folderId } = parsed.data;
 
   if (!fileName || !fileSize) {
     return new Response(
@@ -85,7 +85,11 @@ export const POST: APIRoute = async ({ locals, request }) => {
       userId: locals.user.id,
       folderId: folderId || null,
       title: videoTitle,
+      description: description?.trim() || null,
       status: "processing",
+      versionGroupId: videoId,
+      versionNumber: 1,
+      isCurrentVersion: true,
       streamVideoId,
       fileName,
       fileSize,

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -56,7 +56,7 @@ if (childFolderIds.length > 0) {
   const counts = await db
     .select({ folderId: videos.folderId, count: count() })
     .from(videos)
-    .where(and(eq(videos.userId, user.id), inArray(videos.folderId, childFolderIds)))
+    .where(and(eq(videos.userId, user.id), eq(videos.isCurrentVersion, true), inArray(videos.folderId, childFolderIds)))
     .groupBy(videos.folderId);
 
   folderVideoCounts = Object.fromEntries(counts.map((row) => [row.folderId || "", row.count]));
@@ -64,7 +64,7 @@ if (childFolderIds.length > 0) {
   const folderVideos = await db
     .select({ folderId: videos.folderId, thumbnailUrl: videos.thumbnailUrl })
     .from(videos)
-    .where(and(eq(videos.userId, user.id), inArray(videos.folderId, childFolderIds)))
+    .where(and(eq(videos.userId, user.id), eq(videos.isCurrentVersion, true), inArray(videos.folderId, childFolderIds)))
     .orderBy(desc(videos.createdAt));
 
   folderThumbnails = folderVideos.reduce<Record<string, string[]>>((acc, video) => {
@@ -80,8 +80,8 @@ const userVideos = await db
   .from(videos)
   .where(
     currentFolderId
-      ? and(eq(videos.userId, user.id), eq(videos.folderId, currentFolderId))
-      : and(eq(videos.userId, user.id), isNull(videos.folderId)),
+      ? and(eq(videos.userId, user.id), eq(videos.folderId, currentFolderId), eq(videos.isCurrentVersion, true))
+      : and(eq(videos.userId, user.id), isNull(videos.folderId), eq(videos.isCurrentVersion, true)),
   )
   .orderBy(desc(videos.createdAt));
 
@@ -99,6 +99,18 @@ if (userVideos.length > 0) {
     .groupBy(comments.videoId);
 
   commentCounts = Object.fromEntries(counts.map((c) => [c.videoId, c.count]));
+}
+
+let versionCounts: Record<string, number> = {};
+if (userVideos.length > 0) {
+  const versionGroupIds = userVideos.map((video) => video.versionGroupId || video.id);
+  const counts = await db
+    .select({ versionGroupId: videos.versionGroupId, count: count() })
+    .from(videos)
+    .where(sql`${videos.versionGroupId} IN (${sql.join(versionGroupIds.map((id) => sql`${id}`), sql`, `)})`)
+    .groupBy(videos.versionGroupId);
+
+  versionCounts = Object.fromEntries(counts.map((row) => [row.versionGroupId || "", row.count]));
 }
 ---
 
@@ -150,6 +162,8 @@ if (userVideos.length > 0) {
             status={video.status as "processing" | "ready" | "failed"}
             createdAt={video.createdAt}
             commentCount={commentCounts[video.id] || 0}
+            versionNumber={video.versionNumber}
+            versionCount={versionCounts[video.versionGroupId || video.id] || 1}
           />
         ))}
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,7 @@ if (user) {
 
 <Layout
   title="Collaborative Video Review"
-  description="QuickCut is collaborative video review built on Cloudflare. Timestamped comments, share links for clients, resumable 5GB uploads, and global HLS playback."
+  description="QuickCut is collaborative video review built on Cloudflare. Version stacks, timestamped comments, share links for clients, resumable 5GB uploads, and global HLS playback."
 >
   <!-- Marketing nav -->
   <header class="sticky top-0 z-50 border-b border-border-default bg-bg-primary/80 backdrop-blur">
@@ -56,8 +56,8 @@ if (user) {
           </span>
         </h1>
         <p class="mx-auto mt-6 max-w-2xl text-lg text-text-secondary">
-          Upload up to 5GB, share a link, and collect timestamped feedback from your team or clients —
-          no account required for reviewers. Powered by Cloudflare.
+          Upload up to 5GB, stack new cuts as versions, share a link, and collect timestamped feedback
+          from your team or clients — no account required for reviewers. Powered by Cloudflare.
         </p>
         <div class="mt-10 flex flex-wrap items-center justify-center gap-3">
           <a
@@ -225,9 +225,9 @@ if (user) {
               <path d="M9 4h6v4H9z"></path>
             </svg>
           </div>
-          <h3 class="font-semibold text-text-primary">Threaded replies & resolve</h3>
+          <h3 class="font-semibold text-text-primary">Version stacking</h3>
           <p class="mt-2 text-sm text-text-secondary">
-            Discussions stay organized. Reply inline, mark notes resolved, and keep the conversation moving.
+            Upload new cuts into an ordered stack. Switch versions without mixing comments between edits.
           </p>
         </div>
 
@@ -313,7 +313,7 @@ if (user) {
             <h3 class="font-semibold text-text-primary">Upload</h3>
           </div>
           <p class="mt-3 text-sm text-text-secondary">
-            Drag a file in. Up to 5GB. Resumable. Transcoded to HLS automatically.
+            Drag a file in. Up to 5GB. Resumable. Add later cuts as versions in the same stack.
           </p>
           <!-- Mock upload zone -->
           <div
@@ -387,7 +387,7 @@ if (user) {
             <h3 class="font-semibold text-text-primary">Review</h3>
           </div>
           <p class="mt-3 text-sm text-text-secondary">
-            Comments anchor to timestamps. Reply, resolve, repeat.
+            Comments anchor to timestamps and stay tied to the version they were created on. Reply, resolve, repeat.
           </p>
           <!-- Mock comment thread -->
           <div class="mt-5 space-y-2.5">
@@ -496,8 +496,8 @@ if (user) {
           </div>
           <h3 class="mt-4 text-lg font-semibold text-text-primary">D1</h3>
           <p class="mt-2 text-sm text-text-secondary">
-            Users, sessions, videos, comments, share links — all in serverless SQLite. We use Drizzle ORM
-            for type-safe queries with zero infrastructure to manage.
+            Users, sessions, videos, version groups, comments, share links — all in serverless SQLite.
+            We use Drizzle ORM for type-safe queries with zero infrastructure to manage.
           </p>
           <p class="mt-3 text-sm font-medium text-accent-info">
             Why it matters: no DB ops, low latency reads, scales to zero.
@@ -637,6 +637,27 @@ if (user) {
             Videos are private by default. Only people with an explicit share link can view them, and you
             can revoke any link instantly. Authentication uses PBKDF2-hashed passwords and HttpOnly secure
             cookies.
+          </p>
+        </details>
+
+        <details
+          class="group rounded-xl border border-border-default bg-bg-primary p-5 transition-colors hover:border-border-hover"
+        >
+          <summary class="flex cursor-pointer items-center justify-between text-sm font-semibold text-text-primary">
+            How do video versions work?
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              class="size-4 text-text-tertiary transition-transform group-open:rotate-180"
+            >
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </summary>
+          <p class="mt-3 text-sm text-text-secondary">
+            Each uploaded version is its own reviewable video in a shared stack. Comments, annotations,
+            share links, and review status stay tied to the specific version they were created on.
           </p>
         </details>
 

--- a/src/pages/s/[token].astro
+++ b/src/pages/s/[token].astro
@@ -3,7 +3,7 @@ import Layout from "../../layouts/Layout.astro";
 import { ShareView } from "../../components/ShareView";
 import { createDb } from "../../db";
 import { shareLinks, videos } from "../../db/schema";
-import { eq } from "drizzle-orm";
+import { and, count, eq } from "drizzle-orm";
 import { env } from "cloudflare:workers";
 import { getCommentsWithNames } from "../../lib/comments";
 
@@ -30,6 +30,7 @@ const isRevoked = shareLink.status === "revoked";
 // Get video
 let video = null;
 let allComments: any[] = [];
+let versionCount = 1;
 
 if (!isRevoked) {
   const videoResult = await db
@@ -44,6 +45,13 @@ if (!isRevoked) {
 
   video = videoResult[0];
   allComments = await getCommentsWithNames(db, shareLink.videoId);
+
+  const versionGroupId = video.versionGroupId || video.id;
+  const versionCountResult = await db
+    .select({ count: count() })
+    .from(videos)
+    .where(and(eq(videos.userId, video.userId), eq(videos.versionGroupId, versionGroupId)));
+  versionCount = versionCountResult[0]?.count || 1;
 }
 ---
 
@@ -65,6 +73,7 @@ if (!isRevoked) {
       <ShareView
         client:load
         video={video}
+        versionCount={versionCount}
         initialComments={allComments}
         shareToken={token}
       />


### PR DESCRIPTION
## Summary
- Add version grouping fields and migration so videos can be stacked as ordered versions.
- Add APIs for listing versions and uploading a new version through the existing Cloudflare Stream direct-upload flow.
- Update review, dashboard, and share views with version switching, version badges, and per-version comment/share behavior.

## Verification
- pnpm build