### PR TITLE
fix: make dashboard header buttons responsive with icons

### DIFF
--- a/src/components/CreateFolderDialog.tsx
+++ b/src/components/CreateFolderDialog.tsx
@@ -46,9 +46,14 @@ export function CreateFolderDialog({ parentId = null }: CreateFolderDialogProps)
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="rounded-lg border border-border-default px-5 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary"
+        className="inline-flex items-center gap-2 rounded-lg border border-border-default px-3 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary sm:px-5"
       >
-        New Folder
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+          <line x1="12" y1="11" x2="12" y2="17" />
+          <line x1="9" y1="14" x2="15" y2="14" />
+        </svg>
+        <span className="hidden sm:inline">New Folder</span>
       </button>
 
       <Modal

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -115,21 +115,26 @@ if (userVideos.length > 0) {
 ---
 
 <Layout title={currentFolderRecord ? currentFolderRecord.name : "My Videos"} user={user}>
-  <div class="mx-auto max-w-[1280px] px-8 py-8">
-    <div class="mb-8 flex items-center justify-between">
+  <div class="mx-auto max-w-[1280px] px-4 py-8 sm:px-8">
+    <div class="mb-8 flex flex-wrap items-center justify-between gap-4">
       <div>
         <Breadcrumbs path={folderPath} />
         <h1 class="text-2xl font-bold text-text-primary">
           {currentFolderRecord ? currentFolderRecord.name : "My Videos"}
         </h1>
       </div>
-      <div class="flex items-center gap-3">
+      <div class="flex items-center gap-2 sm:gap-3">
         <CreateFolderDialog client:load parentId={currentFolderId} />
         <a
           href={currentFolderId ? `/upload?folderId=${currentFolderId}` : "/upload"}
-          class="rounded-lg bg-accent-primary px-5 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover hover:shadow-[0_2px_8px_rgba(108,92,231,0.3)]"
+          class="inline-flex items-center gap-2 rounded-lg bg-accent-primary px-3 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover hover:shadow-[0_2px_8px_rgba(108,92,231,0.3)] sm:px-5"
         >
-          Upload Video
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="17 8 12 3 7 8" />
+            <line x1="12" y1="3" x2="12" y2="15" />
+          </svg>
+          <span class="hidden sm:inline">Upload Video</span>
         </a>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Adds SVG icons (folder-plus, upload) to the "New Folder" and "Upload Video" buttons so they remain usable as icon-only buttons on small screens
- Hides button text labels on mobile (`hidden sm:inline`) — icons stay visible at all sizes
- Makes the header row wrap gracefully with `flex-wrap` and `gap-4` instead of forcing everything onto one line
- Reduces horizontal padding on mobile (`px-4 sm:px-8`) to reclaim space
- Tightens button gap on mobile (`gap-2 sm:gap-3`) and reduces internal padding (`px-3 sm:px-5`)

### Before (mobile)
Title and full-text buttons compete for horizontal space, causing awkward layout.

### After (mobile)
- **< sm**: Icon-only buttons sit neatly next to the title, or wrap below if space is still tight
- **>= sm**: Full "New Folder" / "Upload Video" labels appear alongside icons