### PR TITLE
feat(spaces): space management API, invite flow, and settings UI

### DIFF
--- a/src/components/InviteResponse.tsx
+++ b/src/components/InviteResponse.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+
+interface InviteResponseProps {
+  token: string;
+  spaceName: string;
+  spaceId: string;
+}
+
+export function InviteResponse({ token, spaceName, spaceId }: InviteResponseProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState<"accepted" | "declined" | null>(null);
+
+  const handleAction = async (action: "accept" | "decline") => {
+    setLoading(true);
+    setError("");
+
+    try {
+      const res = await fetch(`/api/invites/${token}/${action}`, {
+        method: "POST",
+      });
+      const data = (await res.json().catch(() => null)) as { error?: string } | null;
+
+      if (!res.ok) throw new Error(data?.error || `Failed to ${action} invite`);
+
+      setResult(action === "accept" ? "accepted" : "declined");
+
+      if (action === "accept") {
+        // Redirect to dashboard after a short delay
+        setTimeout(() => {
+          window.location.href = "/dashboard";
+        }, 1500);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : `Failed to ${action} invite`);
+      setLoading(false);
+    }
+  };
+
+  if (result === "accepted") {
+    return (
+      <div className="text-center">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-accent-success/15">
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-accent-success" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+            <polyline points="22 4 12 14.01 9 11.01" />
+          </svg>
+        </div>
+        <h2 className="text-lg font-semibold text-text-primary">
+          Welcome to {spaceName}!
+        </h2>
+        <p className="mt-2 text-sm text-text-secondary">
+          Redirecting to dashboard...
+        </p>
+      </div>
+    );
+  }
+
+  if (result === "declined") {
+    return (
+      <div className="text-center">
+        <h2 className="text-lg font-semibold text-text-primary">
+          Invite declined
+        </h2>
+        <p className="mt-2 text-sm text-text-secondary">
+          You've declined the invite to {spaceName}.
+        </p>
+        <a
+          href="/dashboard"
+          className="mt-6 inline-block rounded-lg bg-accent-primary px-5 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover"
+        >
+          Go to Dashboard
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-center">
+      <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-accent-primary/15">
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-accent-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+          <circle cx="9" cy="7" r="4" />
+          <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+          <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+        </svg>
+      </div>
+      <h2 className="text-lg font-semibold text-text-primary">
+        You've been invited!
+      </h2>
+      <p className="mt-2 text-sm text-text-secondary">
+        You've been invited to join <span className="font-medium text-text-primary">{spaceName}</span>.
+      </p>
+
+      {error && (
+        <div className="mt-4 rounded-lg bg-accent-danger/15 px-4 py-2 text-sm text-accent-danger">
+          {error}
+        </div>
+      )}
+
+      <div className="mt-6 flex gap-3">
+        <button
+          type="button"
+          onClick={() => handleAction("decline")}
+          disabled={loading}
+          className="flex-1 rounded-lg border border-border-default px-4 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary disabled:opacity-50"
+        >
+          Decline
+        </button>
+        <button
+          type="button"
+          onClick={() => handleAction("accept")}
+          disabled={loading}
+          className="flex-1 rounded-lg bg-accent-primary px-4 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover disabled:opacity-50"
+        >
+          {loading ? "Processing..." : "Accept Invite"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SpaceSettings.tsx
+++ b/src/components/SpaceSettings.tsx
@@ -1,0 +1,396 @@
+import { useState } from "react";
+
+interface Space {
+  id: string;
+  name: string;
+  ownerId: string;
+  requiredApprovals: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface Member {
+  id: string;
+  userId: string;
+  role: string;
+  createdAt: string;
+  displayName: string;
+  email: string;
+}
+
+interface Invite {
+  id: string;
+  spaceId: string;
+  email: string;
+  invitedBy: string;
+  token: string;
+  status: string;
+  createdAt: string;
+  acceptedAt: string | null;
+}
+
+interface SpaceSettingsProps {
+  space: Space;
+  members: Member[];
+  pendingInvites: Invite[];
+  currentUserId: string;
+  currentUserRole: string;
+  isDefaultSpace: boolean;
+}
+
+export function SpaceSettings({
+  space: initialSpace,
+  members: initialMembers,
+  pendingInvites: initialInvites,
+  currentUserId,
+  currentUserRole,
+  isDefaultSpace,
+}: SpaceSettingsProps) {
+  const isOwner = currentUserRole === "owner";
+
+  const [space, setSpace] = useState(initialSpace);
+  const [members, setMembers] = useState(initialMembers);
+  const [invites, setInvites] = useState(initialInvites);
+
+  // Settings form state
+  const [name, setName] = useState(space.name);
+  const [requiredApprovals, setRequiredApprovals] = useState(space.requiredApprovals);
+  const [settingsSaving, setSettingsSaving] = useState(false);
+  const [settingsError, setSettingsError] = useState("");
+  const [settingsSuccess, setSettingsSuccess] = useState("");
+
+  // Invite form state
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteSaving, setInviteSaving] = useState(false);
+  const [inviteError, setInviteError] = useState("");
+  const [inviteSuccess, setInviteSuccess] = useState("");
+
+  // General action state
+  const [actionError, setActionError] = useState("");
+
+  const handleSaveSettings = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSettingsSaving(true);
+    setSettingsError("");
+    setSettingsSuccess("");
+
+    try {
+      const res = await fetch(`/api/spaces/${space.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name.trim(), requiredApprovals }),
+      });
+      const data = (await res.json().catch(() => null)) as {
+        error?: string;
+        space?: Space;
+      } | null;
+
+      if (!res.ok) throw new Error(data?.error || "Failed to update settings");
+      if (data?.space) setSpace(data.space);
+      setSettingsSuccess("Settings saved");
+      setTimeout(() => setSettingsSuccess(""), 3000);
+    } catch (err) {
+      setSettingsError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSettingsSaving(false);
+    }
+  };
+
+  const handleInvite = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setInviteSaving(true);
+    setInviteError("");
+    setInviteSuccess("");
+
+    try {
+      const res = await fetch(`/api/spaces/${space.id}/invites`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: inviteEmail.trim() }),
+      });
+      const data = (await res.json().catch(() => null)) as {
+        error?: string;
+        invite?: Invite;
+      } | null;
+
+      if (!res.ok) throw new Error(data?.error || "Failed to send invite");
+      if (data?.invite) setInvites((prev) => [...prev, data.invite!]);
+      setInviteEmail("");
+      setInviteSuccess("Invite sent");
+      setTimeout(() => setInviteSuccess(""), 3000);
+    } catch (err) {
+      setInviteError(err instanceof Error ? err.message : "Failed to invite");
+    } finally {
+      setInviteSaving(false);
+    }
+  };
+
+  const handleRevokeInvite = async (inviteId: string) => {
+    setActionError("");
+    try {
+      const res = await fetch(`/api/spaces/${space.id}/invites/${inviteId}`, {
+        method: "DELETE",
+      });
+      const data = (await res.json().catch(() => null)) as { error?: string } | null;
+      if (!res.ok) throw new Error(data?.error || "Failed to revoke invite");
+      setInvites((prev) => prev.filter((i) => i.id !== inviteId));
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to revoke");
+    }
+  };
+
+  const handleRemoveMember = async (userId: string) => {
+    setActionError("");
+    try {
+      const res = await fetch(`/api/spaces/${space.id}/members/${userId}`, {
+        method: "DELETE",
+      });
+      const data = (await res.json().catch(() => null)) as { error?: string } | null;
+      if (!res.ok) throw new Error(data?.error || "Failed to remove member");
+      setMembers((prev) => prev.filter((m) => m.userId !== userId));
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to remove");
+    }
+  };
+
+  const handleLeave = async () => {
+    if (!confirm("Are you sure you want to leave this space?")) return;
+    setActionError("");
+    try {
+      const res = await fetch(`/api/spaces/${space.id}/leave`, {
+        method: "POST",
+      });
+      const data = (await res.json().catch(() => null)) as { error?: string } | null;
+      if (!res.ok) throw new Error(data?.error || "Failed to leave space");
+      window.location.href = "/dashboard";
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to leave");
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirm(`Are you sure you want to delete "${space.name}"? All videos and folders in this space will be permanently deleted.`)) return;
+    setActionError("");
+    try {
+      const res = await fetch(`/api/spaces/${space.id}`, {
+        method: "DELETE",
+      });
+      const data = (await res.json().catch(() => null)) as { error?: string } | null;
+      if (!res.ok) throw new Error(data?.error || "Failed to delete space");
+      window.location.href = "/dashboard";
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to delete");
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold text-text-primary">{space.name}</h1>
+        <p className="mt-1 text-sm text-text-secondary">
+          {isOwner ? "Manage your space settings, members, and invites." : "View space members."}
+        </p>
+      </div>
+
+      {actionError && (
+        <div className="rounded-lg bg-accent-danger/15 px-4 py-2 text-sm text-accent-danger">
+          {actionError}
+        </div>
+      )}
+
+      {/* Space Settings (owner only) */}
+      {isOwner && (
+        <section className="rounded-xl border border-border-default bg-bg-secondary p-6">
+          <h2 className="text-base font-semibold text-text-primary">Space Settings</h2>
+          <form onSubmit={handleSaveSettings} className="mt-4 space-y-4">
+            <div>
+              <label className="mb-1 block text-sm font-medium text-text-secondary" htmlFor="space-name">
+                Name
+              </label>
+              <input
+                id="space-name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                disabled={settingsSaving}
+                className="w-full rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent-primary focus:outline-none disabled:opacity-50"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium text-text-secondary" htmlFor="required-approvals">
+                Required Approvals
+              </label>
+              <input
+                id="required-approvals"
+                type="number"
+                min={0}
+                max={100}
+                value={requiredApprovals}
+                onChange={(e) => setRequiredApprovals(parseInt(e.target.value) || 0)}
+                disabled={settingsSaving}
+                className="w-full rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent-primary focus:outline-none disabled:opacity-50"
+              />
+              <p className="mt-1 text-xs text-text-tertiary">
+                Set to 0 to disable the approval workflow.
+              </p>
+            </div>
+
+            {settingsError && (
+              <div className="rounded-lg bg-accent-danger/15 px-4 py-2 text-sm text-accent-danger">
+                {settingsError}
+              </div>
+            )}
+            {settingsSuccess && (
+              <div className="rounded-lg bg-accent-success/15 px-4 py-2 text-sm text-accent-success">
+                {settingsSuccess}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={settingsSaving || !name.trim()}
+              className="rounded-lg bg-accent-primary px-4 py-2 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover disabled:opacity-50"
+            >
+              {settingsSaving ? "Saving..." : "Save Settings"}
+            </button>
+          </form>
+        </section>
+      )}
+
+      {/* Members */}
+      <section className="rounded-xl border border-border-default bg-bg-secondary p-6">
+        <h2 className="text-base font-semibold text-text-primary">
+          Members ({members.length})
+        </h2>
+        <ul className="mt-4 divide-y divide-border-default">
+          {members.map((member) => (
+            <li key={member.userId} className="flex items-center justify-between py-3">
+              <div>
+                <p className="text-sm font-medium text-text-primary">
+                  {member.displayName}
+                  {member.userId === currentUserId && (
+                    <span className="ml-2 text-xs text-text-tertiary">(you)</span>
+                  )}
+                </p>
+                <p className="text-xs text-text-tertiary">{member.email}</p>
+              </div>
+              <div className="flex items-center gap-3">
+                <span
+                  className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                    member.role === "owner"
+                      ? "bg-accent-primary/15 text-accent-primary"
+                      : "bg-bg-tertiary text-text-secondary"
+                  }`}
+                >
+                  {member.role}
+                </span>
+                {isOwner && member.userId !== currentUserId && (
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveMember(member.userId)}
+                    className="rounded-lg px-2 py-1 text-xs text-accent-danger transition-colors hover:bg-accent-danger/15"
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        {!isOwner && (
+          <div className="mt-4 border-t border-border-default pt-4">
+            <button
+              type="button"
+              onClick={handleLeave}
+              className="rounded-lg border border-accent-danger px-4 py-2 text-sm font-medium text-accent-danger transition-colors hover:bg-accent-danger/15"
+            >
+              Leave Space
+            </button>
+          </div>
+        )}
+      </section>
+
+      {/* Pending Invites (owner only) */}
+      {isOwner && (
+        <section className="rounded-xl border border-border-default bg-bg-secondary p-6">
+          <h2 className="text-base font-semibold text-text-primary">Invites</h2>
+
+          <form onSubmit={handleInvite} className="mt-4 flex gap-3">
+            <input
+              type="email"
+              value={inviteEmail}
+              onChange={(e) => setInviteEmail(e.target.value)}
+              disabled={inviteSaving}
+              placeholder="colleague@example.com"
+              className="flex-1 rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent-primary focus:outline-none disabled:opacity-50"
+            />
+            <button
+              type="submit"
+              disabled={inviteSaving || !inviteEmail.trim()}
+              className="rounded-lg bg-accent-primary px-4 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover disabled:opacity-50"
+            >
+              {inviteSaving ? "Sending..." : "Send Invite"}
+            </button>
+          </form>
+
+          {inviteError && (
+            <div className="mt-3 rounded-lg bg-accent-danger/15 px-4 py-2 text-sm text-accent-danger">
+              {inviteError}
+            </div>
+          )}
+          {inviteSuccess && (
+            <div className="mt-3 rounded-lg bg-accent-success/15 px-4 py-2 text-sm text-accent-success">
+              {inviteSuccess}
+            </div>
+          )}
+
+          {invites.length > 0 && (
+            <ul className="mt-4 divide-y divide-border-default">
+              {invites.map((invite) => (
+                <li key={invite.id} className="flex items-center justify-between py-3">
+                  <div>
+                    <p className="text-sm text-text-primary">{invite.email}</p>
+                    <p className="text-xs text-text-tertiary">
+                      Invited {new Date(invite.createdAt).toLocaleDateString()}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleRevokeInvite(invite.id)}
+                    className="rounded-lg px-2 py-1 text-xs text-accent-danger transition-colors hover:bg-accent-danger/15"
+                  >
+                    Revoke
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {invites.length === 0 && (
+            <p className="mt-4 text-sm text-text-tertiary">No pending invites.</p>
+          )}
+        </section>
+      )}
+
+      {/* Danger Zone (owner only) */}
+      {isOwner && !isDefaultSpace && (
+        <section className="rounded-xl border border-accent-danger/30 bg-bg-secondary p-6">
+          <h2 className="text-base font-semibold text-accent-danger">Danger Zone</h2>
+          <p className="mt-2 text-sm text-text-secondary">
+            Permanently delete this space and all its videos, folders, and data.
+            This cannot be undone.
+          </p>
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="mt-4 rounded-lg bg-accent-danger px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-danger/90"
+          >
+            Delete Space
+          </button>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -79,4 +79,26 @@ export const folderUpdateSchema = z.object({
   parentId: z.string().uuid().nullable().optional(),
 });
 
+// ---------------------------------------------------------------------------
+// Spaces
+// ---------------------------------------------------------------------------
+
+export const spaceCreateSchema = z.object({
+  name: z.string().trim().min(1, "Space name is required").max(120),
+  requiredApprovals: z.number().int().min(0).max(100).optional().default(0),
+});
+
+export const spaceUpdateSchema = z.object({
+  name: z.string().trim().min(1).max(120).optional(),
+  requiredApprovals: z.number().int().min(0).max(100).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Invites
+// ---------------------------------------------------------------------------
+
+export const inviteCreateSchema = z.object({
+  email: z.string().email("Invalid email address").transform((v) => v.trim().toLowerCase()),
+});
+
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -22,8 +22,8 @@ function parseCookies(cookieHeader: string): Record<string, string> {
   return cookies;
 }
 
-const protectedRoutes = ["/dashboard", "/upload", "/videos/"];
-const authApiRoutes = ["/api/videos", "/api/comments"];
+const protectedRoutes = ["/dashboard", "/upload", "/videos/", "/spaces/"];
+const authApiRoutes = ["/api/videos", "/api/comments", "/api/spaces", "/api/invites"];
 
 export const onRequest = defineMiddleware(async (context, next) => {
   context.locals.user = null;

--- a/src/pages/api/invites/[token]/accept/index.ts
+++ b/src/pages/api/invites/[token]/accept/index.ts
@@ -1,0 +1,72 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { eq } from "drizzle-orm";
+import { createDb } from "../../../../../db";
+import { spaceInvites, spaceMembers } from "../../../../../db/schema";
+
+export const POST: APIRoute = async ({ params, locals }) => {
+  if (!locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { token } = params;
+  if (!token) {
+    return new Response(JSON.stringify({ error: "Invite token required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const db = createDb(env.DB);
+
+  const invite = await db
+    .select()
+    .from(spaceInvites)
+    .where(eq(spaceInvites.token, token))
+    .limit(1);
+
+  if (invite.length === 0) {
+    return new Response(JSON.stringify({ error: "Invite not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const inv = invite[0];
+
+  if (inv.status !== "pending") {
+    return new Response(
+      JSON.stringify({ error: `Invite has already been ${inv.status}` }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  if (locals.user.email.toLowerCase() !== inv.email.toLowerCase()) {
+    return new Response(
+      JSON.stringify({ error: "This invite was sent to a different email address" }),
+      { status: 403, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  // Create membership
+  await db.insert(spaceMembers).values({
+    id: crypto.randomUUID(),
+    spaceId: inv.spaceId,
+    userId: locals.user.id,
+    role: "member",
+  });
+
+  // Mark invite as accepted
+  await db
+    .update(spaceInvites)
+    .set({ status: "accepted", acceptedAt: new Date().toISOString() })
+    .where(eq(spaceInvites.id, inv.id));
+
+  return new Response(
+    JSON.stringify({ success: true, spaceId: inv.spaceId }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+};

--- a/src/pages/api/invites/[token]/decline/index.ts
+++ b/src/pages/api/invites/[token]/decline/index.ts
@@ -1,0 +1,55 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { eq } from "drizzle-orm";
+import { createDb } from "../../../../../db";
+import { spaceInvites } from "../../../../../db/schema";
+
+export const POST: APIRoute = async ({ params, locals }) => {
+  if (!locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { token } = params;
+  if (!token) {
+    return new Response(JSON.stringify({ error: "Invite token required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const db = createDb(env.DB);
+
+  const invite = await db
+    .select()
+    .from(spaceInvites)
+    .where(eq(spaceInvites.token, token))
+    .limit(1);
+
+  if (invite.length === 0) {
+    return new Response(JSON.stringify({ error: "Invite not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const inv = invite[0];
+
+  if (inv.status !== "pending") {
+    return new Response(
+      JSON.stringify({ error: `Invite has already been ${inv.status}` }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  await db
+    .update(spaceInvites)
+    .set({ status: "declined" })
+    .where(eq(spaceInvites.id, inv.id));
+
+  return new Response(JSON.stringify({ success: true }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/src/pages/api/spaces/[id]/index.ts
+++ b/src/pages/api/spaces/[id]/index.ts
@@ -1,0 +1,175 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { eq, count } from "drizzle-orm";
+import { createDb } from "../../../../db";
+import { spaces, spaceMembers } from "../../../../db/schema";
+import { spaceUpdateSchema } from "../../../../lib/validation";
+import { verifySpaceAccess } from "../../../../lib/spaces";
+
+export const GET: APIRoute = async ({ params, locals }) => {
+  if (!locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { id } = params;
+  if (!id) {
+    return new Response(JSON.stringify({ error: "Space ID required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const db = createDb(env.DB);
+
+  const role = await verifySpaceAccess(db, locals.user.id, id);
+  if (!role) {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const space = await db
+    .select()
+    .from(spaces)
+    .where(eq(spaces.id, id))
+    .limit(1);
+
+  if (space.length === 0) {
+    return new Response(JSON.stringify({ error: "Space not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const memberCount = await db
+    .select({ count: count() })
+    .from(spaceMembers)
+    .where(eq(spaceMembers.spaceId, id));
+
+  return new Response(
+    JSON.stringify({
+      space: {
+        ...space[0],
+        memberCount: memberCount[0]?.count ?? 0,
+        role,
+      },
+    }),
+    { headers: { "Content-Type": "application/json" } },
+  );
+};
+
+export const PATCH: APIRoute = async ({ params, locals, request }) => {
+  if (!locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { id } = params;
+  if (!id) {
+    return new Response(JSON.stringify({ error: "Space ID required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const parsed = spaceUpdateSchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return new Response(
+      JSON.stringify({ error: parsed.error.issues[0]?.message || "Invalid input" }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const db = createDb(env.DB);
+
+  const role = await verifySpaceAccess(db, locals.user.id, id);
+  if (role !== "owner") {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const updates: { name?: string; requiredApprovals?: number; updatedAt: string } = {
+    updatedAt: new Date().toISOString(),
+  };
+
+  if (parsed.data.name !== undefined) updates.name = parsed.data.name;
+  if (parsed.data.requiredApprovals !== undefined) updates.requiredApprovals = parsed.data.requiredApprovals;
+
+  await db.update(spaces).set(updates).where(eq(spaces.id, id));
+  const updated = await db.select().from(spaces).where(eq(spaces.id, id)).limit(1);
+
+  return new Response(JSON.stringify({ space: updated[0] }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+export const DELETE: APIRoute = async ({ params, locals }) => {
+  if (!locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { id } = params;
+  if (!id) {
+    return new Response(JSON.stringify({ error: "Space ID required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const db = createDb(env.DB);
+
+  const role = await verifySpaceAccess(db, locals.user.id, id);
+  if (role !== "owner") {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Check if this is the user's default personal space (first space they own)
+  const space = await db
+    .select({ id: spaces.id, name: spaces.name })
+    .from(spaces)
+    .where(eq(spaces.id, id))
+    .limit(1);
+
+  if (space.length === 0) {
+    return new Response(JSON.stringify({ error: "Space not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Find the user's earliest owned space (their "Personal" default space)
+  const firstOwned = await db
+    .select({ id: spaces.id })
+    .from(spaces)
+    .where(eq(spaces.ownerId, locals.user.id))
+    .orderBy(spaces.createdAt)
+    .limit(1);
+
+  if (firstOwned.length > 0 && firstOwned[0].id === id) {
+    return new Response(
+      JSON.stringify({ error: "Cannot delete your default personal space" }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  // CASCADE will handle space_members, space_invites, folders, videos
+  await db.delete(spaces).where(eq(spaces.id, id));
+
+  return new Response(JSON.stringify({ success: true }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/src/pages/api/spaces/[id]/invites/[inviteId]/index.ts
+++ b/src/pages/api/spaces/[id]/invites/[inviteId]/index.ts
@@ -1,0 +1,64 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { and, eq } from "drizzle-orm";
+import { createDb } from "../../../../../../db";
+import { spaceInvites } from "../../../../../../db/schema";
+import { verifySpaceAccess } from "../../../../../../lib/spaces";
+
+export const DELETE: APIRoute = async ({ params, locals }) => {
+  if (!locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { id: spaceId, inviteId } = params;
+  if (!spaceId || !inviteId) {
+    return new Response(JSON.stringify({ error: "Space ID and invite ID required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const db = createDb(env.DB);
+
+  const role = await verifySpaceAccess(db, locals.user.id, spaceId);
+  if (role !== "owner") {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const invite = await db
+    .select({ id: spaceInvites.id, status: spaceInvites.status })
+    .from(spaceInvites)
+    .where(
+      and(eq(spaceInvites.id, inviteId), eq(spaceInvites.spaceId, spaceId)),
+    )
+    .limit(1);
+
+  if (invite.length === 0) {
+    return new Response(JSON.stringify({ error: "Invite not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (invite[0].status !== "pending") {
+    return new Response(
+      JSON.stringify({ error: "Only pending invites can be revoked" }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  await db
+    .update(spaceInvites)
+    .set({ status: "revoked" })
+    .where(eq(spaceInvites.id, inviteId));
+
+  return new Response(JSON.stringify({ success: true }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/src/pages/api/spaces/[id]/invites/index.ts
+++ b/src/pages/api/spaces/[id]/invites/index.ts
@@ -1,0 +1,123 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { and, eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { createDb } from "../../../../../db";
+import { spaceInvites } from "../../../../../db/schema";
+import { inviteCreateSchema } from "../../../../../lib/validation";
+import { verifySpaceAccess } from "../../../../../lib/spaces";
+
+export const GET: APIRoute = async ({ params, locals }) => {
+  if (!locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { id: spaceId } = params;
+  if (!spaceId) {
+    return new Response(JSON.stringify({ error: "Space ID required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const db = createDb(env.DB);
+
+  const role = await verifySpaceAccess(db, locals.user.id, spaceId);
+  if (role !== "owner") {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const invites = await db
+    .select()
+    .from(spaceInvites)
+    .where(
+      and(eq(spaceInvites.spaceId, spaceId), eq(spaceInvites.status, "pending")),
+    );
+
+  return new Response(JSON.stringify({ invites }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+export const POST: APIRoute = async ({ params, locals, request }) => {
+  if (!locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { id: spaceId } = params;
+  if (!spaceId) {
+    return new Response(JSON.stringify({ error: "Space ID required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const parsed = inviteCreateSchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return new Response(
+      JSON.stringify({ error: parsed.error.issues[0]?.message || "Invalid input" }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const db = createDb(env.DB);
+
+  const role = await verifySpaceAccess(db, locals.user.id, spaceId);
+  if (role !== "owner") {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Check for duplicate pending invite for same email + space
+  const existing = await db
+    .select({ id: spaceInvites.id })
+    .from(spaceInvites)
+    .where(
+      and(
+        eq(spaceInvites.spaceId, spaceId),
+        eq(spaceInvites.email, parsed.data.email),
+        eq(spaceInvites.status, "pending"),
+      ),
+    )
+    .limit(1);
+
+  if (existing.length > 0) {
+    return new Response(
+      JSON.stringify({ error: "A pending invite already exists for this email" }),
+      { status: 409, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const invite = {
+    id: crypto.randomUUID(),
+    spaceId,
+    email: parsed.data.email,
+    invitedBy: locals.user.id,
+    token: nanoid(12),
+    status: "pending" as const,
+  };
+
+  await db.insert(spaceInvites).values(invite);
+
+  const created = await db
+    .select()
+    .from(spaceInvites)
+    .where(eq(spaceInvites.id, invite.id))
+    .limit(1);
+
+  return new Response(JSON.stringify({ invite: created[0] }), {
+    status: 201,
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/src/pages/api/spaces/[id]/leave/index.ts
+++ b/src/pages/api/spaces/[id]/leave/index.ts
@@ -1,0 +1,50 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { and, eq } from "drizzle-orm";
+import { createDb } from "../../../../../db";
+import { spaceMembers } from "../../../../../db/schema";
+import { verifySpaceAccess } from "../../../../../lib/spaces";
+
+export const POST: APIRoute = async ({ params, locals }) => {
+  if (!locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { id: spaceId } = params;
+  if (!spaceId) {
+    return new Response(JSON.stringify({ error: "Space ID required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const db = createDb(env.DB);
+
+  const role = await verifySpaceAccess(db, locals.user.id, spaceId);
+  if (!role) {
+    return new Response(JSON.stringify({ error: "Not a member of this space" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (role === "owner") {
+    return new Response(
+      JSON.stringify({ error: "Owners cannot leave. Transfer ownership or delete the space." }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  await db
+    .delete(spaceMembers)
+    .where(
+      and(eq(spaceMembers.spaceId, spaceId), eq(spaceMembers.userId, locals.user.id)),
+    );
+
+  return new Response(JSON.stringify({ success: true }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/src/pages/api/spaces/[id]/members/[userId]/index.ts
+++ b/src/pages/api/spaces/[id]/members/[userId]/index.ts
@@ -1,0 +1,65 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { and, eq } from "drizzle-orm";
+import { createDb } from "../../../../../../db";
+import { spaceMembers } from "../../../../../../db/schema";
+import { verifySpaceAccess } from "../../../../../../lib/spaces";
+
+export const DELETE: APIRoute = async ({ params, locals }) => {
+  if (!locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { id: spaceId, userId: targetUserId } = params;
+  if (!spaceId || !targetUserId) {
+    return new Response(JSON.stringify({ error: "Space ID and user ID required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (targetUserId === locals.user.id) {
+    return new Response(
+      JSON.stringify({ error: "Cannot remove yourself. Use leave instead." }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const db = createDb(env.DB);
+
+  const role = await verifySpaceAccess(db, locals.user.id, spaceId);
+  if (role !== "owner") {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const member = await db
+    .select({ id: spaceMembers.id })
+    .from(spaceMembers)
+    .where(
+      and(eq(spaceMembers.spaceId, spaceId), eq(spaceMembers.userId, targetUserId)),
+    )
+    .limit(1);
+
+  if (member.length === 0) {
+    return new Response(JSON.stringify({ error: "Member not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  await db
+    .delete(spaceMembers)
+    .where(
+      and(eq(spaceMembers.spaceId, spaceId), eq(spaceMembers.userId, targetUserId)),
+    );
+
+  return new Response(JSON.stringify({ success: true }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/src/pages/api/spaces/[id]/members/index.ts
+++ b/src/pages/api/spaces/[id]/members/index.ts
@@ -1,0 +1,50 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { eq } from "drizzle-orm";
+import { createDb } from "../../../../../db";
+import { spaceMembers, users } from "../../../../../db/schema";
+import { verifySpaceAccess } from "../../../../../lib/spaces";
+
+export const GET: APIRoute = async ({ params, locals }) => {
+  if (!locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { id } = params;
+  if (!id) {
+    return new Response(JSON.stringify({ error: "Space ID required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const db = createDb(env.DB);
+
+  const role = await verifySpaceAccess(db, locals.user.id, id);
+  if (!role) {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const members = await db
+    .select({
+      id: spaceMembers.id,
+      userId: spaceMembers.userId,
+      role: spaceMembers.role,
+      createdAt: spaceMembers.createdAt,
+      displayName: users.displayName,
+      email: users.email,
+    })
+    .from(spaceMembers)
+    .innerJoin(users, eq(spaceMembers.userId, users.id))
+    .where(eq(spaceMembers.spaceId, id));
+
+  return new Response(JSON.stringify({ members }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/src/pages/api/spaces/index.ts
+++ b/src/pages/api/spaces/index.ts
@@ -1,0 +1,71 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { eq } from "drizzle-orm";
+import { createDb } from "../../../db";
+import { spaces, spaceMembers } from "../../../db/schema";
+import { spaceCreateSchema } from "../../../lib/validation";
+import { getUserSpaces } from "../../../lib/spaces";
+
+export const GET: APIRoute = async ({ locals }) => {
+  if (!locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const db = createDb(env.DB);
+  const userSpaces = await getUserSpaces(db, locals.user.id);
+
+  return new Response(JSON.stringify({ spaces: userSpaces }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+export const POST: APIRoute = async ({ locals, request }) => {
+  if (!locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const parsed = spaceCreateSchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return new Response(
+      JSON.stringify({ error: parsed.error.issues[0]?.message || "Invalid input" }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const db = createDb(env.DB);
+  const spaceId = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  await db.insert(spaces).values({
+    id: spaceId,
+    name: parsed.data.name,
+    ownerId: locals.user.id,
+    requiredApprovals: parsed.data.requiredApprovals,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  await db.insert(spaceMembers).values({
+    id: crypto.randomUUID(),
+    spaceId,
+    userId: locals.user.id,
+    role: "owner",
+  });
+
+  const created = await db
+    .select()
+    .from(spaces)
+    .where(eq(spaces.id, spaceId))
+    .limit(1);
+
+  return new Response(JSON.stringify({ space: created[0] }), {
+    status: 201,
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/src/pages/invites/[token].astro
+++ b/src/pages/invites/[token].astro
@@ -1,0 +1,120 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import { InviteResponse } from "../../components/InviteResponse";
+import { createDb } from "../../db";
+import { spaceInvites, spaces } from "../../db/schema";
+import { eq } from "drizzle-orm";
+import { env } from "cloudflare:workers";
+
+const user = Astro.locals.user;
+const { token } = Astro.params;
+
+if (!token) {
+  return Astro.redirect("/login");
+}
+
+// If not logged in, redirect to login with return URL
+if (!user) {
+  const returnUrl = encodeURIComponent(`/invites/${token}`);
+  return Astro.redirect(`/login?message=Sign in to accept your invite&returnUrl=${returnUrl}`);
+}
+
+const db = createDb(env.DB);
+
+const invite = await db
+  .select({
+    id: spaceInvites.id,
+    email: spaceInvites.email,
+    status: spaceInvites.status,
+    token: spaceInvites.token,
+    spaceName: spaces.name,
+    spaceId: spaces.id,
+  })
+  .from(spaceInvites)
+  .innerJoin(spaces, eq(spaceInvites.spaceId, spaces.id))
+  .where(eq(spaceInvites.token, token))
+  .limit(1);
+
+const inv = invite[0] ?? null;
+const emailMatch = inv ? user.email.toLowerCase() === inv.email.toLowerCase() : false;
+---
+
+<Layout title="Space Invite" user={user}>
+  <div class="flex min-h-[calc(100vh-3.5rem)] items-center justify-center px-4">
+    <div class="w-full max-w-[440px]">
+      <div class="rounded-2xl border border-border-default bg-bg-secondary p-8">
+        {!inv ? (
+          <div class="text-center">
+            <div class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-accent-danger/15">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-accent-danger" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="10" />
+                <line x1="15" y1="9" x2="9" y2="15" />
+                <line x1="9" y1="9" x2="15" y2="15" />
+              </svg>
+            </div>
+            <h2 class="text-lg font-semibold text-text-primary">Invite not found</h2>
+            <p class="mt-2 text-sm text-text-secondary">
+              This invite link is invalid or has expired.
+            </p>
+            <a
+              href="/dashboard"
+              class="mt-6 inline-block rounded-lg bg-accent-primary px-5 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover"
+            >
+              Go to Dashboard
+            </a>
+          </div>
+        ) : inv.status !== "pending" ? (
+          <div class="text-center">
+            <div class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-bg-tertiary">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-text-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+                <polyline points="22 4 12 14.01 9 11.01" />
+              </svg>
+            </div>
+            <h2 class="text-lg font-semibold text-text-primary">
+              Invite already {inv.status}
+            </h2>
+            <p class="mt-2 text-sm text-text-secondary">
+              This invite to <span class="font-medium text-text-primary">{inv.spaceName}</span> has
+              already been {inv.status}.
+            </p>
+            <a
+              href="/dashboard"
+              class="mt-6 inline-block rounded-lg bg-accent-primary px-5 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover"
+            >
+              Go to Dashboard
+            </a>
+          </div>
+        ) : !emailMatch ? (
+          <div class="text-center">
+            <div class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-accent-warning/15">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-accent-warning" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                <line x1="12" y1="9" x2="12" y2="13" />
+                <line x1="12" y1="17" x2="12.01" y2="17" />
+              </svg>
+            </div>
+            <h2 class="text-lg font-semibold text-text-primary">Email mismatch</h2>
+            <p class="mt-2 text-sm text-text-secondary">
+              This invite was sent to a different email address. You're signed in
+              as <span class="font-medium text-text-primary">{user.email}</span>.
+            </p>
+            <a
+              href="/dashboard"
+              class="mt-6 inline-block rounded-lg bg-accent-primary px-5 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover"
+            >
+              Go to Dashboard
+            </a>
+          </div>
+        ) : (
+          <InviteResponse
+            client:load
+            token={inv.token}
+            spaceName={inv.spaceName}
+            spaceId={inv.spaceId}
+          />
+        )}
+      </div>
+    </div>
+  </div>
+</Layout>

--- a/src/pages/spaces/[id]/settings.astro
+++ b/src/pages/spaces/[id]/settings.astro
@@ -1,0 +1,84 @@
+---
+import Layout from "../../../layouts/Layout.astro";
+import { SpaceSettings } from "../../../components/SpaceSettings";
+import { createDb } from "../../../db";
+import { spaces, spaceMembers, spaceInvites, users } from "../../../db/schema";
+import { eq, and, count } from "drizzle-orm";
+import { env } from "cloudflare:workers";
+import { verifySpaceAccess } from "../../../lib/spaces";
+
+const user = Astro.locals.user;
+if (!user) return Astro.redirect("/login");
+
+const { id } = Astro.params;
+if (!id) return Astro.redirect("/dashboard");
+
+const db = createDb(env.DB);
+
+const role = await verifySpaceAccess(db, user.id, id);
+if (!role) return Astro.redirect("/dashboard");
+
+const space = await db
+  .select()
+  .from(spaces)
+  .where(eq(spaces.id, id))
+  .limit(1);
+
+if (space.length === 0) return Astro.redirect("/dashboard");
+
+const members = await db
+  .select({
+    id: spaceMembers.id,
+    userId: spaceMembers.userId,
+    role: spaceMembers.role,
+    createdAt: spaceMembers.createdAt,
+    displayName: users.displayName,
+    email: users.email,
+  })
+  .from(spaceMembers)
+  .innerJoin(users, eq(spaceMembers.userId, users.id))
+  .where(eq(spaceMembers.spaceId, id));
+
+const pendingInvites = role === "owner"
+  ? await db
+      .select()
+      .from(spaceInvites)
+      .where(and(eq(spaceInvites.spaceId, id), eq(spaceInvites.status, "pending")))
+  : [];
+
+// Check if this is the user's default personal space
+const firstOwned = await db
+  .select({ id: spaces.id })
+  .from(spaces)
+  .where(eq(spaces.ownerId, user.id))
+  .orderBy(spaces.createdAt)
+  .limit(1);
+
+const isDefaultSpace = firstOwned.length > 0 && firstOwned[0].id === id;
+---
+
+<Layout title={`${space[0].name} Settings`} user={user}>
+  <div class="mx-auto max-w-[720px] px-4 py-8 sm:px-8">
+    <div class="mb-6">
+      <a
+        href="/dashboard"
+        class="inline-flex items-center gap-1 text-sm text-text-secondary transition-colors hover:text-text-primary"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="15 18 9 12 15 6" />
+        </svg>
+        Back to Dashboard
+      </a>
+    </div>
+
+    <SpaceSettings
+      client:load
+      space={space[0]}
+      members={members}
+      pendingInvites={pendingInvites}
+      currentUserId={user.id}
+      currentUserRole={role}
+      isDefaultSpace={isDefaultSpace}
+    />
+  </div>
+</Layout>


### PR DESCRIPTION
## Summary

Implements the space management API, invite flow, and settings UI for QuickCut's teams/spaces feature.

**Builds on:** PR #13 (design doc + schema) and PR #14 (space-based migration + auth).

## What's included

### Space CRUD API
- `POST /api/spaces` — create a new space (auto-adds creator as owner)
- `GET /api/spaces` — list all spaces the user is a member of (with role)
- `GET /api/spaces/[id]` — get space details + member count (requires membership)
- `PATCH /api/spaces/[id]` — update name/requiredApprovals (owner only)
- `DELETE /api/spaces/[id]` — delete space (owner only, cannot delete default personal space)

### Member Management API
- `GET /api/spaces/[id]/members` — list all members with role and display name
- `DELETE /api/spaces/[id]/members/[userId]` — remove a member (owner only, cannot remove self)
- `POST /api/spaces/[id]/leave` — leave a space (cannot leave if owner)

### Invite Flow API
- `POST /api/spaces/[id]/invites` — invite by email (owner only, nanoid token, prevents duplicate pending invites)
- `GET /api/spaces/[id]/invites` — list pending invites (owner only)
- `DELETE /api/spaces/[id]/invites/[inviteId]` — revoke a pending invite (owner only)
- `POST /api/invites/[token]/accept` — accept invite (email must match, creates space_members row)
- `POST /api/invites/[token]/decline` — decline invite

### Invite Acceptance Page (`/invites/[token]`)
- Shows space name with accept/decline buttons
- Redirects to login with return URL if not authenticated
- Handles already-used, email-mismatch, and not-found states

### Space Settings Page (`/spaces/[id]/settings`)
- **Owner view:** editable space name + requiredApprovals, member list with remove buttons, pending invites with revoke, invite form, danger zone (delete space)
- **Member view:** read-only member list, leave button

### Infrastructure
- Zod validation schemas for space create/update and invite create
- Middleware protection for `/api/spaces`, `/api/invites`, `/spaces/` routes
- Zero new TypeScript errors (41 pre-existing, 0 introduced)

## Patterns followed
- Same auth pattern (`context.locals.user`), response format, error handling as existing endpoints
- `crypto.randomUUID()` for record IDs, `nanoid(12)` for invite tokens
- React islands with `client:load` for interactive components
- Consistent Tailwind styling with existing dark theme tokens