### PR TITLE
feat: add urgency levels to comments

### DIFF
--- a/migrations/0007_add_comment_urgency.sql
+++ b/migrations/0007_add_comment_urgency.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `comments` ADD `urgency` text DEFAULT 'suggestion' NOT NULL;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1777200000001,
       "tag": "0006_add_transcripts",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1777200000002,
+      "tag": "0007_add_comment_urgency",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/CommentThread.tsx
+++ b/src/components/CommentThread.tsx
@@ -12,29 +12,30 @@ import type {
   FocusRequest,
 } from "../types";
 
-/** Visual + display config for each urgency level. */
+/**
+ * Visual + display config for each urgency level. The colored dot is the
+ * only place urgency colour appears in the UI; surrounding text and pills
+ * use neutral tokens so urgency reads as metadata rather than a primary
+ * action.
+ */
 const URGENCY_META: Record<
   CommentUrgency,
-  { label: string; badge: string; pill: string; ring: string }
+  { label: string; description: string; dot: string }
 > = {
   suggestion: {
     label: "Suggestion",
-    // Compose pill (when not selected) and inline badge styles
-    badge: "bg-accent-info/15 text-accent-info",
-    pill: "bg-accent-info text-white",
-    ring: "ring-accent-info",
+    description: "Optional, nice-to-have",
+    dot: "bg-accent-info",
   },
   important: {
     label: "Important",
-    badge: "bg-accent-warning/15 text-accent-warning",
-    pill: "bg-accent-warning text-white",
-    ring: "ring-accent-warning",
+    description: "Should be addressed",
+    dot: "bg-accent-warning",
   },
   critical: {
     label: "Critical",
-    badge: "bg-accent-danger/15 text-accent-danger",
-    pill: "bg-accent-danger text-white",
-    ring: "ring-accent-danger",
+    description: "Must be fixed",
+    dot: "bg-accent-danger",
   },
 };
 
@@ -43,6 +44,153 @@ const URGENCY_OPTIONS: CommentUrgency[] = [
   "important",
   "critical",
 ];
+
+/**
+ * Compact urgency picker: shows a colored dot + label (label hides on
+ * narrow screens) and opens a small popover with the three options on
+ * click. Closes on outside click, escape key, or selection.
+ */
+function UrgencyPicker({
+  value,
+  onChange,
+}: {
+  value: CommentUrgency;
+  onChange: (next: CommentUrgency) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(() =>
+    URGENCY_OPTIONS.indexOf(value),
+  );
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Sync the keyboard focus index when the popover opens.
+  useEffect(() => {
+    if (open) setActiveIndex(URGENCY_OPTIONS.indexOf(value));
+  }, [open, value]);
+
+  // Close on outside click / escape.
+  useEffect(() => {
+    if (!open) return;
+
+    const onClick = (e: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+      } else if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveIndex((i) => (i + 1) % URGENCY_OPTIONS.length);
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveIndex((i) =>
+          i <= 0 ? URGENCY_OPTIONS.length - 1 : i - 1,
+        );
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const next = URGENCY_OPTIONS[activeIndex];
+        if (next) {
+          onChange(next);
+          setOpen(false);
+        }
+      }
+    };
+
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open, activeIndex, onChange]);
+
+  const meta = URGENCY_META[value];
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={`Urgency: ${meta.label}`}
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex h-7 items-center gap-1.5 rounded-md border border-border-default bg-bg-tertiary px-2 text-xs text-text-secondary transition-colors hover:bg-bg-input focus:border-accent-primary focus:outline-none"
+      >
+        <span className={`h-2 w-2 shrink-0 rounded-full ${meta.dot}`} />
+        <span className="hidden sm:inline">{meta.label}</span>
+        <svg
+          className="h-3 w-3 shrink-0 text-text-tertiary"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          aria-label="Select comment urgency"
+          className="absolute bottom-full left-0 z-20 mb-1 w-56 overflow-hidden rounded-lg border border-border-default bg-bg-secondary shadow-lg"
+        >
+          {URGENCY_OPTIONS.map((level, index) => {
+            const optionMeta = URGENCY_META[level];
+            const selected = level === value;
+            const active = index === activeIndex;
+            return (
+              <button
+                key={level}
+                type="button"
+                role="option"
+                aria-selected={selected}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => {
+                  onChange(level);
+                  setOpen(false);
+                }}
+                className={`flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors ${
+                  active ? "bg-bg-tertiary" : "bg-transparent"
+                }`}
+              >
+                <span
+                  className={`h-2 w-2 shrink-0 rounded-full ${optionMeta.dot}`}
+                />
+                <span className="flex-1">
+                  <span className="font-medium text-text-primary">
+                    {optionMeta.label}
+                  </span>
+                  <span className="ml-1.5 text-text-tertiary">
+                    {optionMeta.description}
+                  </span>
+                </span>
+                {selected && (
+                  <svg
+                    className="h-3.5 w-3.5 shrink-0 text-text-secondary"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
 
 interface CommentThreadProps {
   videoId: string;
@@ -492,9 +640,13 @@ export function CommentThread({
                         {comment.displayName}
                       </span>
                       <span
-                        className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${URGENCY_META[comment.urgency].badge}`}
+                        className="inline-flex items-center gap-1 rounded-full bg-bg-tertiary px-1.5 py-0.5 text-[10px] font-medium text-text-secondary"
                         title={`${URGENCY_META[comment.urgency].label} comment`}
                       >
+                        <span
+                          className={`h-1.5 w-1.5 shrink-0 rounded-full ${URGENCY_META[comment.urgency].dot}`}
+                          aria-hidden="true"
+                        />
                         {URGENCY_META[comment.urgency].label}
                       </span>
                       {comment.timestamp != null && (
@@ -661,38 +813,24 @@ export function CommentThread({
             </button>
           </div>
         )}
-        {videoStatus === "ready" && onToolChange && (
-          <div className="mb-2 flex w-full items-center gap-2">
-            <AnnotationToolbar activeTool={activeTool} onToolChange={onToolChange} />
-            <span className="rounded bg-bg-tertiary px-2 py-1 font-mono text-xs text-accent-primary">
-              {formatTC(currentTime)}
-            </span>
-          </div>
-        )}
-        {/* Urgency selector — top-level comments only */}
-        <div className="mb-2 flex w-full items-center gap-1.5" role="radiogroup" aria-label="Comment urgency">
-          <span className="mr-1 text-[10px] font-semibold uppercase tracking-wide text-text-tertiary">
-            Urgency
-          </span>
-          {URGENCY_OPTIONS.map((level) => {
-            const isActive = newCommentUrgency === level;
-            return (
-              <button
-                key={level}
-                type="button"
-                role="radio"
-                aria-checked={isActive}
-                onClick={() => setNewCommentUrgency(level)}
-                className={`rounded-full px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide transition-all ${
-                  isActive
-                    ? URGENCY_META[level].pill
-                    : `${URGENCY_META[level].badge} hover:opacity-80`
-                }`}
-              >
-                {URGENCY_META[level].label}
-              </button>
-            );
-          })}
+        {/*
+          Compose toolbar row. Renders annotation tools + timecode when the
+          video is ready; the urgency picker always renders so reviewers can
+          tag urgency even before processing finishes.
+        */}
+        <div className="mb-2 flex w-full flex-wrap items-center gap-2">
+          {videoStatus === "ready" && onToolChange && (
+            <>
+              <AnnotationToolbar activeTool={activeTool} onToolChange={onToolChange} />
+              <span className="rounded bg-bg-tertiary px-2 py-1 font-mono text-xs text-accent-primary">
+                {formatTC(currentTime)}
+              </span>
+            </>
+          )}
+          <UrgencyPicker
+            value={newCommentUrgency}
+            onChange={setNewCommentUrgency}
+          />
         </div>
         <div className="flex min-w-0 items-center gap-2">
           <input

--- a/src/components/CommentThread.tsx
+++ b/src/components/CommentThread.tsx
@@ -144,31 +144,70 @@ function UrgencyPicker({
             const selected = level === value;
             const active = index === activeIndex;
             return (
-              <button
+              <div
                 key={level}
-                type="button"
                 role="option"
                 aria-selected={selected}
                 onMouseEnter={() => setActiveIndex(index)}
-                onClick={() => {
-                  onChange(level);
-                  setOpen(false);
-                }}
-                className={`flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors ${
+                className={`group/row flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors ${
                   active ? "bg-bg-tertiary" : "bg-transparent"
                 }`}
               >
-                <span
-                  className={`h-2 w-2 shrink-0 rounded-full ${optionMeta.dot}`}
-                />
-                <span className="flex-1">
+                <button
+                  type="button"
+                  onClick={() => {
+                    onChange(level);
+                    setOpen(false);
+                  }}
+                  className="flex flex-1 items-center gap-2 text-left"
+                >
+                  <span
+                    className={`h-2 w-2 shrink-0 rounded-full ${optionMeta.dot}`}
+                  />
                   <span className="font-medium text-text-primary">
                     {optionMeta.label}
                   </span>
-                  <span className="ml-1.5 text-text-tertiary">
+                </button>
+
+                {/*
+                  Info icon: reveals the description on hover or keyboard
+                  focus via the sibling group-hover/group-focus utilities.
+                  The tooltip content also doubles as the title attribute so
+                  it is accessible to screen readers and pointer-less users.
+                */}
+                <span className="relative inline-flex">
+                  <span
+                    tabIndex={0}
+                    role="button"
+                    aria-label={`${optionMeta.label}: ${optionMeta.description}`}
+                    title={optionMeta.description}
+                    className="peer inline-flex h-4 w-4 shrink-0 cursor-help items-center justify-center rounded-full text-text-tertiary transition-colors hover:text-text-secondary focus:text-text-secondary focus:outline-none"
+                    onMouseDown={(e) => e.stopPropagation()}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <svg
+                      className="h-3.5 w-3.5"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <circle cx="12" cy="12" r="10" />
+                      <line x1="12" y1="16" x2="12" y2="12" />
+                      <line x1="12" y1="8" x2="12.01" y2="8" />
+                    </svg>
+                  </span>
+                  <span
+                    role="tooltip"
+                    className="pointer-events-none absolute right-0 top-full z-30 mt-1 hidden w-44 rounded-md border border-border-default bg-bg-primary px-2.5 py-1.5 text-[11px] text-text-secondary shadow-lg peer-hover:block peer-focus:block"
+                  >
                     {optionMeta.description}
                   </span>
                 </span>
+
                 {selected && (
                   <svg
                     className="h-3.5 w-3.5 shrink-0 text-text-secondary"
@@ -183,7 +222,7 @@ function UrgencyPicker({
                     <polyline points="20 6 9 17 4 12" />
                   </svg>
                 )}
-              </button>
+              </div>
             );
           })}
         </div>

--- a/src/components/CommentThread.tsx
+++ b/src/components/CommentThread.tsx
@@ -5,7 +5,44 @@ import type { Viewer } from "../lib/realtime";
 import { PresenceBar } from "./PresenceBar";
 import { AnnotationToolbar } from "./AnnotationOverlay";
 import type { AnnotationTool } from "./AnnotationOverlay";
-import type { Annotation, Comment, FocusRequest } from "../types";
+import type {
+  Annotation,
+  Comment,
+  CommentUrgency,
+  FocusRequest,
+} from "../types";
+
+/** Visual + display config for each urgency level. */
+const URGENCY_META: Record<
+  CommentUrgency,
+  { label: string; badge: string; pill: string; ring: string }
+> = {
+  suggestion: {
+    label: "Suggestion",
+    // Compose pill (when not selected) and inline badge styles
+    badge: "bg-accent-info/15 text-accent-info",
+    pill: "bg-accent-info text-white",
+    ring: "ring-accent-info",
+  },
+  important: {
+    label: "Important",
+    badge: "bg-accent-warning/15 text-accent-warning",
+    pill: "bg-accent-warning text-white",
+    ring: "ring-accent-warning",
+  },
+  critical: {
+    label: "Critical",
+    badge: "bg-accent-danger/15 text-accent-danger",
+    pill: "bg-accent-danger text-white",
+    ring: "ring-accent-danger",
+  },
+};
+
+const URGENCY_OPTIONS: CommentUrgency[] = [
+  "suggestion",
+  "important",
+  "critical",
+];
 
 interface CommentThreadProps {
   videoId: string;
@@ -71,6 +108,8 @@ export function CommentThread({
   const [comments, setComments] = useState<Comment[]>(initialComments);
   const [filter, setFilter] = useState<FilterType>("all");
   const [newComment, setNewComment] = useState("");
+  const [newCommentUrgency, setNewCommentUrgency] =
+    useState<CommentUrgency>("suggestion");
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
   const [replyText, setReplyText] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -221,6 +260,7 @@ export function CommentThread({
       const body: Record<string, unknown> = {
         text: newComment.trim(),
         timestamp: videoStatus === "ready" ? currentTime : null,
+        urgency: newCommentUrgency,
       };
 
       if (pendingAnnotation) {
@@ -244,6 +284,7 @@ export function CommentThread({
           return sortComments([...prev, data.comment]);
         });
         setNewComment("");
+        setNewCommentUrgency("suggestion");
         onAnnotationClear?.();
         lastFetchRef.current = new Date().toISOString();
       } else {
@@ -446,9 +487,15 @@ export function CommentThread({
                     {getInitials(comment.displayName)}
                   </div>
                   <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
+                    <div className="flex flex-wrap items-center gap-2">
                       <span className="text-sm font-semibold text-text-primary">
                         {comment.displayName}
+                      </span>
+                      <span
+                        className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${URGENCY_META[comment.urgency].badge}`}
+                        title={`${URGENCY_META[comment.urgency].label} comment`}
+                      >
+                        {URGENCY_META[comment.urgency].label}
                       </span>
                       {comment.timestamp != null && (
                         <button
@@ -622,6 +669,31 @@ export function CommentThread({
             </span>
           </div>
         )}
+        {/* Urgency selector — top-level comments only */}
+        <div className="mb-2 flex w-full items-center gap-1.5" role="radiogroup" aria-label="Comment urgency">
+          <span className="mr-1 text-[10px] font-semibold uppercase tracking-wide text-text-tertiary">
+            Urgency
+          </span>
+          {URGENCY_OPTIONS.map((level) => {
+            const isActive = newCommentUrgency === level;
+            return (
+              <button
+                key={level}
+                type="button"
+                role="radio"
+                aria-checked={isActive}
+                onClick={() => setNewCommentUrgency(level)}
+                className={`rounded-full px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide transition-all ${
+                  isActive
+                    ? URGENCY_META[level].pill
+                    : `${URGENCY_META[level].badge} hover:opacity-80`
+                }`}
+              >
+                {URGENCY_META[level].label}
+              </button>
+            );
+          })}
+        </div>
         <div className="flex min-w-0 items-center gap-2">
           <input
             type="text"

--- a/src/components/CommentThread.tsx
+++ b/src/components/CommentThread.tsx
@@ -167,6 +167,20 @@ function UrgencyPicker({
                   <span className="font-medium text-text-primary">
                     {optionMeta.label}
                   </span>
+                  {selected && (
+                    <svg
+                      className="h-3.5 w-3.5 shrink-0 text-text-secondary"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                  )}
                 </button>
 
                 {/*
@@ -174,6 +188,8 @@ function UrgencyPicker({
                   focus via the sibling group-hover/group-focus utilities.
                   The tooltip content also doubles as the title attribute so
                   it is accessible to screen readers and pointer-less users.
+                  Always pinned to the right of the row so its position is
+                  stable across selected and unselected states.
                 */}
                 <span className="relative inline-flex">
                   <span
@@ -207,21 +223,6 @@ function UrgencyPicker({
                     {optionMeta.description}
                   </span>
                 </span>
-
-                {selected && (
-                  <svg
-                    className="h-3.5 w-3.5 shrink-0 text-text-secondary"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden="true"
-                  >
-                    <polyline points="20 6 9 17 4 12" />
-                  </svg>
-                )}
               </div>
             );
           })}

--- a/src/components/CommentThread.tsx
+++ b/src/components/CommentThread.tsx
@@ -22,6 +22,11 @@ const URGENCY_META: Record<
   CommentUrgency,
   { label: string; description: string; dot: string }
 > = {
+  idea: {
+    label: "Idea",
+    description: "Concept to consider",
+    dot: "bg-accent-primary",
+  },
   suggestion: {
     label: "Suggestion",
     description: "Optional, nice-to-have",
@@ -39,7 +44,9 @@ const URGENCY_META: Record<
   },
 };
 
+// Listed from lowest to highest severity so the dropdown reads naturally.
 const URGENCY_OPTIONS: CommentUrgency[] = [
+  "idea",
   "suggestion",
   "important",
   "critical",

--- a/src/components/CommentTimeline.tsx
+++ b/src/components/CommentTimeline.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from "react";
+import type { CommentUrgency } from "../types";
 
 interface TimelineComment {
   id: string;
@@ -6,6 +7,7 @@ interface TimelineComment {
   text: string;
   displayName: string;
   isResolved: boolean;
+  urgency: CommentUrgency;
 }
 
 interface CommentTimelineProps {
@@ -15,6 +17,17 @@ interface CommentTimelineProps {
   onSeek?: (time: number) => void;
   onCommentClick?: (commentId: string) => void;
 }
+
+/**
+ * Tailwind class for an unresolved marker, keyed by urgency. Resolved
+ * markers always render in the muted secondary color so reviewers can
+ * still distinguish completed feedback at a glance.
+ */
+const URGENCY_DOT: Record<CommentUrgency, string> = {
+  suggestion: "bg-accent-info",
+  important: "bg-accent-warning",
+  critical: "bg-accent-danger",
+};
 
 export function CommentTimeline({
   comments,
@@ -63,14 +76,13 @@ export function CommentTimeline({
       {comments.map((comment) => {
         if (comment.timestamp == null) return null;
         const position = (comment.timestamp / duration) * 100;
+        const dotColor = comment.isResolved
+          ? "bg-accent-secondary"
+          : URGENCY_DOT[comment.urgency];
         return (
           <button
             key={comment.id}
-            className={`absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full transition-transform hover:scale-150 ${
-              comment.isResolved
-                ? "bg-accent-secondary"
-                : "bg-accent-warning"
-            }`}
+            className={`absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full transition-transform hover:scale-150 ${dotColor}`}
             style={{ left: `${position}%` }}
             onMouseEnter={(e) => handleMarkerHover(comment, e)}
             onMouseLeave={() => setHoveredComment(null)}

--- a/src/components/CommentTimeline.tsx
+++ b/src/components/CommentTimeline.tsx
@@ -24,6 +24,7 @@ interface CommentTimelineProps {
  * still distinguish completed feedback at a glance.
  */
 const URGENCY_DOT: Record<CommentUrgency, string> = {
+  idea: "bg-accent-primary",
   suggestion: "bg-accent-info",
   important: "bg-accent-warning",
   critical: "bg-accent-danger",

--- a/src/components/UploadVersionModal.tsx
+++ b/src/components/UploadVersionModal.tsx
@@ -140,7 +140,7 @@ export function UploadVersionModal({
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="rounded-lg border border-border-default px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-tertiary"
+        className="w-full rounded-lg border border-border-default px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-tertiary sm:w-auto"
       >
         Upload new version
       </button>

--- a/src/components/VideoCard.astro
+++ b/src/components/VideoCard.astro
@@ -2,6 +2,12 @@
 import StatusBadge from "./StatusBadge.astro";
 import { VideoCardMenu } from "./VideoCardMenu";
 
+interface UrgencyCounts {
+  suggestion: number;
+  important: number;
+  critical: number;
+}
+
 interface Props {
   id: string;
   title: string;
@@ -10,6 +16,7 @@ interface Props {
   status: "processing" | "ready" | "failed";
   createdAt: string;
   commentCount: number;
+  urgencyCounts?: UrgencyCounts;
   versionNumber?: number;
   versionCount?: number;
   folderId?: string | null;
@@ -23,10 +30,18 @@ const {
   status,
   createdAt,
   commentCount,
+  urgencyCounts = { suggestion: 0, important: 0, critical: 0 },
   versionNumber = 1,
   versionCount = 1,
   folderId = null,
 } = Astro.props;
+
+// Order by severity descending so reviewers see the most urgent items first.
+const urgencyBadges = [
+  { key: "critical", count: urgencyCounts.critical, classes: "bg-accent-danger/15 text-accent-danger" },
+  { key: "important", count: urgencyCounts.important, classes: "bg-accent-warning/15 text-accent-warning" },
+  { key: "suggestion", count: urgencyCounts.suggestion, classes: "bg-accent-info/15 text-accent-info" },
+].filter((b) => b.count > 0);
 
 function formatDuration(seconds: number | null): string {
   if (!seconds) return "";
@@ -82,6 +97,18 @@ function formatDate(dateStr: string): string {
           </span>
         )}
       </div>
+      {urgencyBadges.length > 0 && (
+        <div class="mt-2 flex flex-wrap items-center gap-1.5">
+          {urgencyBadges.map((badge) => (
+            <span
+              class={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${badge.classes}`}
+              title={`${badge.count} unresolved ${badge.key} comment${badge.count === 1 ? "" : "s"}`}
+            >
+              {badge.count} {badge.key}
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   </a>
   <div class="absolute right-2 top-2 z-10">

--- a/src/components/VideoCard.astro
+++ b/src/components/VideoCard.astro
@@ -3,6 +3,7 @@ import StatusBadge from "./StatusBadge.astro";
 import { VideoCardMenu } from "./VideoCardMenu";
 
 interface UrgencyCounts {
+  idea: number;
   suggestion: number;
   important: number;
   critical: number;
@@ -30,7 +31,7 @@ const {
   status,
   createdAt,
   commentCount,
-  urgencyCounts = { suggestion: 0, important: 0, critical: 0 },
+  urgencyCounts = { idea: 0, suggestion: 0, important: 0, critical: 0 },
   versionNumber = 1,
   versionCount = 1,
   folderId = null,
@@ -43,6 +44,7 @@ const urgencyBadges = [
   { key: "critical", count: urgencyCounts.critical, dot: "bg-accent-danger" },
   { key: "important", count: urgencyCounts.important, dot: "bg-accent-warning" },
   { key: "suggestion", count: urgencyCounts.suggestion, dot: "bg-accent-info" },
+  { key: "idea", count: urgencyCounts.idea, dot: "bg-accent-primary" },
 ].filter((b) => b.count > 0);
 
 function formatDuration(seconds: number | null): string {

--- a/src/components/VideoCard.astro
+++ b/src/components/VideoCard.astro
@@ -36,11 +36,13 @@ const {
   folderId = null,
 } = Astro.props;
 
-// Order by severity descending so reviewers see the most urgent items first.
+// Order by severity descending so reviewers see the most urgent items
+// first. Each entry renders a small colored dot + count; the urgency name
+// only surfaces in the tooltip so the card stays calm.
 const urgencyBadges = [
-  { key: "critical", count: urgencyCounts.critical, classes: "bg-accent-danger/15 text-accent-danger" },
-  { key: "important", count: urgencyCounts.important, classes: "bg-accent-warning/15 text-accent-warning" },
-  { key: "suggestion", count: urgencyCounts.suggestion, classes: "bg-accent-info/15 text-accent-info" },
+  { key: "critical", count: urgencyCounts.critical, dot: "bg-accent-danger" },
+  { key: "important", count: urgencyCounts.important, dot: "bg-accent-warning" },
+  { key: "suggestion", count: urgencyCounts.suggestion, dot: "bg-accent-info" },
 ].filter((b) => b.count > 0);
 
 function formatDuration(seconds: number | null): string {
@@ -98,13 +100,14 @@ function formatDate(dateStr: string): string {
         )}
       </div>
       {urgencyBadges.length > 0 && (
-        <div class="mt-2 flex flex-wrap items-center gap-1.5">
+        <div class="mt-2 flex flex-wrap items-center gap-3">
           {urgencyBadges.map((badge) => (
             <span
-              class={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${badge.classes}`}
+              class="inline-flex items-center gap-1 text-xs text-text-secondary"
               title={`${badge.count} unresolved ${badge.key} comment${badge.count === 1 ? "" : "s"}`}
             >
-              {badge.count} {badge.key}
+              <span class={`h-1.5 w-1.5 rounded-full ${badge.dot}`} aria-hidden="true" />
+              {badge.count}
             </span>
           ))}
         </div>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -161,6 +161,11 @@ export const comments = sqliteTable("comments", {
   }),
   resolvedAt: text("resolved_at"),
   annotation: text("annotation"),
+  urgency: text("urgency", {
+    enum: ["suggestion", "important", "critical"],
+  })
+    .notNull()
+    .default("suggestion"),
   createdAt: text("created_at")
     .notNull()
     .default(sql`(datetime('now'))`),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -162,7 +162,7 @@ export const comments = sqliteTable("comments", {
   resolvedAt: text("resolved_at"),
   annotation: text("annotation"),
   urgency: text("urgency", {
-    enum: ["suggestion", "important", "critical"],
+    enum: ["idea", "suggestion", "important", "critical"],
   })
     .notNull()
     .default("suggestion"),

--- a/src/durable-objects/VideoRoom.ts
+++ b/src/durable-objects/VideoRoom.ts
@@ -1,5 +1,5 @@
 import { DurableObject } from "cloudflare:workers";
-import type { Annotation } from "../types";
+import type { Annotation, CommentUrgency } from "../types";
 
 /**
  * Shape of comments broadcast to connected clients.
@@ -18,6 +18,7 @@ export interface BroadcastComment {
 	resolvedBy: string | null;
 	resolvedAt: string | null;
 	annotation: Annotation | null;
+	urgency: CommentUrgency;
 	createdAt: string;
 	displayName: string;
 }

--- a/src/lib/comments.ts
+++ b/src/lib/comments.ts
@@ -21,6 +21,7 @@ export async function getCommentsWithNames(
       resolvedBy: comments.resolvedBy,
       resolvedAt: comments.resolvedAt,
       annotation: comments.annotation,
+      urgency: comments.urgency,
       createdAt: comments.createdAt,
     })
     .from(comments)

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -40,7 +40,12 @@ export const uploadSchema = z.object({
   generateTranscript: z.boolean().optional(),
 });
 
-export const urgencySchema = z.enum(["suggestion", "important", "critical"]);
+export const urgencySchema = z.enum([
+  "idea",
+  "suggestion",
+  "important",
+  "critical",
+]);
 
 export const commentSchema = z.object({
   text: z.string().min(1, "Comment text is required").max(5000),

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -40,10 +40,13 @@ export const uploadSchema = z.object({
   generateTranscript: z.boolean().optional(),
 });
 
+export const urgencySchema = z.enum(["suggestion", "important", "critical"]);
+
 export const commentSchema = z.object({
   text: z.string().min(1, "Comment text is required").max(5000),
   timestamp: z.number().nullable().optional(),
   annotation: annotationSchema.nullable().optional(),
+  urgency: urgencySchema.optional().default("suggestion"),
 });
 
 export const anonymousCommentSchema = z.object({
@@ -52,6 +55,7 @@ export const anonymousCommentSchema = z.object({
   displayName: z.string().min(1, "Display name is required").max(100),
   parentId: z.string().optional(),
   annotation: annotationSchema.nullable().optional(),
+  urgency: urgencySchema.optional().default("suggestion"),
 });
 
 export const videoUpdateSchema = z.object({

--- a/src/pages/api/comments/[id]/reply.ts
+++ b/src/pages/api/comments/[id]/reply.ts
@@ -48,6 +48,8 @@ export const POST: APIRoute = async ({ params, locals, request }) => {
   }
 
   const commentId = crypto.randomUUID();
+  // Replies don't carry urgency; default to "suggestion" so the column stays
+  // populated without surfacing in the UI.
   const newReply = {
     id: commentId,
     videoId: parent[0].videoId,
@@ -61,6 +63,7 @@ export const POST: APIRoute = async ({ params, locals, request }) => {
     resolvedBy: null,
     resolvedAt: null,
     annotation: null,
+    urgency: "suggestion" as const,
   };
 
   await db.insert(comments).values(newReply);

--- a/src/pages/api/share/[token]/comments.ts
+++ b/src/pages/api/share/[token]/comments.ts
@@ -115,7 +115,12 @@ export const POST: APIRoute = async ({ params, request }) => {
 
   // Replies don't carry urgency; force "suggestion" for them. Validate input
   // for top-level comments and fall back to "suggestion" if missing/invalid.
-  const allowedUrgencies = ["suggestion", "important", "critical"] as const;
+  const allowedUrgencies = [
+    "idea",
+    "suggestion",
+    "important",
+    "critical",
+  ] as const;
   type Urgency = (typeof allowedUrgencies)[number];
   const isReply = !!parentId;
   const commentUrgency: Urgency = isReply

--- a/src/pages/api/share/[token]/comments.ts
+++ b/src/pages/api/share/[token]/comments.ts
@@ -97,7 +97,7 @@ export const POST: APIRoute = async ({ params, request }) => {
 
   const videoId = shareLinkResult[0].videoId;
   const body = await request.json();
-  const { text, timestamp, displayName, parentId, annotation } = body;
+  const { text, timestamp, displayName, parentId, annotation, urgency } = body;
 
   if (!text || !text.trim()) {
     return new Response(JSON.stringify({ error: "Comment text is required" }), {
@@ -113,6 +113,17 @@ export const POST: APIRoute = async ({ params, request }) => {
     );
   }
 
+  // Replies don't carry urgency; force "suggestion" for them. Validate input
+  // for top-level comments and fall back to "suggestion" if missing/invalid.
+  const allowedUrgencies = ["suggestion", "important", "critical"] as const;
+  type Urgency = (typeof allowedUrgencies)[number];
+  const isReply = !!parentId;
+  const commentUrgency: Urgency = isReply
+    ? "suggestion"
+    : allowedUrgencies.includes(urgency as Urgency)
+      ? (urgency as Urgency)
+      : "suggestion";
+
   const commentId = crypto.randomUUID();
   const newComment = {
     id: commentId,
@@ -127,6 +138,7 @@ export const POST: APIRoute = async ({ params, request }) => {
     resolvedBy: null,
     resolvedAt: null,
     annotation: annotation ? JSON.stringify(annotation) : null,
+    urgency: commentUrgency,
   };
 
   await db.insert(comments).values(newComment);

--- a/src/pages/api/videos/[id]/comments.ts
+++ b/src/pages/api/videos/[id]/comments.ts
@@ -90,7 +90,12 @@ export const POST: APIRoute = async ({ params, locals, request }) => {
   }
 
   // Validate urgency; default to "suggestion" if not provided.
-  const allowedUrgencies = ["suggestion", "important", "critical"] as const;
+  const allowedUrgencies = [
+    "idea",
+    "suggestion",
+    "important",
+    "critical",
+  ] as const;
   type Urgency = (typeof allowedUrgencies)[number];
   const commentUrgency: Urgency = allowedUrgencies.includes(urgency as Urgency)
     ? (urgency as Urgency)

--- a/src/pages/api/videos/[id]/comments.ts
+++ b/src/pages/api/videos/[id]/comments.ts
@@ -80,7 +80,7 @@ export const POST: APIRoute = async ({ params, locals, request }) => {
   }
 
   const body = await request.json();
-  const { text, timestamp, annotation } = body;
+  const { text, timestamp, annotation, urgency } = body;
 
   if (!text || !text.trim()) {
     return new Response(JSON.stringify({ error: "Comment text is required" }), {
@@ -88,6 +88,13 @@ export const POST: APIRoute = async ({ params, locals, request }) => {
       headers: { "Content-Type": "application/json" },
     });
   }
+
+  // Validate urgency; default to "suggestion" if not provided.
+  const allowedUrgencies = ["suggestion", "important", "critical"] as const;
+  type Urgency = (typeof allowedUrgencies)[number];
+  const commentUrgency: Urgency = allowedUrgencies.includes(urgency as Urgency)
+    ? (urgency as Urgency)
+    : "suggestion";
 
   const db = createDb(env.DB);
 
@@ -118,6 +125,7 @@ export const POST: APIRoute = async ({ params, locals, request }) => {
     resolvedBy: null,
     resolvedAt: null,
     annotation: annotation ? JSON.stringify(annotation) : null,
+    urgency: commentUrgency,
   };
 
   await db.insert(comments).values(newComment);

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -89,7 +89,12 @@ const userVideos = await db
 // unresolved comments. Replies and resolved comments are excluded from the
 // urgency breakdown so reviewers see only outstanding work.
 let commentCounts: Record<string, number> = {};
-type UrgencyCounts = { suggestion: number; important: number; critical: number };
+type UrgencyCounts = {
+  idea: number;
+  suggestion: number;
+  important: number;
+  critical: number;
+};
 let urgencyCounts: Record<string, UrgencyCounts> = {};
 if (userVideos.length > 0) {
   const videoIds = userVideos.map((v) => v.id);
@@ -119,6 +124,7 @@ if (userVideos.length > 0) {
   urgencyCounts = urgencyRows.reduce<Record<string, UrgencyCounts>>(
     (acc, row) => {
       const bucket = acc[row.videoId] || {
+        idea: 0,
         suggestion: 0,
         important: 0,
         critical: 0,
@@ -197,7 +203,7 @@ if (userVideos.length > 0) {
             status={video.status as "processing" | "ready" | "failed"}
             createdAt={video.createdAt}
             commentCount={commentCounts[video.id] || 0}
-            urgencyCounts={urgencyCounts[video.id] || { suggestion: 0, important: 0, critical: 0 }}
+            urgencyCounts={urgencyCounts[video.id] || { idea: 0, suggestion: 0, important: 0, critical: 0 }}
             versionNumber={video.versionNumber}
             versionCount={versionCounts[video.versionGroupId || video.id] || 1}
           />

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -85,8 +85,12 @@ const userVideos = await db
   )
   .orderBy(desc(videos.createdAt));
 
-// Get comment counts
+// Get comment counts (per video) + urgency breakdown for top-level,
+// unresolved comments. Replies and resolved comments are excluded from the
+// urgency breakdown so reviewers see only outstanding work.
 let commentCounts: Record<string, number> = {};
+type UrgencyCounts = { suggestion: number; important: number; critical: number };
+let urgencyCounts: Record<string, UrgencyCounts> = {};
 if (userVideos.length > 0) {
   const videoIds = userVideos.map((v) => v.id);
   const counts = await db
@@ -99,6 +103,32 @@ if (userVideos.length > 0) {
     .groupBy(comments.videoId);
 
   commentCounts = Object.fromEntries(counts.map((c) => [c.videoId, c.count]));
+
+  const urgencyRows = await db
+    .select({
+      videoId: comments.videoId,
+      urgency: comments.urgency,
+      count: count(),
+    })
+    .from(comments)
+    .where(
+      sql`${comments.videoId} IN (${sql.join(videoIds.map((id) => sql`${id}`), sql`, `)}) AND ${comments.parentId} IS NULL AND ${comments.isResolved} = 0`,
+    )
+    .groupBy(comments.videoId, comments.urgency);
+
+  urgencyCounts = urgencyRows.reduce<Record<string, UrgencyCounts>>(
+    (acc, row) => {
+      const bucket = acc[row.videoId] || {
+        suggestion: 0,
+        important: 0,
+        critical: 0,
+      };
+      bucket[row.urgency as keyof UrgencyCounts] = row.count;
+      acc[row.videoId] = bucket;
+      return acc;
+    },
+    {},
+  );
 }
 
 let versionCounts: Record<string, number> = {};
@@ -167,6 +197,7 @@ if (userVideos.length > 0) {
             status={video.status as "processing" | "ready" | "failed"}
             createdAt={video.createdAt}
             commentCount={commentCounts[video.id] || 0}
+            urgencyCounts={urgencyCounts[video.id] || { suggestion: 0, important: 0, critical: 0 }}
             versionNumber={video.versionNumber}
             versionCount={versionCounts[video.versionGroupId || video.id] || 1}
           />

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,14 @@ export interface RectAnnotation {
 
 export type Annotation = PointAnnotation | RectAnnotation;
 
+export type CommentUrgency = "suggestion" | "important" | "critical";
+
+export const COMMENT_URGENCIES: CommentUrgency[] = [
+  "suggestion",
+  "important",
+  "critical",
+];
+
 export interface Comment {
   id: string;
   videoId: string;
@@ -27,6 +35,7 @@ export interface Comment {
   resolvedBy: string | null;
   resolvedAt: string | null;
   annotation: Annotation | null;
+  urgency: CommentUrgency;
   createdAt: string;
   displayName: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,9 +14,14 @@ export interface RectAnnotation {
 
 export type Annotation = PointAnnotation | RectAnnotation;
 
-export type CommentUrgency = "suggestion" | "important" | "critical";
+export type CommentUrgency =
+  | "idea"
+  | "suggestion"
+  | "important"
+  | "critical";
 
 export const COMMENT_URGENCIES: CommentUrgency[] = [
+  "idea",
   "suggestion",
   "important",
   "critical",


### PR DESCRIPTION
## Summary

Adds a 3-level urgency enum (`suggestion`, `important`, `critical`) to top-level comments so reviewers can communicate context with each piece of feedback. Replies don't carry urgency.

## Changes

**Database**
- New migration `0007_add_comment_urgency.sql` adds an `urgency` column to `comments` with default `'suggestion'`. Existing comments backfill to `suggestion`.
- Updated Drizzle schema with the new column.

**API / validation**
- `commentSchema` and `anonymousCommentSchema` accept an optional `urgency` (defaults to `suggestion`).
- `POST /api/videos/[id]/comments` and `POST /api/share/[token]/comments` persist urgency for top-level comments. Anonymous replies and authenticated replies always store `suggestion`.
- `BroadcastComment` includes urgency so it propagates over WebSocket fanout.

**UI**
- `CommentThread`: new urgency selector (3 pill buttons) in the compose form, pre-selecting `suggestion`. Each top-level comment displays a color-coded urgency badge next to the author name.
- `CommentTimeline`: dot color is now driven by urgency (blue / orange / red) for unresolved comments. Resolved comments still render in the muted secondary color.
- `VideoCard` (dashboard): shows a per-video breakdown of unresolved top-level comments by urgency (e.g. "3 critical · 2 important · 5 suggestion") so creators can triage at a glance.

## Color mapping

| Urgency | Color token |
|---|---|
| Suggestion | `accent-info` (blue) |
| Important | `accent-warning` (orange) |
| Critical | `accent-danger` (red) |

## Verification

- `pnpm build` passes
- Local D1 migration applies cleanly