### PR TITLE
Add transcript generation workflow

### DIFF
--- a/migrations/0006_add_transcripts.sql
+++ b/migrations/0006_add_transcripts.sql
@@ -1,0 +1,26 @@
+ALTER TABLE `videos` ADD `transcript_requested` integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+CREATE TABLE `transcripts` (
+	`id` text PRIMARY KEY NOT NULL,
+	`video_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`status` text DEFAULT 'requested' NOT NULL,
+	`raw_text` text,
+	`cleaned_text` text,
+	`vtt` text,
+	`word_count` integer,
+	`audio_download_url` text,
+	`workflow_instance_id` text,
+	`error_message` text,
+	`requested_at` text DEFAULT (datetime('now')) NOT NULL,
+	`started_at` text,
+	`completed_at` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`video_id`) REFERENCES `videos`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `transcripts_video_id_unique` ON `transcripts` (`video_id`);
+--> statement-breakpoint
+CREATE INDEX `transcripts_user_status_idx` ON `transcripts` (`user_id`, `status`);

--- a/src/components/TranscriptPanel.tsx
+++ b/src/components/TranscriptPanel.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useRef, useState } from "react";
+
+type TranscriptStatus =
+  | "not_requested"
+  | "requested"
+  | "queued"
+  | "exporting_audio"
+  | "waiting_for_audio"
+  | "transcribing"
+  | "cleaning"
+  | "ready"
+  | "ready_raw_only"
+  | "failed"
+  | "skipped_feature_disabled";
+
+interface TranscriptRecord {
+  status: TranscriptStatus;
+  rawText: string | null;
+  cleanedText: string | null;
+  errorMessage: string | null;
+}
+
+interface TranscriptResponse {
+  transcript: TranscriptRecord | null;
+  transcriptRequested: boolean;
+  transcriptsEnabled: boolean;
+  videoStatus: string;
+}
+
+interface TranscriptPanelProps {
+  videoId: string;
+}
+
+const statusCopy: Record<TranscriptStatus, { title: string; body: string }> = {
+  not_requested: {
+    title: "Transcript not generated",
+    body: "Generate a transcript when you want a searchable text version of this video.",
+  },
+  requested: {
+    title: "Transcript requested",
+    body: "The transcript will start after the video finishes processing.",
+  },
+  queued: {
+    title: "Transcript queued",
+    body: "The transcript job is queued and will start shortly.",
+  },
+  exporting_audio: {
+    title: "Preparing audio",
+    body: "We are asking Cloudflare Stream for an audio-only version of the video.",
+  },
+  waiting_for_audio: {
+    title: "Waiting for audio",
+    body: "Cloudflare Stream is preparing the audio file for transcription.",
+  },
+  transcribing: {
+    title: "Transcribing audio",
+    body: "Workers AI is turning the audio into text.",
+  },
+  cleaning: {
+    title: "Cleaning transcript",
+    body: "An LLM is improving punctuation, paragraphs, and readability.",
+  },
+  ready: {
+    title: "Transcript ready",
+    body: "",
+  },
+  ready_raw_only: {
+    title: "Raw transcript ready",
+    body: "Cleanup failed, so this is the raw speech-to-text output.",
+  },
+  failed: {
+    title: "Transcript failed",
+    body: "Something went wrong while generating this transcript.",
+  },
+  skipped_feature_disabled: {
+    title: "Transcript unavailable",
+    body: "Transcript generation is currently disabled for this account.",
+  },
+};
+
+function isFinalStatus(status: TranscriptStatus): boolean {
+  return ["ready", "ready_raw_only", "failed", "skipped_feature_disabled", "not_requested"].includes(status);
+}
+
+export function TranscriptPanel({ videoId }: TranscriptPanelProps) {
+  const [data, setData] = useState<TranscriptResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState("");
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const load = async () => {
+    try {
+      const response = await fetch(`/api/videos/${videoId}/transcript`);
+      if (!response.ok) throw new Error("Failed to load transcript");
+      const next = (await response.json()) as TranscriptResponse;
+      setData(next);
+      setError("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load transcript");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, [videoId]);
+
+  const status: TranscriptStatus = data?.transcript?.status ?? (data?.transcriptRequested ? "requested" : "not_requested");
+
+  useEffect(() => {
+    if (!data || isFinalStatus(status)) return;
+
+    pollRef.current = setInterval(() => {
+      void load();
+    }, 4000);
+
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [data, status, videoId]);
+
+  const generate = async () => {
+    setGenerating(true);
+    setError("");
+    try {
+      const response = await fetch(`/api/videos/${videoId}/transcript`, { method: "POST" });
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error || "Failed to generate transcript");
+      }
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to generate transcript");
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <section className="rounded-xl border border-border-default bg-bg-secondary p-4">
+        <p className="text-sm text-text-secondary">Loading transcript status...</p>
+      </section>
+    );
+  }
+
+  const copy = statusCopy[status];
+  const text = data?.transcript?.cleanedText || data?.transcript?.rawText || "";
+  const canGenerate = data?.transcriptsEnabled && status === "not_requested" && data.videoStatus === "ready";
+
+  return (
+    <section className="rounded-xl border border-border-default bg-bg-secondary p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-sm font-semibold text-text-primary">{copy.title}</h2>
+          {copy.body && <p className="mt-1 text-xs text-text-tertiary">{copy.body}</p>}
+        </div>
+        {!isFinalStatus(status) && (
+          <span className="mt-1 h-2 w-2 shrink-0 animate-pulse rounded-full bg-accent-warning" />
+        )}
+      </div>
+
+      {error && <div className="mt-3 rounded-lg bg-accent-danger/15 px-3 py-2 text-xs text-accent-danger">{error}</div>}
+      {status === "failed" && data?.transcript?.errorMessage && (
+        <div className="mt-3 rounded-lg bg-accent-danger/15 px-3 py-2 text-xs text-accent-danger">
+          {data.transcript.errorMessage}
+        </div>
+      )}
+
+      {canGenerate && (
+        <button
+          type="button"
+          onClick={generate}
+          disabled={generating}
+          className="mt-4 rounded-lg bg-accent-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-50"
+        >
+          {generating ? "Starting..." : "Generate transcript"}
+        </button>
+      )}
+
+      {text && (
+        <div className="mt-4 max-h-[360px] overflow-auto whitespace-pre-wrap rounded-lg border border-border-default bg-bg-input p-4 text-sm leading-6 text-text-secondary">
+          {text}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/TranscriptPanel.tsx
+++ b/src/components/TranscriptPanel.tsx
@@ -1,17 +1,5 @@
-import { useEffect, useRef, useState } from "react";
-
-type TranscriptStatus =
-  | "not_requested"
-  | "requested"
-  | "queued"
-  | "exporting_audio"
-  | "waiting_for_audio"
-  | "transcribing"
-  | "cleaning"
-  | "ready"
-  | "ready_raw_only"
-  | "failed"
-  | "skipped_feature_disabled";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { TranscriptStatus } from "../lib/transcript-status";
 
 interface TranscriptRecord {
   status: TranscriptStatus;
@@ -78,8 +66,19 @@ const statusCopy: Record<TranscriptStatus, { title: string; body: string }> = {
   },
 };
 
+const FAST_POLL_STATUSES: TranscriptStatus[] = ["requested", "queued", "exporting_audio"];
+const SLOW_POLL_STATUSES: TranscriptStatus[] = ["waiting_for_audio", "transcribing", "cleaning"];
+const FAST_INTERVAL = 4_000;
+const SLOW_INTERVAL = 12_000;
+
 function isFinalStatus(status: TranscriptStatus): boolean {
   return ["ready", "ready_raw_only", "failed", "skipped_feature_disabled", "not_requested"].includes(status);
+}
+
+function getPollInterval(status: TranscriptStatus): number | null {
+  if (FAST_POLL_STATUSES.includes(status)) return FAST_INTERVAL;
+  if (SLOW_POLL_STATUSES.includes(status)) return SLOW_INTERVAL;
+  return null;
 }
 
 export function TranscriptPanel({ videoId }: TranscriptPanelProps) {
@@ -87,9 +86,9 @@ export function TranscriptPanel({ videoId }: TranscriptPanelProps) {
   const [loading, setLoading] = useState(true);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState("");
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const load = async () => {
+  const load = useCallback(async () => {
     try {
       const response = await fetch(`/api/videos/${videoId}/transcript`);
       if (!response.ok) throw new Error("Failed to load transcript");
@@ -101,25 +100,32 @@ export function TranscriptPanel({ videoId }: TranscriptPanelProps) {
     } finally {
       setLoading(false);
     }
-  };
+  }, [videoId]);
 
   useEffect(() => {
     void load();
-  }, [videoId]);
+  }, [load]);
 
   const status: TranscriptStatus = data?.transcript?.status ?? (data?.transcriptRequested ? "requested" : "not_requested");
 
   useEffect(() => {
-    if (!data || isFinalStatus(status)) return;
+    if (!data) return;
 
-    pollRef.current = setInterval(() => {
-      void load();
-    }, 4000);
+    const interval = getPollInterval(status);
+    if (!interval) return;
+
+    const schedule = () => {
+      pollRef.current = setTimeout(async () => {
+        await load();
+        schedule();
+      }, interval);
+    };
+    schedule();
 
     return () => {
-      if (pollRef.current) clearInterval(pollRef.current);
+      if (pollRef.current) clearTimeout(pollRef.current);
     };
-  }, [data, status, videoId]);
+  }, [data, status, load]);
 
   const generate = async () => {
     setGenerating(true);
@@ -149,6 +155,7 @@ export function TranscriptPanel({ videoId }: TranscriptPanelProps) {
   const copy = statusCopy[status];
   const text = data?.transcript?.cleanedText || data?.transcript?.rawText || "";
   const canGenerate = data?.transcriptsEnabled && status === "not_requested" && data.videoStatus === "ready";
+  const canRetry = data?.transcriptsEnabled && status === "failed" && data.videoStatus === "ready";
 
   return (
     <section className="rounded-xl border border-border-default bg-bg-secondary p-4">
@@ -177,6 +184,17 @@ export function TranscriptPanel({ videoId }: TranscriptPanelProps) {
           className="mt-4 rounded-lg bg-accent-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-50"
         >
           {generating ? "Starting..." : "Generate transcript"}
+        </button>
+      )}
+
+      {canRetry && (
+        <button
+          type="button"
+          onClick={generate}
+          disabled={generating}
+          className="mt-4 rounded-lg border border-border-default px-4 py-2 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary disabled:opacity-50"
+        >
+          {generating ? "Retrying..." : "Retry transcript"}
         </button>
       )}
 

--- a/src/components/UploadForm.tsx
+++ b/src/components/UploadForm.tsx
@@ -7,13 +7,15 @@ type UploadState = "idle" | "selected" | "uploading" | "processing" | "error";
 
 interface UploadFormProps {
   folderId?: string | null;
+  transcriptsEnabled?: boolean;
 }
 
-export function UploadForm({ folderId = null }: UploadFormProps) {
+export function UploadForm({ folderId = null, transcriptsEnabled = false }: UploadFormProps) {
   const [state, setState] = useState<UploadState>("idle");
   const [file, setFile] = useState<File | null>(null);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [generateTranscript, setGenerateTranscript] = useState(false);
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState("");
   const [dragOver, setDragOver] = useState(false);
@@ -77,6 +79,7 @@ export function UploadForm({ folderId = null }: UploadFormProps) {
           title: title.trim() || undefined,
           description: description.trim() || undefined,
           folderId,
+          generateTranscript: transcriptsEnabled ? generateTranscript : false,
         }),
       });
 
@@ -238,6 +241,23 @@ export function UploadForm({ folderId = null }: UploadFormProps) {
                 placeholder="Add a description..."
               />
             </div>
+            {transcriptsEnabled && (
+              <label className="flex cursor-pointer gap-3 rounded-xl border border-border-default bg-bg-secondary p-4 transition-colors hover:border-border-hover">
+                <input
+                  type="checkbox"
+                  checked={generateTranscript}
+                  onChange={(event) => setGenerateTranscript(event.target.checked)}
+                  disabled={state === "uploading"}
+                  className="mt-1 h-4 w-4 rounded border-border-default bg-bg-input text-accent-primary focus:ring-accent-primary disabled:opacity-50"
+                />
+                <span>
+                  <span className="block text-sm font-medium text-text-primary">Generate transcript for this video</span>
+                  <span className="mt-1 block text-xs text-text-tertiary">
+                    Create a searchable transcript after upload. The video will be available while the transcript is generated.
+                  </span>
+                </span>
+              </label>
+            )}
           </div>
 
           {state === "uploading" && (

--- a/src/components/UploadVersionModal.tsx
+++ b/src/components/UploadVersionModal.tsx
@@ -10,6 +10,7 @@ interface UploadVersionModalProps {
   videoId: string;
   title: string;
   description: string;
+  transcriptsEnabled?: boolean;
 }
 
 function formatFileSize(bytes: number): string {
@@ -18,7 +19,12 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / 1024).toFixed(1)} KB`;
 }
 
-export function UploadVersionModal({ videoId, title: initialTitle, description: initialDescription }: UploadVersionModalProps) {
+export function UploadVersionModal({
+  videoId,
+  title: initialTitle,
+  description: initialDescription,
+  transcriptsEnabled = false,
+}: UploadVersionModalProps) {
   const headingId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
   const [open, setOpen] = useState(false);
@@ -26,6 +32,7 @@ export function UploadVersionModal({ videoId, title: initialTitle, description: 
   const [file, setFile] = useState<File | null>(null);
   const [title, setTitle] = useState(initialTitle);
   const [description, setDescription] = useState(initialDescription);
+  const [generateTranscript, setGenerateTranscript] = useState(false);
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState("");
   const [dragOver, setDragOver] = useState(false);
@@ -35,6 +42,7 @@ export function UploadVersionModal({ videoId, title: initialTitle, description: 
     setFile(null);
     setTitle(initialTitle);
     setDescription(initialDescription);
+    setGenerateTranscript(false);
     setProgress(0);
     setError("");
     setDragOver(false);
@@ -83,6 +91,7 @@ export function UploadVersionModal({ videoId, title: initialTitle, description: 
           fileSize: file.size,
           title: title.trim() || undefined,
           description: description.trim(),
+          generateTranscript: transcriptsEnabled ? generateTranscript : false,
         }),
       });
 
@@ -210,6 +219,22 @@ export function UploadVersionModal({ videoId, title: initialTitle, description: 
               className="w-full resize-none rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary focus:border-accent-primary focus:outline-none disabled:opacity-50"
             />
           </div>
+
+          {transcriptsEnabled && (
+            <label className="flex cursor-pointer gap-3 rounded-xl border border-border-default bg-bg-tertiary p-3 transition-colors hover:border-border-hover">
+              <input
+                type="checkbox"
+                checked={generateTranscript}
+                onChange={(event) => setGenerateTranscript(event.target.checked)}
+                disabled={state === "uploading"}
+                className="mt-1 h-4 w-4 rounded border-border-default bg-bg-input text-accent-primary focus:ring-accent-primary disabled:opacity-50"
+              />
+              <span>
+                <span className="block text-sm font-medium text-text-primary">Generate transcript for this version</span>
+                <span className="mt-1 block text-xs text-text-tertiary">Create a transcript after the new version finishes processing.</span>
+              </span>
+            </label>
+          )}
 
           {state === "uploading" && (
             <div>

--- a/src/components/VideoDetailView.tsx
+++ b/src/components/VideoDetailView.tsx
@@ -6,6 +6,7 @@ import { VideoPlayer } from "./VideoPlayer";
 import { VideoPageLayout } from "./VideoPageLayout";
 import { AnnotationOverlay } from "./AnnotationOverlay";
 import { UploadVersionModal } from "./UploadVersionModal";
+import { TranscriptPanel } from "./TranscriptPanel";
 import { useStreamPlayer } from "../hooks/useStreamPlayer";
 import type { Annotation, Comment } from "../types";
 import type { AnnotationTool } from "./AnnotationOverlay";
@@ -23,6 +24,7 @@ interface VideoDetailViewProps {
   isOwner: boolean;
   uploadDate: string;
   fileName: string | null;
+  transcriptsEnabled: boolean;
 }
 
 function formatDate(dateStr: string): string {
@@ -76,6 +78,7 @@ export function VideoDetailView({
   isOwner,
   uploadDate,
   fileName,
+  transcriptsEnabled,
 }: VideoDetailViewProps) {
   const [processingStatus, setProcessingStatus] = useState(status);
   const [liveComments, setLiveComments] = useState(initialComments);
@@ -191,7 +194,12 @@ export function VideoDetailView({
         )}
         {isOwner && (
           <span className="w-full sm:w-auto">
-            <UploadVersionModal videoId={videoId} title={title} description={description} />
+            <UploadVersionModal
+              videoId={videoId}
+              title={title}
+              description={description}
+              transcriptsEnabled={transcriptsEnabled}
+            />
           </span>
         )}
       </div>
@@ -218,6 +226,8 @@ export function VideoDetailView({
         placeholder="Add a description..."
         className="break-words text-sm text-text-secondary"
       />
+
+      <TranscriptPanel videoId={videoId} />
     </>
   );
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -68,6 +68,55 @@ export const videos = sqliteTable("videos", {
   duration: real("duration"),
   fileName: text("file_name"),
   fileSize: integer("file_size"),
+  transcriptRequested: integer("transcript_requested", { mode: "boolean" })
+    .notNull()
+    .default(false),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+});
+
+export const transcripts = sqliteTable("transcripts", {
+  id: text("id").primaryKey(),
+  videoId: text("video_id")
+    .notNull()
+    .unique()
+    .references(() => videos.id, { onDelete: "cascade" }),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  status: text("status", {
+    enum: [
+      "not_requested",
+      "requested",
+      "queued",
+      "exporting_audio",
+      "waiting_for_audio",
+      "transcribing",
+      "cleaning",
+      "ready",
+      "ready_raw_only",
+      "failed",
+      "skipped_feature_disabled",
+    ],
+  })
+    .notNull()
+    .default("requested"),
+  rawText: text("raw_text"),
+  cleanedText: text("cleaned_text"),
+  vtt: text("vtt"),
+  wordCount: integer("word_count"),
+  audioDownloadUrl: text("audio_download_url"),
+  workflowInstanceId: text("workflow_instance_id"),
+  errorMessage: text("error_message"),
+  requestedAt: text("requested_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+  startedAt: text("started_at"),
+  completedAt: text("completed_at"),
   createdAt: text("created_at")
     .notNull()
     .default(sql`(datetime('now'))`),

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -1,0 +1,30 @@
+export const TRANSCRIPT_GENERATION_FLAG = "transcript-generation";
+
+interface FlagshipBinding {
+  getBooleanValue(
+    flagKey: string,
+    defaultValue: boolean,
+    context?: Record<string, string>,
+  ): Promise<boolean>;
+}
+
+interface FlagUser {
+  id: string;
+  email: string;
+}
+
+export async function isTranscriptGenerationEnabled(
+  env: Env,
+  user: FlagUser | null | undefined,
+): Promise<boolean> {
+  if (!user) return false;
+  if (env.TRANSCRIPTS_ENABLED === "false") return false;
+
+  const flags = (env as Env & { FLAGS?: FlagshipBinding }).FLAGS;
+  if (!flags) return false;
+
+  return flags.getBooleanValue(TRANSCRIPT_GENERATION_FLAG, false, {
+    userId: user.id,
+    email: user.email,
+  });
+}

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -1,13 +1,5 @@
 export const TRANSCRIPT_GENERATION_FLAG = "transcript-generation";
 
-interface FlagshipBinding {
-  getBooleanValue(
-    flagKey: string,
-    defaultValue: boolean,
-    context?: Record<string, string>,
-  ): Promise<boolean>;
-}
-
 interface FlagUser {
   id: string;
   email: string;
@@ -20,11 +12,12 @@ export async function isTranscriptGenerationEnabled(
   if (!user) return false;
   if (env.TRANSCRIPTS_ENABLED === "false") return false;
 
-  const flags = (env as Env & { FLAGS?: FlagshipBinding }).FLAGS;
-  if (!flags) return false;
-
-  return flags.getBooleanValue(TRANSCRIPT_GENERATION_FLAG, false, {
-    userId: user.id,
-    email: user.email,
-  });
+  try {
+    return await env.FLAGS.getBooleanValue(TRANSCRIPT_GENERATION_FLAG, false, {
+      userId: user.id,
+      email: user.email,
+    });
+  } catch {
+    return false;
+  }
 }

--- a/src/lib/stream.ts
+++ b/src/lib/stream.ts
@@ -91,3 +91,61 @@ export async function deleteVideo(
     );
   }
 }
+
+export interface StreamAudioDownload {
+  status: "inprogress" | "ready" | "error" | string;
+  url: string | null;
+  percentComplete?: number;
+}
+
+interface StreamDownloadsResponse {
+  result?: {
+    audio?: StreamAudioDownload;
+  };
+}
+
+export async function requestAudioDownload(
+  accountId: string,
+  apiToken: string,
+  streamVideoId: string,
+): Promise<StreamAudioDownload> {
+  const response = await fetch(
+    `${STREAM_API_BASE}/${accountId}/stream/${streamVideoId}/downloads/audio`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Stream audio download request failed: ${response.status}`);
+  }
+
+  const data = (await response.json()) as StreamDownloadsResponse;
+  if (!data.result?.audio) throw new Error("Stream response did not include audio download details");
+  return data.result.audio;
+}
+
+export async function getAudioDownload(
+  accountId: string,
+  apiToken: string,
+  streamVideoId: string,
+): Promise<StreamAudioDownload | null> {
+  const response = await fetch(
+    `${STREAM_API_BASE}/${accountId}/stream/${streamVideoId}/downloads`,
+    {
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Stream downloads lookup failed: ${response.status}`);
+  }
+
+  const data = (await response.json()) as StreamDownloadsResponse;
+  return data.result?.audio || null;
+}

--- a/src/lib/stream.ts
+++ b/src/lib/stream.ts
@@ -119,6 +119,15 @@ export async function requestAudioDownload(
     },
   );
 
+  // Tolerate 409 Conflict -- audio download was already requested.
+  // Fall back to checking download status via the GET endpoint.
+  if (response.status === 409) {
+    const existing = await getAudioDownload(accountId, apiToken, streamVideoId);
+    if (existing) return existing;
+    // If GET also returns nothing, the 409 is unexpected -- throw.
+    throw new Error("Stream returned 409 but no existing audio download found");
+  }
+
   if (!response.ok) {
     throw new Error(`Stream audio download request failed: ${response.status}`);
   }

--- a/src/lib/transcript-status.ts
+++ b/src/lib/transcript-status.ts
@@ -1,0 +1,12 @@
+export type TranscriptStatus =
+  | "not_requested"
+  | "requested"
+  | "queued"
+  | "exporting_audio"
+  | "waiting_for_audio"
+  | "transcribing"
+  | "cleaning"
+  | "ready"
+  | "ready_raw_only"
+  | "failed"
+  | "skipped_feature_disabled";

--- a/src/lib/transcripts.ts
+++ b/src/lib/transcripts.ts
@@ -1,0 +1,111 @@
+import { eq } from "drizzle-orm";
+import type { Database } from "../db";
+import { transcripts, users, videos } from "../db/schema";
+import { isTranscriptGenerationEnabled } from "./flags";
+
+export type TranscriptStatus =
+  | "not_requested"
+  | "requested"
+  | "queued"
+  | "exporting_audio"
+  | "waiting_for_audio"
+  | "transcribing"
+  | "cleaning"
+  | "ready"
+  | "ready_raw_only"
+  | "failed"
+  | "skipped_feature_disabled";
+
+interface WorkflowBinding {
+  create(options: { id?: string; params?: unknown }): Promise<{ id: string }>;
+}
+
+export interface TranscriptWorkflowParams {
+  transcriptId: string;
+  videoId: string;
+}
+
+export async function queueTranscriptForVideo(
+  env: Env,
+  db: Database,
+  video: typeof videos.$inferSelect,
+): Promise<void> {
+  if (!video.transcriptRequested || video.status !== "ready") return;
+
+  const existing = await db
+    .select()
+    .from(transcripts)
+    .where(eq(transcripts.videoId, video.id))
+    .limit(1);
+
+  if (existing[0] && existing[0].status !== "failed") return;
+
+  const userResult = await db
+    .select({ id: users.id, email: users.email })
+    .from(users)
+    .where(eq(users.id, video.userId))
+    .limit(1);
+  const user = userResult[0];
+  if (!user) return;
+
+  const enabled = await isTranscriptGenerationEnabled(env, user);
+  const now = new Date().toISOString();
+  const transcriptId = existing[0]?.id || crypto.randomUUID();
+
+  if (!enabled) {
+    if (existing[0]) {
+      await db
+        .update(transcripts)
+        .set({ status: "skipped_feature_disabled", updatedAt: now })
+        .where(eq(transcripts.id, transcriptId));
+    } else {
+      await db.insert(transcripts).values({
+        id: transcriptId,
+        videoId: video.id,
+        userId: video.userId,
+        status: "skipped_feature_disabled",
+        requestedAt: now,
+        updatedAt: now,
+      });
+    }
+    return;
+  }
+
+  const workflowInstanceId = `transcript-${transcriptId}`;
+
+  if (existing[0]) {
+    await db
+      .update(transcripts)
+      .set({
+        status: "queued",
+        errorMessage: null,
+        workflowInstanceId,
+        updatedAt: now,
+      })
+      .where(eq(transcripts.id, transcriptId));
+  } else {
+    await db.insert(transcripts).values({
+      id: transcriptId,
+      videoId: video.id,
+      userId: video.userId,
+      status: "queued",
+      workflowInstanceId,
+      requestedAt: now,
+      updatedAt: now,
+    });
+  }
+
+  const workflow = (env as Env & { TRANSCRIPT_WORKFLOW?: WorkflowBinding }).TRANSCRIPT_WORKFLOW;
+  if (!workflow) return;
+
+  try {
+    await workflow.create({
+      id: workflowInstanceId,
+      params: { transcriptId, videoId: video.id } satisfies TranscriptWorkflowParams,
+    });
+  } catch (error) {
+    // Duplicate webhook deliveries can race workflow creation. If the row already
+    // points at this instance, leave it queued and let the existing workflow run.
+    console.warn("Transcript workflow was not created:", error);
+  }
+}

--- a/src/lib/transcripts.ts
+++ b/src/lib/transcripts.ts
@@ -3,18 +3,7 @@ import type { Database } from "../db";
 import { transcripts, users, videos } from "../db/schema";
 import { isTranscriptGenerationEnabled } from "./flags";
 
-export type TranscriptStatus =
-  | "not_requested"
-  | "requested"
-  | "queued"
-  | "exporting_audio"
-  | "waiting_for_audio"
-  | "transcribing"
-  | "cleaning"
-  | "ready"
-  | "ready_raw_only"
-  | "failed"
-  | "skipped_feature_disabled";
+export type { TranscriptStatus } from "./transcript-status";
 
 interface WorkflowBinding {
   create(options: { id?: string; params?: unknown }): Promise<{ id: string }>;
@@ -104,8 +93,25 @@ export async function queueTranscriptForVideo(
       params: { transcriptId, videoId: video.id } satisfies TranscriptWorkflowParams,
     });
   } catch (error) {
-    // Duplicate webhook deliveries can race workflow creation. If the row already
-    // points at this instance, leave it queued and let the existing workflow run.
-    console.warn("Transcript workflow was not created:", error);
+    const message = error instanceof Error ? error.message : String(error);
+    const isDuplicate = message.includes("already exists") || message.includes("duplicate");
+
+    if (isDuplicate) {
+      // Duplicate webhook deliveries can race workflow creation. The existing
+      // workflow will pick up the queued row.
+      console.warn("Transcript workflow instance already exists:", workflowInstanceId);
+    } else {
+      // Non-duplicate failure means the workflow service is down or misconfigured.
+      // Mark transcript as failed so the user can retry later.
+      console.error("Transcript workflow creation failed:", error);
+      await db
+        .update(transcripts)
+        .set({
+          status: "failed",
+          errorMessage: `Workflow creation failed: ${message}`,
+          updatedAt: now,
+        })
+        .where(eq(transcripts.id, transcriptId));
+    }
   }
 }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -37,6 +37,7 @@ export const uploadSchema = z.object({
   title: z.string().optional(),
   description: z.string().max(2000).optional(),
   folderId: z.string().uuid().nullable().optional(),
+  generateTranscript: z.boolean().optional(),
 });
 
 export const commentSchema = z.object({

--- a/src/pages/api/auth/register.ts
+++ b/src/pages/api/auth/register.ts
@@ -10,6 +10,7 @@ export const POST: APIRoute = async ({ request, redirect }) => {
 
   let email: string;
   let password: string;
+  let confirmPassword: string;
   let displayName: string;
 
   const contentType = request.headers.get("content-type") || "";
@@ -17,11 +18,13 @@ export const POST: APIRoute = async ({ request, redirect }) => {
     const body = await request.json();
     email = body.email?.trim().toLowerCase();
     password = body.password;
+    confirmPassword = body.confirmPassword;
     displayName = body.displayName?.trim();
   } else {
     const formData = await request.formData();
     email = (formData.get("email") as string)?.trim().toLowerCase();
     password = formData.get("password") as string;
+    confirmPassword = formData.get("confirmPassword") as string;
     displayName = (formData.get("displayName") as string)?.trim();
   }
 
@@ -30,8 +33,16 @@ export const POST: APIRoute = async ({ request, redirect }) => {
     return redirect("/register?error=All fields are required");
   }
 
+  if (!email.endsWith("@cloudflare.com")) {
+    return redirect("/register?error=QuickCut is currently limited to Cloudflare email addresses");
+  }
+
   if (password.length < 8) {
     return redirect("/register?error=Password must be at least 8 characters");
+  }
+
+  if (password !== confirmPassword) {
+    return redirect("/register?error=Passwords do not match");
   }
 
   // Check if email exists

--- a/src/pages/api/auth/register.ts
+++ b/src/pages/api/auth/register.ts
@@ -29,7 +29,7 @@ export const POST: APIRoute = async ({ request, redirect }) => {
   }
 
   // Validation
-  if (!email || !password || !displayName) {
+  if (!email || !password || !confirmPassword || !displayName) {
     return redirect("/register?error=All fields are required");
   }
 

--- a/src/pages/api/videos/[id]/status.ts
+++ b/src/pages/api/videos/[id]/status.ts
@@ -4,6 +4,7 @@ import { createDb } from "../../../../db";
 import { videos } from "../../../../db/schema";
 import { eq } from "drizzle-orm";
 import { getVideoInfo } from "../../../../lib/stream";
+import { queueTranscriptForVideo } from "../../../../lib/transcripts";
 
 export const GET: APIRoute = async ({ params, locals }) => {
   if (!locals.user) {
@@ -48,6 +49,7 @@ export const GET: APIRoute = async ({ params, locals }) => {
       );
 
       if (info.readyToStream && info.status.state === "ready") {
+        const now = new Date().toISOString();
         // Update DB with the real data from Stream
         await db
           .update(videos)
@@ -56,9 +58,18 @@ export const GET: APIRoute = async ({ params, locals }) => {
             duration: info.duration,
             thumbnailUrl: info.thumbnail,
             streamPlaybackUrl: info.playback.hls,
-            updatedAt: new Date().toISOString(),
+            updatedAt: now,
           })
           .where(eq(videos.id, id));
+
+        await queueTranscriptForVideo(env, db, {
+          ...video,
+          status: "ready",
+          duration: info.duration,
+          thumbnailUrl: info.thumbnail,
+          streamPlaybackUrl: info.playback.hls,
+          updatedAt: now,
+        });
 
         return new Response(
           JSON.stringify({

--- a/src/pages/api/videos/[id]/transcript.ts
+++ b/src/pages/api/videos/[id]/transcript.ts
@@ -1,0 +1,83 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { eq } from "drizzle-orm";
+import { createDb } from "../../../../db";
+import { transcripts, videos } from "../../../../db/schema";
+import { isTranscriptGenerationEnabled } from "../../../../lib/flags";
+import { queueTranscriptForVideo } from "../../../../lib/transcripts";
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const GET: APIRoute = async ({ params, locals }) => {
+  if (!locals.user) return json({ error: "Unauthorized" }, 401);
+
+  const { id } = params;
+  if (!id) return json({ error: "Video ID required" }, 400);
+
+  const db = createDb(env.DB);
+  const videoResult = await db.select().from(videos).where(eq(videos.id, id)).limit(1);
+  const video = videoResult[0];
+
+  if (!video) return json({ error: "Video not found" }, 404);
+  if (video.userId !== locals.user.id) return json({ error: "Forbidden" }, 403);
+
+  const transcriptResult = await db.select().from(transcripts).where(eq(transcripts.videoId, id)).limit(1);
+  const transcript = transcriptResult[0] || null;
+
+  return json({
+    transcript,
+    transcriptRequested: video.transcriptRequested,
+    transcriptsEnabled: await isTranscriptGenerationEnabled(env, locals.user),
+    videoStatus: video.status,
+  });
+};
+
+export const POST: APIRoute = async ({ params, locals }) => {
+  if (!locals.user) return json({ error: "Unauthorized" }, 401);
+
+  const { id } = params;
+  if (!id) return json({ error: "Video ID required" }, 400);
+
+  const db = createDb(env.DB);
+  const videoResult = await db.select().from(videos).where(eq(videos.id, id)).limit(1);
+  const video = videoResult[0];
+
+  if (!video) return json({ error: "Video not found" }, 404);
+  if (video.userId !== locals.user.id) return json({ error: "Forbidden" }, 403);
+
+  const enabled = await isTranscriptGenerationEnabled(env, locals.user);
+  if (!enabled) return json({ error: "Transcript generation is not enabled" }, 403);
+
+  await db
+    .update(videos)
+    .set({ transcriptRequested: true, updatedAt: new Date().toISOString() })
+    .where(eq(videos.id, id));
+
+  const existingTranscript = await db
+    .select({ id: transcripts.id })
+    .from(transcripts)
+    .where(eq(transcripts.videoId, id))
+    .limit(1);
+
+  if (!existingTranscript[0] && video.status !== "ready") {
+    const now = new Date().toISOString();
+    await db.insert(transcripts).values({
+      id: crypto.randomUUID(),
+      videoId: id,
+      userId: locals.user.id,
+      status: "requested",
+      requestedAt: now,
+      updatedAt: now,
+    });
+  }
+
+  await queueTranscriptForVideo(env, db, { ...video, transcriptRequested: true });
+
+  const transcriptResult = await db.select().from(transcripts).where(eq(transcripts.videoId, id)).limit(1);
+  return json({ transcript: transcriptResult[0] || null }, 202);
+};

--- a/src/pages/api/videos/[id]/versions.ts
+++ b/src/pages/api/videos/[id]/versions.ts
@@ -5,6 +5,7 @@ import { createDb } from "../../../../db";
 import { comments, videos } from "../../../../db/schema";
 import { createDirectUpload } from "../../../../lib/stream";
 import { uploadSchema } from "../../../../lib/validation";
+import { isTranscriptGenerationEnabled } from "../../../../lib/flags";
 
 const ALLOWED_EXTENSIONS = ["mp4", "mov", "webm", "avi", "mkv"];
 const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024;
@@ -75,7 +76,7 @@ export const POST: APIRoute = async ({ params, locals, request }) => {
     return json({ error: parsed.error.issues[0]?.message || "Invalid input" }, 400);
   }
 
-  const { fileName, fileSize, title, description } = parsed.data;
+  const { fileName, fileSize, title, description, generateTranscript } = parsed.data;
   const ext = fileName.split(".").pop()?.toLowerCase();
 
   if (!ext || !ALLOWED_EXTENSIONS.includes(ext)) {
@@ -113,6 +114,9 @@ export const POST: APIRoute = async ({ params, locals, request }) => {
 
     const videoId = crypto.randomUUID();
     const now = new Date().toISOString();
+    const transcriptRequested = generateTranscript
+      ? await isTranscriptGenerationEnabled(env, locals.user)
+      : false;
 
     await db
       .update(videos)
@@ -133,6 +137,7 @@ export const POST: APIRoute = async ({ params, locals, request }) => {
       streamVideoId,
       fileName,
       fileSize,
+      transcriptRequested,
       createdAt: now,
       updatedAt: now,
     });

--- a/src/pages/api/videos/upload.ts
+++ b/src/pages/api/videos/upload.ts
@@ -5,6 +5,7 @@ import { folders, videos } from "../../../db/schema";
 import { createDirectUpload } from "../../../lib/stream";
 import { and, eq } from "drizzle-orm";
 import { uploadSchema } from "../../../lib/validation";
+import { isTranscriptGenerationEnabled } from "../../../lib/flags";
 
 const ALLOWED_EXTENSIONS = ["mp4", "mov", "webm", "avi", "mkv"];
 const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024; // 5GB
@@ -25,7 +26,7 @@ export const POST: APIRoute = async ({ locals, request }) => {
     });
   }
 
-  const { fileName, fileSize, title, description, folderId } = parsed.data;
+  const { fileName, fileSize, title, description, folderId, generateTranscript } = parsed.data;
 
   if (!fileName || !fileSize) {
     return new Response(
@@ -64,6 +65,9 @@ export const POST: APIRoute = async ({ locals, request }) => {
     const db = createDb(env.DB);
     const videoId = crypto.randomUUID();
     const videoTitle = title?.trim() || fileName.replace(/\.[^.]+$/, "");
+    const transcriptRequested = generateTranscript
+      ? await isTranscriptGenerationEnabled(env, locals.user)
+      : false;
 
     if (folderId) {
       const folder = await db
@@ -93,6 +97,7 @@ export const POST: APIRoute = async ({ locals, request }) => {
       streamVideoId,
       fileName,
       fileSize,
+      transcriptRequested,
     });
 
     return new Response(

--- a/src/pages/api/webhooks/stream.ts
+++ b/src/pages/api/webhooks/stream.ts
@@ -3,6 +3,7 @@ import { env } from "cloudflare:workers";
 import { createDb } from "../../../db";
 import { videos } from "../../../db/schema";
 import { eq } from "drizzle-orm";
+import { queueTranscriptForVideo } from "../../../lib/transcripts";
 
 interface StreamWebhookPayload {
   uid: string;
@@ -107,6 +108,7 @@ export const POST: APIRoute = async ({ request }) => {
   const video = videoRecords[0];
 
   if (payload.readyToStream && payload.status.state === "ready") {
+    const now = new Date().toISOString();
     await db
       .update(videos)
       .set({
@@ -114,9 +116,18 @@ export const POST: APIRoute = async ({ request }) => {
         duration: payload.duration,
         thumbnailUrl: payload.thumbnail,
         streamPlaybackUrl: payload.playback.hls,
-        updatedAt: new Date().toISOString(),
+        updatedAt: now,
       })
       .where(eq(videos.id, video.id));
+
+    await queueTranscriptForVideo(env, db, {
+      ...video,
+      status: "ready",
+      duration: payload.duration,
+      thumbnailUrl: payload.thumbnail,
+      streamPlaybackUrl: payload.playback.hls,
+      updatedAt: now,
+    });
   } else if (payload.status.state === "error") {
     await db
       .update(videos)

--- a/src/pages/register.astro
+++ b/src/pages/register.astro
@@ -15,7 +15,7 @@ const error = Astro.url.searchParams.get("error");
       <div class="mb-8 text-center">
         <h1 class="text-3xl font-bold text-text-primary">QuickCut</h1>
         <p class="mt-2 text-sm text-text-secondary">
-          Create your account to start reviewing videos.
+          Create your account with your Cloudflare email to start reviewing videos.
         </p>
       </div>
 
@@ -50,8 +50,9 @@ const error = Astro.url.searchParams.get("error");
               name="email"
               required
               class="w-full rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent-primary focus:outline-none"
-              placeholder="you@example.com"
+              placeholder="you@cloudflare.com"
             />
+            <p class="mt-1 text-xs text-text-tertiary">QuickCut is currently limited to Cloudflare email addresses.</p>
           </div>
           <div>
             <label for="password" class="mb-1 block text-sm font-medium text-text-secondary">

--- a/src/pages/upload.astro
+++ b/src/pages/upload.astro
@@ -5,6 +5,7 @@ import { createDb } from "../db";
 import { folders } from "../db/schema";
 import { and, eq } from "drizzle-orm";
 import { env } from "cloudflare:workers";
+import { isTranscriptGenerationEnabled } from "../lib/flags";
 
 const user = Astro.locals.user;
 if (!user) return Astro.redirect("/login");
@@ -26,6 +27,7 @@ if (folderId && folderResult.length === 0) {
 }
 
 const targetFolder = folderResult[0] || null;
+const transcriptsEnabled = await isTranscriptGenerationEnabled(env, user);
 ---
 
 <Layout title="Upload Video" user={user}>
@@ -43,6 +45,6 @@ const targetFolder = folderResult[0] || null;
         <span class="font-medium text-text-primary">{targetFolder ? targetFolder.name : "All Videos"}</span>
       </div>
     </div>
-    <UploadForm client:load folderId={folderId} />
+    <UploadForm client:load folderId={folderId} transcriptsEnabled={transcriptsEnabled} />
   </div>
 </Layout>

--- a/src/pages/videos/[id].astro
+++ b/src/pages/videos/[id].astro
@@ -7,6 +7,7 @@ import { videos, shareLinks } from "../../db/schema";
 import { eq } from "drizzle-orm";
 import { env } from "cloudflare:workers";
 import { getCommentsWithNames } from "../../lib/comments";
+import { isTranscriptGenerationEnabled } from "../../lib/flags";
 
 const user = Astro.locals.user;
 if (!user) return Astro.redirect("/login");
@@ -30,6 +31,7 @@ const shareLink = shareLinkResult[0] || null;
 const commentsWithNames = await getCommentsWithNames(db, id);
 
 const appUrl = new URL(Astro.request.url).origin;
+const transcriptsEnabled = await isTranscriptGenerationEnabled(env, user);
 ---
 
 <Layout title={video.title} user={user}>
@@ -57,6 +59,7 @@ const appUrl = new URL(Astro.request.url).origin;
       isOwner={true}
       uploadDate={video.createdAt}
       fileName={video.fileName}
+      transcriptsEnabled={transcriptsEnabled}
     />
   </div>
 </Layout>

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2,6 +2,7 @@ import { handle } from "@astrojs/cloudflare/handler";
 
 // Re-export Durable Object classes so Wrangler can register them.
 export { VideoRoom } from "./durable-objects/VideoRoom";
+export { TranscriptWorkflow } from "./workflows/TranscriptWorkflow";
 
 export default {
 	async fetch(request, env, ctx) {

--- a/src/workflows/TranscriptWorkflow.ts
+++ b/src/workflows/TranscriptWorkflow.ts
@@ -1,0 +1,169 @@
+import { WorkflowEntrypoint } from "cloudflare:workers";
+import type { WorkflowEvent, WorkflowStep } from "cloudflare:workers";
+import { eq } from "drizzle-orm";
+import { createDb } from "../db";
+import { transcripts, videos } from "../db/schema";
+import { getAudioDownload, requestAudioDownload } from "../lib/stream";
+import type { TranscriptWorkflowParams } from "../lib/transcripts";
+
+interface WhisperResponse {
+  text?: string;
+  word_count?: number;
+  vtt?: string;
+}
+
+interface TextGenerationResponse {
+  response?: string;
+}
+
+function now() {
+  return new Date().toISOString();
+}
+
+function getCleanupPrompt(rawText: string) {
+  return [
+    "Clean up this speech-to-text transcript for readability.",
+    "Preserve the speaker's meaning. Do not add facts. Do not summarize.",
+    "Fix obvious punctuation, casing, paragraph breaks, and repeated false starts.",
+    "Return only the cleaned transcript text.",
+    "",
+    rawText,
+  ].join("\n");
+}
+
+export class TranscriptWorkflow extends WorkflowEntrypoint<Env, TranscriptWorkflowParams> {
+  async run(event: WorkflowEvent<TranscriptWorkflowParams>, step: WorkflowStep) {
+    const { transcriptId, videoId } = event.payload;
+    const db = createDb(this.env.DB);
+
+    try {
+      const video = await step.do("load video", async () => {
+        const result = await db.select().from(videos).where(eq(videos.id, videoId)).limit(1);
+        if (!result[0]) throw new Error("Video not found");
+        if (!result[0].streamVideoId) throw new Error("Video is missing Stream ID");
+        return result[0];
+      });
+
+      await step.do("mark exporting audio", async () => {
+        await db
+          .update(transcripts)
+          .set({ status: "exporting_audio", startedAt: now(), updatedAt: now() })
+          .where(eq(transcripts.id, transcriptId));
+      });
+
+      await step.do("request audio download", async () => {
+        await requestAudioDownload(
+          this.env.STREAM_ACCOUNT_ID,
+          this.env.STREAM_API_TOKEN,
+          video.streamVideoId!,
+        );
+      });
+
+      let audioUrl = await step.do(
+        "wait for audio download",
+        { retries: { limit: 20, delay: "15 seconds", backoff: "linear" }, timeout: "2 minutes" },
+        async () => {
+          await db
+            .update(transcripts)
+            .set({ status: "waiting_for_audio", updatedAt: now() })
+            .where(eq(transcripts.id, transcriptId));
+
+          const audio = await getAudioDownload(
+            this.env.STREAM_ACCOUNT_ID,
+            this.env.STREAM_API_TOKEN,
+            video.streamVideoId!,
+          );
+
+          if (!audio || audio.status === "inprogress") {
+            throw new Error("Audio download is not ready yet");
+          }
+          if (audio.status !== "ready" || !audio.url) {
+            throw new Error(`Audio download failed with status ${audio.status}`);
+          }
+
+          await db
+            .update(transcripts)
+            .set({ audioDownloadUrl: audio.url, updatedAt: now() })
+            .where(eq(transcripts.id, transcriptId));
+
+          return audio.url;
+        },
+      );
+
+      const whisper = await step.do("transcribe audio", { timeout: "10 minutes" }, async () => {
+        await db
+          .update(transcripts)
+          .set({ status: "transcribing", updatedAt: now() })
+          .where(eq(transcripts.id, transcriptId));
+
+        const audioResponse = await fetch(audioUrl);
+        if (!audioResponse.ok) throw new Error(`Audio fetch failed: ${audioResponse.status}`);
+
+        const audioBuffer = await audioResponse.arrayBuffer();
+        const response = await this.env.AI.run("@cf/openai/whisper", {
+          audio: [...new Uint8Array(audioBuffer)],
+        }) as WhisperResponse;
+
+        if (!response.text) throw new Error("Workers AI did not return transcript text");
+
+        await db
+          .update(transcripts)
+          .set({
+            rawText: response.text,
+            vtt: response.vtt || null,
+            wordCount: response.word_count || null,
+            status: "ready_raw_only",
+            updatedAt: now(),
+          })
+          .where(eq(transcripts.id, transcriptId));
+
+        return response;
+      });
+
+      await step.do("clean transcript", { timeout: "5 minutes" }, async () => {
+        await db
+          .update(transcripts)
+          .set({ status: "cleaning", updatedAt: now() })
+          .where(eq(transcripts.id, transcriptId));
+
+        try {
+          const response = await this.env.AI.run(this.env.TRANSCRIPT_CLEANUP_MODEL, {
+            messages: [{ role: "user", content: getCleanupPrompt(whisper.text!) }],
+          }) as TextGenerationResponse;
+
+          const cleaned = response.response?.trim();
+          await db
+            .update(transcripts)
+            .set({
+              cleanedText: cleaned || null,
+              status: cleaned ? "ready" : "ready_raw_only",
+              completedAt: now(),
+              updatedAt: now(),
+            })
+            .where(eq(transcripts.id, transcriptId));
+        } catch (error) {
+          await db
+            .update(transcripts)
+            .set({
+              status: "ready_raw_only",
+              errorMessage: error instanceof Error ? error.message : "Transcript cleanup failed",
+              completedAt: now(),
+              updatedAt: now(),
+            })
+            .where(eq(transcripts.id, transcriptId));
+        }
+      });
+    } catch (error) {
+      await db
+        .update(transcripts)
+        .set({
+          status: "failed",
+          errorMessage: error instanceof Error ? error.message : "Transcript workflow failed",
+          completedAt: now(),
+          updatedAt: now(),
+        })
+        .where(eq(transcripts.id, transcriptId));
+      throw error;
+    }
+  }
+}

--- a/src/workflows/TranscriptWorkflow.ts
+++ b/src/workflows/TranscriptWorkflow.ts
@@ -36,134 +36,122 @@ export class TranscriptWorkflow extends WorkflowEntrypoint<Env, TranscriptWorkfl
     const { transcriptId, videoId } = event.payload;
     const db = createDb(this.env.DB);
 
-    try {
-      const video = await step.do("load video", async () => {
-        const result = await db.select().from(videos).where(eq(videos.id, videoId)).limit(1);
-        if (!result[0]) throw new Error("Video not found");
-        if (!result[0].streamVideoId) throw new Error("Video is missing Stream ID");
-        return result[0];
-      });
+    const video = await step.do("load video", async () => {
+      const result = await db.select().from(videos).where(eq(videos.id, videoId)).limit(1);
+      if (!result[0]) throw new Error("Video not found");
+      if (!result[0].streamVideoId) throw new Error("Video is missing Stream ID");
+      return result[0];
+    });
 
-      await step.do("mark exporting audio", async () => {
+    await step.do("mark exporting audio", async () => {
+      await db
+        .update(transcripts)
+        .set({ status: "exporting_audio", startedAt: now(), updatedAt: now() })
+        .where(eq(transcripts.id, transcriptId));
+    });
+
+    await step.do("request audio download", async () => {
+      await requestAudioDownload(
+        this.env.STREAM_ACCOUNT_ID,
+        this.env.STREAM_API_TOKEN,
+        video.streamVideoId!,
+      );
+    });
+
+    const audioUrl = await step.do(
+      "wait for audio download",
+      { retries: { limit: 20, delay: "15 seconds", backoff: "linear" }, timeout: "2 minutes" },
+      async () => {
         await db
           .update(transcripts)
-          .set({ status: "exporting_audio", startedAt: now(), updatedAt: now() })
+          .set({ status: "waiting_for_audio", updatedAt: now() })
           .where(eq(transcripts.id, transcriptId));
-      });
 
-      await step.do("request audio download", async () => {
-        await requestAudioDownload(
+        const audio = await getAudioDownload(
           this.env.STREAM_ACCOUNT_ID,
           this.env.STREAM_API_TOKEN,
           video.streamVideoId!,
         );
-      });
 
-      let audioUrl = await step.do(
-        "wait for audio download",
-        { retries: { limit: 20, delay: "15 seconds", backoff: "linear" }, timeout: "2 minutes" },
-        async () => {
-          await db
-            .update(transcripts)
-            .set({ status: "waiting_for_audio", updatedAt: now() })
-            .where(eq(transcripts.id, transcriptId));
-
-          const audio = await getAudioDownload(
-            this.env.STREAM_ACCOUNT_ID,
-            this.env.STREAM_API_TOKEN,
-            video.streamVideoId!,
-          );
-
-          if (!audio || audio.status === "inprogress") {
-            throw new Error("Audio download is not ready yet");
-          }
-          if (audio.status !== "ready" || !audio.url) {
-            throw new Error(`Audio download failed with status ${audio.status}`);
-          }
-
-          await db
-            .update(transcripts)
-            .set({ audioDownloadUrl: audio.url, updatedAt: now() })
-            .where(eq(transcripts.id, transcriptId));
-
-          return audio.url;
-        },
-      );
-
-      const whisper = await step.do("transcribe audio", { timeout: "10 minutes" }, async () => {
-        await db
-          .update(transcripts)
-          .set({ status: "transcribing", updatedAt: now() })
-          .where(eq(transcripts.id, transcriptId));
-
-        const audioResponse = await fetch(audioUrl);
-        if (!audioResponse.ok) throw new Error(`Audio fetch failed: ${audioResponse.status}`);
-
-        const audioBuffer = await audioResponse.arrayBuffer();
-        const response = await this.env.AI.run("@cf/openai/whisper", {
-          audio: [...new Uint8Array(audioBuffer)],
-        }) as WhisperResponse;
-
-        if (!response.text) throw new Error("Workers AI did not return transcript text");
-
-        await db
-          .update(transcripts)
-          .set({
-            rawText: response.text,
-            vtt: response.vtt || null,
-            wordCount: response.word_count || null,
-            status: "ready_raw_only",
-            updatedAt: now(),
-          })
-          .where(eq(transcripts.id, transcriptId));
-
-        return response;
-      });
-
-      await step.do("clean transcript", { timeout: "5 minutes" }, async () => {
-        await db
-          .update(transcripts)
-          .set({ status: "cleaning", updatedAt: now() })
-          .where(eq(transcripts.id, transcriptId));
-
-        try {
-          const response = await this.env.AI.run(this.env.TRANSCRIPT_CLEANUP_MODEL, {
-            messages: [{ role: "user", content: getCleanupPrompt(whisper.text!) }],
-          }) as TextGenerationResponse;
-
-          const cleaned = response.response?.trim();
-          await db
-            .update(transcripts)
-            .set({
-              cleanedText: cleaned || null,
-              status: cleaned ? "ready" : "ready_raw_only",
-              completedAt: now(),
-              updatedAt: now(),
-            })
-            .where(eq(transcripts.id, transcriptId));
-        } catch (error) {
-          await db
-            .update(transcripts)
-            .set({
-              status: "ready_raw_only",
-              errorMessage: error instanceof Error ? error.message : "Transcript cleanup failed",
-              completedAt: now(),
-              updatedAt: now(),
-            })
-            .where(eq(transcripts.id, transcriptId));
+        if (!audio || audio.status === "inprogress") {
+          throw new Error("Audio download is not ready yet");
         }
-      });
-    } catch (error) {
+        if (audio.status !== "ready" || !audio.url) {
+          throw new Error(`Audio download failed with status ${audio.status}`);
+        }
+
+        await db
+          .update(transcripts)
+          .set({ audioDownloadUrl: audio.url, updatedAt: now() })
+          .where(eq(transcripts.id, transcriptId));
+
+        return audio.url;
+      },
+    );
+
+    const whisper = await step.do("transcribe audio", { timeout: "10 minutes" }, async () => {
+      await db
+        .update(transcripts)
+        .set({ status: "transcribing", updatedAt: now() })
+        .where(eq(transcripts.id, transcriptId));
+
+      const audioResponse = await fetch(audioUrl);
+      if (!audioResponse.ok) throw new Error(`Audio fetch failed: ${audioResponse.status}`);
+
+      const audioBytes = new Uint8Array(await audioResponse.arrayBuffer());
+      const response = await this.env.AI.run("@cf/openai/whisper", {
+        audio: [...audioBytes],
+      }) as WhisperResponse;
+
+      if (!response.text) throw new Error("Workers AI did not return transcript text");
+
       await db
         .update(transcripts)
         .set({
-          status: "failed",
-          errorMessage: error instanceof Error ? error.message : "Transcript workflow failed",
-          completedAt: now(),
+          rawText: response.text,
+          vtt: response.vtt || null,
+          wordCount: response.word_count || null,
+          status: "ready_raw_only",
           updatedAt: now(),
         })
         .where(eq(transcripts.id, transcriptId));
-      throw error;
-    }
+
+      return response;
+    });
+
+    await step.do("clean transcript", { timeout: "5 minutes" }, async () => {
+      await db
+        .update(transcripts)
+        .set({ status: "cleaning", updatedAt: now() })
+        .where(eq(transcripts.id, transcriptId));
+
+      try {
+        const response = await this.env.AI.run(this.env.TRANSCRIPT_CLEANUP_MODEL, {
+          messages: [{ role: "user", content: getCleanupPrompt(whisper.text!) }],
+        }) as TextGenerationResponse;
+
+        const cleaned = response.response?.trim();
+        await db
+          .update(transcripts)
+          .set({
+            cleanedText: cleaned || null,
+            status: cleaned ? "ready" : "ready_raw_only",
+            completedAt: now(),
+            updatedAt: now(),
+          })
+          .where(eq(transcripts.id, transcriptId));
+      } catch (cleanupError) {
+        // Cleanup failure is non-fatal -- raw transcript is still usable.
+        await db
+          .update(transcripts)
+          .set({
+            status: "ready_raw_only",
+            errorMessage: cleanupError instanceof Error ? cleanupError.message : "Transcript cleanup failed",
+            completedAt: now(),
+            updatedAt: now(),
+          })
+          .where(eq(transcripts.id, transcriptId));
+      }
+    });
   }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,6 +13,22 @@
 	"observability": {
 		"enabled": true
 	},
+	"flagship": [
+		{
+			"binding": "FLAGS",
+			"app_id": "TODO_FLAGSHIP_APP_ID"
+		}
+	],
+	"ai": {
+		"binding": "AI"
+	},
+	"workflows": [
+		{
+			"binding": "TRANSCRIPT_WORKFLOW",
+			"name": "quickcut-transcript-workflow",
+			"class_name": "TranscriptWorkflow"
+		}
+	],
 	"d1_databases": [
 		{
 			"binding": "DB",
@@ -35,6 +51,8 @@
 		}
 	],
 	"vars": {
-		"STREAM_ACCOUNT_ID": "4426cbeacb457b1ca1b865d6c36ced0d"
+		"STREAM_ACCOUNT_ID": "4426cbeacb457b1ca1b865d6c36ced0d",
+		"TRANSCRIPTS_ENABLED": "true",
+		"TRANSCRIPT_CLEANUP_MODEL": "@cf/meta/llama-3.1-8b-instruct"
 	}
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,58 +1,56 @@
 {
-	"$schema": "node_modules/wrangler/config-schema.json",
-	"name": "quickcut",
-	"main": "./src/worker.ts",
-	"compatibility_date": "2026-04-21",
-	"compatibility_flags": [
-		"nodejs_compat"
-	],
-	"assets": {
-		"binding": "ASSETS",
-		"directory": "./dist"
-	},
-	"observability": {
-		"enabled": true
-	},
-	"flagship": [
-		{
-			"binding": "FLAGS",
-			"app_id": "TODO_FLAGSHIP_APP_ID"
-		}
-	],
-	"ai": {
-		"binding": "AI"
-	},
-	"workflows": [
-		{
-			"binding": "TRANSCRIPT_WORKFLOW",
-			"name": "quickcut-transcript-workflow",
-			"class_name": "TranscriptWorkflow"
-		}
-	],
-	"d1_databases": [
-		{
-			"binding": "DB",
-			"database_name": "quickcut-db",
-			"database_id": "e92ddd0c-e338-49e0-8427-79e1d998200a"
-		}
-	],
-	"durable_objects": {
-		"bindings": [
-			{
-				"name": "VIDEO_ROOM",
-				"class_name": "VideoRoom"
-			}
-		]
-	},
-	"migrations": [
-		{
-			"tag": "v1",
-			"new_sqlite_classes": ["VideoRoom"]
-		}
-	],
-	"vars": {
-		"STREAM_ACCOUNT_ID": "4426cbeacb457b1ca1b865d6c36ced0d",
-		"TRANSCRIPTS_ENABLED": "true",
-		"TRANSCRIPT_CLEANUP_MODEL": "@cf/meta/llama-3.1-8b-instruct"
-	}
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "quickcut",
+  "main": "./src/worker.ts",
+  "compatibility_date": "2026-04-21",
+  "compatibility_flags": ["nodejs_compat"],
+  "assets": {
+    "binding": "ASSETS",
+    "directory": "./dist",
+  },
+  "observability": {
+    "enabled": true,
+  },
+  "flagship": [
+    {
+      "binding": "FLAGS",
+      "app_id": "0e0911ff-8d97-4af0-a6cb-95093b8b045e",
+    },
+  ],
+  "ai": {
+    "binding": "AI",
+  },
+  "workflows": [
+    {
+      "binding": "TRANSCRIPT_WORKFLOW",
+      "name": "quickcut-transcript-workflow",
+      "class_name": "TranscriptWorkflow",
+    },
+  ],
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "quickcut-db",
+      "database_id": "e92ddd0c-e338-49e0-8427-79e1d998200a",
+    },
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "VIDEO_ROOM",
+        "class_name": "VideoRoom",
+      },
+    ],
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["VideoRoom"],
+    },
+  ],
+  "vars": {
+    "STREAM_ACCOUNT_ID": "4426cbeacb457b1ca1b865d6c36ced0d",
+    "TRANSCRIPTS_ENABLED": "true",
+    "TRANSCRIPT_CLEANUP_MODEL": "@cf/meta/llama-3.1-8b-instruct",
+  },
 }


### PR DESCRIPTION
## Summary
- Restrict signups to Cloudflare email addresses and validate password confirmation.
- Add Flagship-gated transcript opt-in for uploads and version uploads.
- Add transcript schema, status API/UI, Stream audio export helpers, and a Workflows-based Workers AI transcription/cleanup pipeline.

## Validation
- `pnpm build`

## Notes
- This PR is stacked on `feature/video-version-stacking`.
- `wrangler.jsonc` includes `TODO_FLAGSHIP_APP_ID`; replace it with the real Flagship app ID before deploying.
- Apply `migrations/0006_add_transcripts.sql` before using transcript generation.