### PR TITLE
fix: move transcript panel below comments on small screens

### DIFF
--- a/src/components/VideoDetailView.tsx
+++ b/src/components/VideoDetailView.tsx
@@ -226,9 +226,11 @@ export function VideoDetailView({
         placeholder="Add a description..."
         className="break-words text-sm text-text-secondary"
       />
-
-      <TranscriptPanel videoId={videoId} videoTitle={title} transcriptsEnabled={transcriptsEnabled} />
     </>
+  );
+
+  const transcriptSection = (
+    <TranscriptPanel videoId={videoId} videoTitle={title} transcriptsEnabled={transcriptsEnabled} />
   );
 
   const rightColumn = (
@@ -253,5 +255,5 @@ export function VideoDetailView({
     />
   );
 
-  return <VideoPageLayout leftColumn={leftColumn} rightColumn={rightColumn} />;
+  return <VideoPageLayout leftColumn={leftColumn} rightColumn={rightColumn} bottomContent={transcriptSection} />;
 }

--- a/src/components/VideoPageLayout.tsx
+++ b/src/components/VideoPageLayout.tsx
@@ -3,15 +3,19 @@ import type { ReactNode } from "react";
 interface VideoPageLayoutProps {
   leftColumn: ReactNode;
   rightColumn: ReactNode;
+  bottomContent?: ReactNode;
 }
 
-export function VideoPageLayout({ leftColumn, rightColumn }: VideoPageLayoutProps) {
+export function VideoPageLayout({ leftColumn, rightColumn, bottomContent }: VideoPageLayoutProps) {
   return (
     <div className="grid grid-cols-1 gap-8 lg:grid-cols-[1fr_380px]">
       <div className="space-y-6">{leftColumn}</div>
       <div className="flex flex-col rounded-xl border border-border-default bg-bg-secondary">
         {rightColumn}
       </div>
+      {bottomContent && (
+        <div className="lg:col-start-1">{bottomContent}</div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- On mobile/small screens (single-column layout), the transcript panel was appearing **above** the comments section because it was part of the left column content
- Moves the `TranscriptPanel` out of `leftColumn` and into a new `bottomContent` slot on `VideoPageLayout`
- On small screens, the transcript now renders **after** the comments (natural DOM order: left column -> right column -> bottom content)
- On large screens (`lg:` breakpoint), the transcript stays aligned under the video/description column via `lg:col-start-1`

## Layout order

| Screen size | Order |
|---|---|
| Small (< lg) | Video -> Description -> Comments -> Transcript |
| Large (>= lg) | Left: Video, Description / Right: Comments / Below left: Transcript |