### PR TITLE
fix: hide transcript panel when feature is disabled and no transcript exists

### DIFF
--- a/src/components/TranscriptPanel.tsx
+++ b/src/components/TranscriptPanel.tsx
@@ -18,6 +18,7 @@ interface TranscriptResponse {
 interface TranscriptPanelProps {
   videoId: string;
   videoTitle: string;
+  transcriptsEnabled: boolean;
 }
 
 const statusCopy: Record<TranscriptStatus, { title: string; body: string }> = {
@@ -82,7 +83,7 @@ function getPollInterval(status: TranscriptStatus): number | null {
   return null;
 }
 
-export function TranscriptPanel({ videoId, videoTitle }: TranscriptPanelProps) {
+export function TranscriptPanel({ videoId, videoTitle, transcriptsEnabled }: TranscriptPanelProps) {
   const [data, setData] = useState<TranscriptResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [generating, setGenerating] = useState(false);
@@ -154,8 +155,14 @@ export function TranscriptPanel({ videoId, videoTitle }: TranscriptPanelProps) {
     );
   }
 
-  const copy = statusCopy[status];
   const text = data?.transcript?.cleanedText || data?.transcript?.rawText || "";
+
+  // Hide the panel entirely when transcripts aren't enabled and no transcript exists
+  if (!transcriptsEnabled && !text) {
+    return null;
+  }
+
+  const copy = statusCopy[status];
   const canGenerate = data?.transcriptsEnabled && status === "not_requested" && data.videoStatus === "ready";
   const canRetry = data?.transcriptsEnabled && status === "failed" && data.videoStatus === "ready";
 

--- a/src/components/VideoDetailView.tsx
+++ b/src/components/VideoDetailView.tsx
@@ -227,7 +227,7 @@ export function VideoDetailView({
         className="break-words text-sm text-text-secondary"
       />
 
-      <TranscriptPanel videoId={videoId} videoTitle={title} />
+      <TranscriptPanel videoId={videoId} videoTitle={title} transcriptsEnabled={transcriptsEnabled} />
     </>
   );
 


### PR DESCRIPTION
## Summary

- Hides the TranscriptPanel entirely when the transcript feature is disabled **and** no existing transcript text is available
- Preserves the panel (with full transcript text, copy/download actions) when a transcript has already been generated, even if the feature is later disabled
- Passes `transcriptsEnabled` prop from `VideoDetailView` into `TranscriptPanel` so it can make the visibility decision after fetching transcript data

## Behavior

| Scenario | Result |
|---|---|
| Transcripts enabled, no transcript yet | Panel shown (with "Generate transcript" button) |
| Transcripts enabled, transcript exists | Panel shown (with transcript text) |
| Transcripts disabled, transcript exists | Panel shown (with transcript text) |
| Transcripts disabled, no transcript | Panel hidden |