### PR TITLE
Add space switcher and scoped dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # QuickCut
 
-Collaborative video review, built on Cloudflare. Upload up to 5GB, stack new versions, share a link, and collect timestamped feedback from your team or clients — no account required for reviewers.
+Collaborative video review, built on Cloudflare. Organize work into team spaces, upload up to 5GB, stack new versions, share a link, and collect timestamped feedback from your team or clients — no account required for external reviewers.
 
 > Think Frame.io, but small, focused, and running entirely on the edge.
 
 ## Features
 
 - **Resumable 5GB uploads** — drag-drop with TUS-resumable direct uploads to Cloudflare Stream
+- **Spaces for teams and clients** — create separate workspaces, invite members, switch contexts, and keep videos scoped to the right group
 - **Version stacking** — upload new cuts into an ordered stack while keeping review history version-specific
 - **Timestamped comments** — feedback pinned to the exact frame
 - **Threaded replies + resolve** — keep review discussions organized
-- **Review statuses** — `Needs Review` → `In Progress` → `Approved`
+- **Approval workflows** — configure required approvals per space and track sign-off on each cut
+- **Invite notifications** — pending space invites show in the account menu and can be accepted from `/notifications`
 - **Public share links** — reviewers comment without an account; revoke anytime
 - **Global HLS playback** — adaptive streaming via Cloudflare Stream
 - **Auth + sessions** — email/password (PBKDF2), HttpOnly secure cookies, "remember me"
@@ -42,9 +44,13 @@ Serverless SQLite backs every persistent record. The `DB` binding gives the Work
 Tables (see `src/db/schema.ts`):
 - `users` — accounts (PBKDF2-hashed passwords)
 - `sessions` — server-side sessions tied to `quickcut_session` cookie
-- `videos` — Stream UID, status, review status, metadata, version group fields
+- `spaces` — team/client workspaces, ownership, and required approval settings
+- `space_members` — user membership and role per space
+- `space_invites` — pending, accepted, declined, and revoked space invites
+- `videos` — Stream UID, status, metadata, version group fields, and space ownership
 - `share_links` — token, status, view count
 - `comments` — timestamped, threaded (`parentId`), resolvable
+- `approvals` — per-user approval records for videos
 
 Migrations are managed via `drizzle-kit` and applied with `wrangler d1 migrations apply`.
 
@@ -85,7 +91,7 @@ src/
 ├── db/              Drizzle schema and client factory
 ├── durable-objects/ Durable Object classes (VideoRoom for real-time comment fan-out)
 ├── layouts/         Layout.astro
-├── lib/             Auth, Stream, broadcast (DO RPC), realtime (client WS) helpers
+├── lib/             Auth, Stream, spaces, invites, broadcast (DO RPC), realtime (client WS) helpers
 ├── middleware.ts    Session loader + route protection
 ├── worker.ts        Custom Worker entry — delegates to Astro and exports DOs
 ├── pages/
@@ -93,10 +99,13 @@ src/
 │   ├── login.astro      Sign-in form
 │   ├── register.astro   Account creation
 │   ├── dashboard.astro  Video grid (auth)
+│   ├── notifications.astro  Pending space invites
 │   ├── upload.astro     Upload (auth)
+│   ├── spaces/[id]/settings.astro  Space settings, members, and invites
 │   ├── videos/[id].astro    Authenticated review view
+│   ├── invites/[token].astro    Direct invite accept/decline view
 │   ├── s/[token].astro      Public share view (no auth)
-│   └── api/             Auth, videos, versions, comments, share-links, webhooks, /live (WS upgrade)
+│   └── api/             Auth, spaces, invites, videos, versions, comments, share-links, webhooks, /live (WS upgrade)
 └── styles/          Tailwind + design tokens
 migrations/          D1 migrations
 wrangler.jsonc       Worker + bindings config (DB, Durable Objects, vars)

--- a/src/components/CreateFolderDialog.tsx
+++ b/src/components/CreateFolderDialog.tsx
@@ -3,9 +3,10 @@ import { Modal } from "./Modal";
 
 interface CreateFolderDialogProps {
   parentId?: string | null;
+  spaceId: string;
 }
 
-export function CreateFolderDialog({ parentId = null }: CreateFolderDialogProps) {
+export function CreateFolderDialog({ parentId = null, spaceId }: CreateFolderDialogProps) {
   const headingId = useId();
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
@@ -23,7 +24,7 @@ export function CreateFolderDialog({ parentId = null }: CreateFolderDialogProps)
       const res = await fetch("/api/folders", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: name.trim(), parentId }),
+        body: JSON.stringify({ name: name.trim(), parentId, spaceId }),
       });
       const data = await res.json().catch(() => null) as { error?: string } | null;
       if (!res.ok) throw new Error(data?.error || "Failed to create folder");

--- a/src/components/FolderCard.astro
+++ b/src/components/FolderCard.astro
@@ -5,16 +5,17 @@ interface Props {
   id: string;
   name: string;
   parentId: string | null;
+  spaceId: string;
   videoCount: number;
   thumbnails: string[];
 }
 
-const { id, name, parentId, videoCount, thumbnails } = Astro.props;
+const { id, name, parentId, spaceId, videoCount, thumbnails } = Astro.props;
 const remaining = Math.max(videoCount - thumbnails.length, 0);
 ---
 
 <div class="group relative overflow-hidden rounded-xl border border-border-default bg-bg-secondary transition-all duration-200 hover:scale-[1.02] hover:border-border-hover hover:shadow-[0_4px_16px_rgba(0,0,0,0.3)]">
-  <a href={`/dashboard?folderId=${id}`} class="block">
+  <a href={`/dashboard?space=${spaceId}&folderId=${id}`} class="block">
     <div class="relative aspect-video bg-bg-tertiary p-3">
       <div class="absolute left-0 top-0 h-8 w-20 rounded-br-2xl bg-bg-secondary"></div>
       <div class="grid h-full grid-cols-2 gap-2 overflow-hidden rounded-lg pt-3">
@@ -42,6 +43,6 @@ const remaining = Math.max(videoCount - thumbnails.length, 0);
     </div>
   </a>
   <div class="absolute right-2 top-2 z-10">
-    <FolderCardMenu client:load folderId={id} folderName={name} parentId={parentId} />
+    <FolderCardMenu client:load folderId={id} folderName={name} parentId={parentId} spaceId={spaceId} />
   </div>
 </div>

--- a/src/components/FolderCardMenu.tsx
+++ b/src/components/FolderCardMenu.tsx
@@ -7,9 +7,10 @@ interface FolderCardMenuProps {
   folderId: string;
   folderName: string;
   parentId?: string | null;
+  spaceId: string;
 }
 
-export function FolderCardMenu({ folderId, folderName, parentId = null }: FolderCardMenuProps) {
+export function FolderCardMenu({ folderId, folderName, parentId = null, spaceId }: FolderCardMenuProps) {
   const headingId = useId();
   const [open, setOpen] = useState(false);
   const [renameOpen, setRenameOpen] = useState(false);
@@ -87,7 +88,7 @@ export function FolderCardMenu({ folderId, folderName, parentId = null }: Folder
       const res = await fetch(`/api/folders/${folderId}`, { method: "DELETE" });
       const data = await res.json().catch(() => null) as { error?: string } | null;
       if (!res.ok) throw new Error(data?.error || "Failed to delete folder");
-      window.location.href = parentId ? `/dashboard?folderId=${parentId}` : "/dashboard";
+      window.location.href = parentId ? `/dashboard?space=${spaceId}&folderId=${parentId}` : `/dashboard?space=${spaceId}`;
     } catch (err) {
       alert(err instanceof Error ? err.message : "Failed to delete folder");
       setSaving(false);
@@ -194,6 +195,7 @@ export function FolderCardMenu({ folderId, folderName, parentId = null }: Folder
         entityId={folderId}
         entityType="folder"
         currentFolderId={parentId}
+        spaceId={spaceId}
         onClose={() => setMoveOpen(false)}
       />
 

--- a/src/components/MoveToFolderDialog.tsx
+++ b/src/components/MoveToFolderDialog.tsx
@@ -12,6 +12,7 @@ interface MoveToFolderDialogProps {
   entityId: string;
   entityType: "video" | "folder";
   currentFolderId?: string | null;
+  spaceId?: string | null;
   onClose: () => void;
 }
 
@@ -60,6 +61,7 @@ export function MoveToFolderDialog({
   entityId,
   entityType,
   currentFolderId = null,
+  spaceId = null,
   onClose,
 }: MoveToFolderDialogProps) {
   const headingId = useId();
@@ -75,7 +77,7 @@ export function MoveToFolderDialog({
     setError("");
     setLoading(true);
 
-    fetch("/api/folders")
+    fetch(spaceId ? `/api/folders?space=${spaceId}` : "/api/folders")
       .then(async (res) => await res.json() as { folders?: Folder[]; error?: string })
       .then((data) => {
         if (data.error) throw new Error(data.error);
@@ -83,7 +85,7 @@ export function MoveToFolderDialog({
       })
       .catch((err) => setError(err instanceof Error ? err.message : "Failed to load folders"))
       .finally(() => setLoading(false));
-  }, [currentFolderId, isOpen]);
+  }, [currentFolderId, isOpen, spaceId]);
 
   const handleMove = async () => {
     setSaving(true);

--- a/src/components/PendingInvitesList.tsx
+++ b/src/components/PendingInvitesList.tsx
@@ -1,0 +1,128 @@
+import { useState } from "react";
+import type { PendingInviteForUser } from "../lib/invites";
+import { ToastViewport, useToast } from "./Toast";
+
+interface PendingInvitesListProps {
+  invites: PendingInviteForUser[];
+}
+
+interface AcceptInviteResponse {
+  success?: boolean;
+  spaceId?: string;
+  error?: string;
+}
+
+interface AcceptedSpace {
+  id: string;
+  name: string;
+}
+
+export function PendingInvitesList({ invites }: PendingInvitesListProps) {
+  const [pendingInvites, setPendingInvites] = useState(invites);
+  const [loadingToken, setLoadingToken] = useState<string | null>(null);
+  const [acceptedSpaces, setAcceptedSpaces] = useState<AcceptedSpace[]>([]);
+  const { toasts, showToast, dismissToast } = useToast();
+
+  const handleAccept = async (invite: PendingInviteForUser) => {
+    setLoadingToken(invite.token);
+
+    try {
+      const res = await fetch(`/api/invites/${invite.token}/accept`, {
+        method: "POST",
+      });
+      const data = (await res.json().catch(() => null)) as AcceptInviteResponse | null;
+
+      if (!res.ok) throw new Error(data?.error || "Failed to accept invite");
+
+      setPendingInvites((current) => current.filter((item) => item.token !== invite.token));
+      setAcceptedSpaces((current) => [
+        { id: data?.spaceId || invite.spaceId, name: invite.spaceName },
+        ...current,
+      ]);
+      window.dispatchEvent(new CustomEvent("quickcut:invite-accepted"));
+      showToast(`Joined ${invite.spaceName}`);
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : "Failed to accept invite", "error");
+    } finally {
+      setLoadingToken(null);
+    }
+  };
+
+  return (
+    <>
+      <ToastViewport toasts={toasts} onDismiss={dismissToast} />
+
+      {acceptedSpaces.length > 0 && (
+        <div className="mb-6 space-y-2">
+          {acceptedSpaces.map((space) => (
+            <div key={space.id} className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-accent-success/30 bg-accent-success/10 px-4 py-3 text-sm text-text-primary">
+              <span>
+                You joined <span className="font-medium">{space.name}</span>.
+              </span>
+              <a
+                href={`/dashboard?space=${space.id}`}
+                className="rounded-lg bg-accent-primary px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-accent-hover"
+              >
+                Open space
+              </a>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {pendingInvites.length === 0 ? (
+        <div className="rounded-2xl border border-border-default bg-bg-secondary p-8 text-center">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-bg-tertiary text-text-tertiary">
+            <svg className="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a3 3 0 11-5.714 0" />
+            </svg>
+          </div>
+          <h2 className="text-lg font-semibold text-text-primary">No pending notifications</h2>
+          <p className="mt-2 text-sm text-text-secondary">
+            Space invites will appear here when someone invites you to collaborate.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {pendingInvites.map((invite) => {
+            const isLoading = loadingToken === invite.token;
+
+            return (
+              <li key={invite.id} className="rounded-2xl border border-border-default bg-bg-secondary p-5">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-text-primary">
+                      Invitation to join {invite.spaceName}
+                    </p>
+                    <p className="mt-1 text-sm text-text-secondary">
+                      {invite.inviterDisplayName} invited you to collaborate in this space.
+                    </p>
+                    <p className="mt-1 text-xs text-text-tertiary">
+                      Invited {new Date(invite.createdAt).toLocaleDateString()} by {invite.inviterEmail}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <a
+                      href={`/invites/${invite.token}`}
+                      className="rounded-lg border border-border-default px-3 py-2 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary"
+                    >
+                      View invite
+                    </a>
+                    <button
+                      type="button"
+                      onClick={() => handleAccept(invite)}
+                      disabled={isLoading || loadingToken !== null}
+                      className="rounded-lg bg-accent-primary px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-50"
+                    >
+                      {isLoading ? "Accepting..." : "Accept Invite"}
+                    </button>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </>
+  );
+}

--- a/src/components/SpaceSettings.tsx
+++ b/src/components/SpaceSettings.tsx
@@ -185,6 +185,22 @@ export function SpaceSettings({
 
   return (
     <div className="space-y-8">
+      {inviteSuccess && (
+        <div className="pointer-events-none fixed inset-x-4 bottom-4 z-[60] sm:inset-x-auto sm:bottom-auto sm:right-6 sm:top-20">
+          <div
+            role="status"
+            className="pointer-events-auto flex items-center gap-3 rounded-xl border border-accent-success/30 bg-bg-secondary px-4 py-3 text-sm text-text-primary shadow-xl"
+          >
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-success/15 text-accent-success">
+              <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fillRule="evenodd" d="M16.704 5.296a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L8 12.586l7.29-7.29a1 1 0 011.414 0z" clipRule="evenodd" />
+              </svg>
+            </span>
+            <span>{inviteSuccess}</span>
+          </div>
+        </div>
+      )}
+
       {/* Header */}
       <div>
         <h1 className="text-2xl font-bold text-text-primary">{space.name}</h1>
@@ -346,12 +362,6 @@ export function SpaceSettings({
               {inviteError}
             </div>
           )}
-          {inviteSuccess && (
-            <div className="mt-3 rounded-lg bg-accent-success/15 px-4 py-2 text-sm text-accent-success">
-              {inviteSuccess}
-            </div>
-          )}
-
           {invites.length > 0 && (
             <ul className="mt-4 divide-y divide-border-default">
               {invites.map((invite) => (

--- a/src/components/SpaceSettings.tsx
+++ b/src/components/SpaceSettings.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { ToastViewport, useToast } from "./Toast";
 
 interface Space {
   id: string;
@@ -62,8 +63,7 @@ export function SpaceSettings({
   // Invite form state
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteSaving, setInviteSaving] = useState(false);
-  const [inviteError, setInviteError] = useState("");
-  const [inviteSuccess, setInviteSuccess] = useState("");
+  const { toasts, showToast, dismissToast } = useToast();
 
   // General action state
   const [actionError, setActionError] = useState("");
@@ -99,8 +99,6 @@ export function SpaceSettings({
   const handleInvite = async (e: React.FormEvent) => {
     e.preventDefault();
     setInviteSaving(true);
-    setInviteError("");
-    setInviteSuccess("");
 
     try {
       const res = await fetch(`/api/spaces/${space.id}/invites`, {
@@ -116,10 +114,9 @@ export function SpaceSettings({
       if (!res.ok) throw new Error(data?.error || "Failed to send invite");
       if (data?.invite) setInvites((prev) => [...prev, data.invite!]);
       setInviteEmail("");
-      setInviteSuccess("Invite sent");
-      setTimeout(() => setInviteSuccess(""), 3000);
+      showToast("Invite sent");
     } catch (err) {
-      setInviteError(err instanceof Error ? err.message : "Failed to invite");
+      showToast(err instanceof Error ? err.message : "Failed to invite", "error");
     } finally {
       setInviteSaving(false);
     }
@@ -185,21 +182,7 @@ export function SpaceSettings({
 
   return (
     <div className="space-y-8">
-      {inviteSuccess && (
-        <div className="pointer-events-none fixed inset-x-4 bottom-4 z-[60] sm:inset-x-auto sm:bottom-auto sm:right-6 sm:top-20">
-          <div
-            role="status"
-            className="pointer-events-auto flex items-center gap-3 rounded-xl border border-accent-success/30 bg-bg-secondary px-4 py-3 text-sm text-text-primary shadow-xl"
-          >
-            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-success/15 text-accent-success">
-              <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                <path fillRule="evenodd" d="M16.704 5.296a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L8 12.586l7.29-7.29a1 1 0 011.414 0z" clipRule="evenodd" />
-              </svg>
-            </span>
-            <span>{inviteSuccess}</span>
-          </div>
-        </div>
-      )}
+      <ToastViewport toasts={toasts} onDismiss={dismissToast} />
 
       {/* Header */}
       <div>
@@ -357,11 +340,6 @@ export function SpaceSettings({
             </button>
           </form>
 
-          {inviteError && (
-            <div className="mt-3 rounded-lg bg-accent-danger/15 px-4 py-2 text-sm text-accent-danger">
-              {inviteError}
-            </div>
-          )}
           {invites.length > 0 && (
             <ul className="mt-4 divide-y divide-border-default">
               {invites.map((invite) => (

--- a/src/components/SpaceSettings.tsx
+++ b/src/components/SpaceSettings.tsx
@@ -323,19 +323,19 @@ export function SpaceSettings({
         <section className="rounded-xl border border-border-default bg-bg-secondary p-6">
           <h2 className="text-base font-semibold text-text-primary">Invites</h2>
 
-          <form onSubmit={handleInvite} className="mt-4 flex gap-3">
+          <form onSubmit={handleInvite} className="mt-4 flex flex-col gap-3 sm:flex-row">
             <input
               type="email"
               value={inviteEmail}
               onChange={(e) => setInviteEmail(e.target.value)}
               disabled={inviteSaving}
               placeholder="colleague@example.com"
-              className="flex-1 rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent-primary focus:outline-none disabled:opacity-50"
+              className="w-full rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent-primary focus:outline-none disabled:opacity-50 sm:flex-1"
             />
             <button
               type="submit"
               disabled={inviteSaving || !inviteEmail.trim()}
-              className="rounded-lg bg-accent-primary px-4 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover disabled:opacity-50"
+              className="w-full rounded-lg bg-accent-primary px-4 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover disabled:opacity-50 sm:w-auto"
             >
               {inviteSaving ? "Sending..." : "Send Invite"}
             </button>

--- a/src/components/SpaceSettings.tsx
+++ b/src/components/SpaceSettings.tsx
@@ -299,6 +299,12 @@ export function SpaceSettings({
           ))}
         </ul>
 
+        {isOwner && members.length <= 1 && (
+          <div className="mt-4 rounded-lg border border-border-default bg-bg-primary px-4 py-3 text-sm text-text-secondary">
+            Invite teammates so they can review, comment, and approve videos in this space.
+          </div>
+        )}
+
         {!isOwner && (
           <div className="mt-4 border-t border-border-default pt-4">
             <button

--- a/src/components/SpaceSettings.tsx
+++ b/src/components/SpaceSettings.tsx
@@ -323,19 +323,19 @@ export function SpaceSettings({
         <section className="rounded-xl border border-border-default bg-bg-secondary p-6">
           <h2 className="text-base font-semibold text-text-primary">Invites</h2>
 
-          <form onSubmit={handleInvite} className="mt-4 flex flex-col gap-3 sm:flex-row">
+          <form onSubmit={handleInvite} className="mt-4 flex flex-col gap-3 lg:flex-row">
             <input
               type="email"
               value={inviteEmail}
               onChange={(e) => setInviteEmail(e.target.value)}
               disabled={inviteSaving}
               placeholder="colleague@example.com"
-              className="w-full rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent-primary focus:outline-none disabled:opacity-50 sm:flex-1"
+              className="w-full rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent-primary focus:outline-none disabled:opacity-50 lg:flex-1"
             />
             <button
               type="submit"
               disabled={inviteSaving || !inviteEmail.trim()}
-              className="w-full rounded-lg bg-accent-primary px-4 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover disabled:opacity-50 sm:w-auto"
+              className="w-full rounded-lg bg-accent-primary px-4 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover disabled:opacity-50 lg:w-auto"
             >
               {inviteSaving ? "Sending..." : "Send Invite"}
             </button>

--- a/src/components/SpaceSwitcher.tsx
+++ b/src/components/SpaceSwitcher.tsx
@@ -115,11 +115,10 @@ export function SpaceSwitcher({ spaces, selectedSpaceId }: SpaceSwitcherProps) {
                 type="button"
                 role="menuitem"
                 onClick={() => selectSpace(space.id)}
-                className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm transition-colors hover:bg-bg-tertiary"
+                className="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left text-sm transition-colors hover:bg-bg-tertiary"
               >
                 <span className="min-w-0">
                   <span className="block truncate font-medium text-text-primary">{space.name}</span>
-                  <span className="text-xs text-text-tertiary">{space.requiredApprovals} required approvals</span>
                 </span>
                 <span className="flex shrink-0 items-center gap-2">
                   <span className="rounded-full bg-bg-tertiary px-2 py-0.5 text-[10px] uppercase tracking-wide text-text-secondary">
@@ -136,9 +135,9 @@ export function SpaceSwitcher({ spaces, selectedSpaceId }: SpaceSwitcherProps) {
                 href={`/spaces/${selectedSpace.id}/settings?space=${selectedSpace.id}`}
                 className="flex items-center gap-2 px-3 py-2 text-sm text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary"
               >
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75} aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.653.854.102.05.203.103.302.159.325.183.72.188 1.04-.004l1.096-.658a1.125 1.125 0 011.45.191l1.832 1.832c.389.389.47.995.191 1.45l-.658 1.096c-.192.32-.187.715-.004 1.04.056.099.109.2.159.302.168.34.48.59.854.653l1.281.213c.542.09.94.56.94 1.11v2.593c0 .55-.398 1.02-.94 1.11l-1.281.213a1.125 1.125 0 00-.854.653 6.963 6.963 0 01-.159.302c-.183.325-.188.72.004 1.04l.658 1.096c.279.455.198 1.061-.191 1.45l-1.832 1.832a1.125 1.125 0 01-1.45.191l-1.096-.658a1.125 1.125 0 00-1.04-.004c-.099.056-.2.109-.302.159a1.125 1.125 0 00-.653.854l-.213 1.281c-.09.542-.56.94-1.11.94h-2.593c-.55 0-1.02-.398-1.11-.94l-.213-1.281a1.125 1.125 0 00-.653-.854 6.963 6.963 0 01-.302-.159 1.125 1.125 0 00-1.04.004l-1.096.658a1.125 1.125 0 01-1.45-.191l-1.832-1.832a1.125 1.125 0 01-.191-1.45l.658-1.096c.192-.32.187-.715.004-1.04a6.963 6.963 0 01-.159-.302 1.125 1.125 0 00-.854-.653l-1.281-.213a1.125 1.125 0 01-.94-1.11v-2.593c0-.55.398-1.02.94-1.11l1.281-.213c.374-.063.686-.313.854-.653.05-.102.103-.203.159-.302.183-.325.188-.72-.004-1.04l-.658-1.096a1.125 1.125 0 01.191-1.45l1.832-1.832a1.125 1.125 0 011.45-.191l1.096.658c.32.192.715.187 1.04.004.099-.056.2-.109.302-.159.34-.168.59-.48.653-.854l.213-1.281z" />
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <svg className="h-4 w-4 shrink-0 overflow-visible" fill="none" viewBox="0 0 20 20" stroke="currentColor" strokeWidth={1.5} aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M8.5 2.5h3l.4 2a6.8 6.8 0 011.4.8l1.9-.7 1.5 2.6-1.5 1.3a6.9 6.9 0 010 1.6l1.5 1.3-1.5 2.6-1.9-.7a6.8 6.8 0 01-1.4.8l-.4 2h-3l-.4-2a6.8 6.8 0 01-1.4-.8l-1.9.7-1.5-2.6 1.5-1.3a6.9 6.9 0 010-1.6L3.3 7.2l1.5-2.6 1.9.7a6.8 6.8 0 011.4-.8l.4-2z" />
+                  <circle cx="10" cy="9.3" r="2.2" />
                 </svg>
                 Settings
               </a>

--- a/src/components/SpaceSwitcher.tsx
+++ b/src/components/SpaceSwitcher.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useId, useRef, useState } from "react";
+import { Modal } from "./Modal";
+import type { SpaceWithRole } from "../lib/spaces";
+
+interface SpaceSwitcherProps {
+  spaces: SpaceWithRole[];
+  selectedSpaceId: string | null;
+}
+
+interface CreateSpaceResponse {
+  space?: {
+    id: string;
+    name: string;
+  };
+  error?: string;
+}
+
+function buildUrlForSpace(spaceId: string) {
+  const url = new URL(window.location.href);
+  url.searchParams.set("space", spaceId);
+  url.searchParams.delete("folderId");
+  if (url.pathname.startsWith("/spaces/")) {
+    url.pathname = `/spaces/${spaceId}/settings`;
+  } else if (url.pathname !== "/upload") {
+    url.pathname = "/dashboard";
+  }
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function SpaceSwitcher({ spaces, selectedSpaceId }: SpaceSwitcherProps) {
+  const headingId = useId();
+  const menuRef = useRef<HTMLDivElement>(null);
+  const selectedSpace = spaces.find((space) => space.id === selectedSpaceId) ?? spaces[0] ?? null;
+  const [open, setOpen] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [requiredApprovals, setRequiredApprovals] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const selectSpace = (spaceId: string) => {
+    window.location.href = buildUrlForSpace(spaceId);
+  };
+
+  const handleCreate = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!name.trim()) return;
+
+    setSaving(true);
+    setError("");
+
+    try {
+      const res = await fetch("/api/spaces", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name.trim(), requiredApprovals }),
+      });
+      const data = (await res.json().catch(() => null)) as CreateSpaceResponse | null;
+      if (!res.ok || !data?.space) throw new Error(data?.error || "Failed to create space");
+      selectSpace(data.space.id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create space");
+      setSaving(false);
+    }
+  };
+
+  const closeCreate = () => {
+    if (saving) return;
+    setCreateOpen(false);
+    setName("");
+    setRequiredApprovals(0);
+    setError("");
+  };
+
+  if (!selectedSpace) return null;
+
+  return (
+    <>
+      <div className="relative" ref={menuRef}>
+        <button
+          type="button"
+          onClick={() => setOpen((value) => !value)}
+          className="inline-flex max-w-[220px] items-center gap-2 rounded-lg border border-border-default bg-bg-secondary px-3 py-1.5 text-sm text-text-primary transition-colors hover:bg-bg-tertiary"
+          aria-haspopup="menu"
+          aria-expanded={open}
+        >
+          <span className="truncate font-medium">{selectedSpace.name}</span>
+          <span className="hidden rounded-full bg-bg-tertiary px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-text-tertiary sm:inline">
+            {selectedSpace.role}
+          </span>
+          <svg className="h-4 w-4 shrink-0 text-text-tertiary" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fillRule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.17l3.71-3.94a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clipRule="evenodd" />
+          </svg>
+        </button>
+
+        {open && (
+          <div
+            role="menu"
+            className="absolute right-0 z-50 mt-2 w-72 overflow-hidden rounded-xl border border-border-default bg-bg-secondary py-1 shadow-xl"
+          >
+            {spaces.map((space) => (
+              <button
+                key={space.id}
+                type="button"
+                role="menuitem"
+                onClick={() => selectSpace(space.id)}
+                className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm transition-colors hover:bg-bg-tertiary"
+              >
+                <span className="min-w-0">
+                  <span className="block truncate font-medium text-text-primary">{space.name}</span>
+                  <span className="text-xs text-text-tertiary">{space.requiredApprovals} required approvals</span>
+                </span>
+                <span className="flex shrink-0 items-center gap-2">
+                  <span className="rounded-full bg-bg-tertiary px-2 py-0.5 text-[10px] uppercase tracking-wide text-text-secondary">
+                    {space.role}
+                  </span>
+                  {space.id === selectedSpace.id && <span className="h-2 w-2 rounded-full bg-accent-primary" aria-label="Selected" />}
+                </span>
+              </button>
+            ))}
+
+            <div className="mt-1 border-t border-border-default py-1">
+              <a
+                role="menuitem"
+                href={`/spaces/${selectedSpace.id}/settings?space=${selectedSpace.id}`}
+                className="flex items-center gap-2 px-3 py-2 text-sm text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary"
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75} aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.653.854.102.05.203.103.302.159.325.183.72.188 1.04-.004l1.096-.658a1.125 1.125 0 011.45.191l1.832 1.832c.389.389.47.995.191 1.45l-.658 1.096c-.192.32-.187.715-.004 1.04.056.099.109.2.159.302.168.34.48.59.854.653l1.281.213c.542.09.94.56.94 1.11v2.593c0 .55-.398 1.02-.94 1.11l-1.281.213a1.125 1.125 0 00-.854.653 6.963 6.963 0 01-.159.302c-.183.325-.188.72.004 1.04l.658 1.096c.279.455.198 1.061-.191 1.45l-1.832 1.832a1.125 1.125 0 01-1.45.191l-1.096-.658a1.125 1.125 0 00-1.04-.004c-.099.056-.2.109-.302.159a1.125 1.125 0 00-.653.854l-.213 1.281c-.09.542-.56.94-1.11.94h-2.593c-.55 0-1.02-.398-1.11-.94l-.213-1.281a1.125 1.125 0 00-.653-.854 6.963 6.963 0 01-.302-.159 1.125 1.125 0 00-1.04.004l-1.096.658a1.125 1.125 0 01-1.45-.191l-1.832-1.832a1.125 1.125 0 01-.191-1.45l.658-1.096c.192-.32.187-.715.004-1.04a6.963 6.963 0 01-.159-.302 1.125 1.125 0 00-.854-.653l-1.281-.213a1.125 1.125 0 01-.94-1.11v-2.593c0-.55.398-1.02.94-1.11l1.281-.213c.374-.063.686-.313.854-.653.05-.102.103-.203.159-.302.183-.325.188-.72-.004-1.04l-.658-1.096a1.125 1.125 0 01.191-1.45l1.832-1.832a1.125 1.125 0 011.45-.191l1.096.658c.32.192.715.187 1.04.004.099-.056.2-.109.302-.159.34-.168.59-.48.653-.854l.213-1.281z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+                Settings
+              </a>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  setOpen(false);
+                  setCreateOpen(true);
+                }}
+                className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-accent-primary transition-colors hover:bg-bg-tertiary"
+              >
+                <span className="text-lg leading-none">+</span>
+                Create Space
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <Modal
+        isOpen={createOpen}
+        onClose={closeCreate}
+        closeOnBackdropClick={!saving}
+        closeOnEscape={!saving}
+        showCloseButton={!saving}
+        ariaLabelledBy={headingId}
+        size="sm"
+      >
+        <h2 id={headingId} className="text-lg font-semibold text-text-primary">Create space</h2>
+        <p className="mt-1 text-sm text-text-secondary">Add a workspace for videos, folders, and reviewers.</p>
+        <form onSubmit={handleCreate} className="mt-5 space-y-4">
+          <div>
+            <label className="mb-1 block text-sm font-medium text-text-secondary" htmlFor="space-name">Name</label>
+            <input
+              id="space-name"
+              type="text"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              disabled={saving}
+              autoFocus
+              className="w-full rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent-primary focus:outline-none disabled:opacity-50"
+              placeholder="Marketing Team"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-text-secondary" htmlFor="space-approvals">Required approvals</label>
+            <input
+              id="space-approvals"
+              type="number"
+              min={0}
+              max={100}
+              value={requiredApprovals}
+              onChange={(event) => setRequiredApprovals(parseInt(event.target.value) || 0)}
+              disabled={saving}
+              className="w-full rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent-primary focus:outline-none disabled:opacity-50"
+            />
+          </div>
+          {error && <div className="rounded-lg bg-accent-danger/15 px-4 py-2 text-sm text-accent-danger">{error}</div>}
+          <div className="flex gap-3">
+            <button type="button" onClick={closeCreate} disabled={saving} className="flex-1 rounded-lg border border-border-default px-4 py-2 text-sm text-text-primary transition-colors hover:bg-bg-tertiary disabled:opacity-50">Cancel</button>
+            <button type="submit" disabled={saving || !name.trim()} className="flex-1 rounded-lg bg-accent-primary px-4 py-2 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover disabled:opacity-50">
+              {saving ? "Creating..." : "Create"}
+            </button>
+          </div>
+        </form>
+      </Modal>
+    </>
+  );
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+
+export type ToastVariant = "success" | "error";
+
+export interface ToastMessage {
+  id: string;
+  message: string;
+  variant: ToastVariant;
+}
+
+export function useToast() {
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+
+  const dismissToast = (id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  };
+
+  const showToast = (message: string, variant: ToastVariant = "success") => {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    setToasts((current) => [...current, { id, message, variant }]);
+    setTimeout(() => dismissToast(id), 3000);
+  };
+
+  return { toasts, showToast, dismissToast };
+}
+
+interface ToastViewportProps {
+  toasts: ToastMessage[];
+  onDismiss: (id: string) => void;
+}
+
+export function ToastViewport({ toasts, onDismiss }: ToastViewportProps) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="pointer-events-none fixed inset-x-4 bottom-4 z-[60] flex flex-col gap-2 sm:inset-x-auto sm:bottom-auto sm:right-6 sm:top-20">
+      {toasts.map((toast) => {
+        const isSuccess = toast.variant === "success";
+
+        return (
+          <div
+            key={toast.id}
+            role={isSuccess ? "status" : "alert"}
+            className={`pointer-events-auto flex items-center gap-3 rounded-xl border bg-bg-secondary px-4 py-3 text-sm text-text-primary shadow-xl ${
+              isSuccess ? "border-accent-success/30" : "border-accent-danger/30"
+            }`}
+          >
+            <span
+              className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full ${
+                isSuccess
+                  ? "bg-accent-success/15 text-accent-success"
+                  : "bg-accent-danger/15 text-accent-danger"
+              }`}
+            >
+              {isSuccess ? (
+                <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fillRule="evenodd" d="M16.704 5.296a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L8 12.586l7.29-7.29a1 1 0 011.414 0z" clipRule="evenodd" />
+                </svg>
+              ) : (
+                <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clipRule="evenodd" />
+                </svg>
+              )}
+            </span>
+            <span className="min-w-0 flex-1">{toast.message}</span>
+            <button
+              type="button"
+              onClick={() => onDismiss(toast.id)}
+              aria-label="Dismiss notification"
+              className="rounded-md px-1 text-text-tertiary transition-colors hover:bg-bg-tertiary hover:text-text-primary"
+            >
+              x
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/UploadForm.tsx
+++ b/src/components/UploadForm.tsx
@@ -7,14 +7,17 @@ type UploadState = "idle" | "selected" | "uploading" | "processing" | "error";
 
 interface UploadFormProps {
   folderId?: string | null;
+  spaces: Array<{ id: string; name: string; role: string }>;
+  selectedSpaceId: string;
   transcriptsEnabled?: boolean;
 }
 
-export function UploadForm({ folderId = null, transcriptsEnabled = false }: UploadFormProps) {
+export function UploadForm({ folderId = null, spaces, selectedSpaceId, transcriptsEnabled = false }: UploadFormProps) {
   const [state, setState] = useState<UploadState>("idle");
   const [file, setFile] = useState<File | null>(null);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [spaceId, setSpaceId] = useState(selectedSpaceId);
   const [generateTranscript, setGenerateTranscript] = useState(false);
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState("");
@@ -76,9 +79,10 @@ export function UploadForm({ folderId = null, transcriptsEnabled = false }: Uplo
         body: JSON.stringify({
           fileName: file.name,
           fileSize: file.size,
+          spaceId,
           title: title.trim() || undefined,
           description: description.trim() || undefined,
-          folderId,
+          folderId: spaceId === selectedSpaceId ? folderId : null,
           generateTranscript: transcriptsEnabled ? generateTranscript : false,
         }),
       });
@@ -111,7 +115,7 @@ export function UploadForm({ folderId = null, transcriptsEnabled = false }: Uplo
           setState("processing");
           // Redirect to video detail page
           setTimeout(() => {
-            window.location.href = `/videos/${videoId}`;
+            window.location.href = `/videos/${videoId}?space=${spaceId}`;
           }, 1500);
         } else {
           setError("Upload failed. Please try again.");
@@ -217,6 +221,22 @@ export function UploadForm({ folderId = null, transcriptsEnabled = false }: Uplo
           </div>
 
           <div className="space-y-4">
+            <div>
+              <label className="mb-1 block text-sm font-medium text-text-secondary" htmlFor="upload-space">Space</label>
+              <select
+                id="upload-space"
+                value={spaceId}
+                onChange={(e) => setSpaceId(e.target.value)}
+                disabled={state === "uploading"}
+                className="w-full rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary focus:border-accent-primary focus:outline-none disabled:opacity-50"
+              >
+                {spaces.map((space) => (
+                  <option key={space.id} value={space.id}>
+                    {space.name} ({space.role})
+                  </option>
+                ))}
+              </select>
+            </div>
             <div>
               <label className="mb-1 block text-sm font-medium text-text-secondary">Title</label>
               <input

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 interface UserMenuProps {
   displayName: string;
   email: string;
+  notificationCount?: number;
 }
 
 function getInitials(name: string): string {
@@ -15,10 +16,22 @@ function getInitials(name: string): string {
     .slice(0, 2);
 }
 
-export function UserMenu({ displayName, email }: UserMenuProps) {
+export function UserMenu({ displayName, email, notificationCount = 0 }: UserMenuProps) {
   const [open, setOpen] = useState(false);
+  const [count, setCount] = useState(notificationCount);
   const containerRef = useRef<HTMLDivElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
+  const hasNotifications = count > 0;
+
+  useEffect(() => {
+    setCount(notificationCount);
+  }, [notificationCount]);
+
+  useEffect(() => {
+    const handler = () => setCount((current) => Math.max(0, current - 1));
+    window.addEventListener("quickcut:invite-accepted", handler);
+    return () => window.removeEventListener("quickcut:invite-accepted", handler);
+  }, []);
 
   // Close on outside click
   useEffect(() => {
@@ -58,9 +71,14 @@ export function UserMenu({ displayName, email }: UserMenuProps) {
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={`Account menu for ${displayName}`}
-        className="flex h-9 w-9 items-center justify-center rounded-full bg-accent-primary text-xs font-medium text-white transition-all duration-150 hover:bg-accent-hover focus:outline-none focus:ring-2 focus:ring-accent-primary focus:ring-offset-2 focus:ring-offset-bg-primary"
+        className="relative flex h-9 w-9 items-center justify-center rounded-full bg-accent-primary text-xs font-medium text-white transition-all duration-150 hover:bg-accent-hover focus:outline-none focus:ring-2 focus:ring-accent-primary focus:ring-offset-2 focus:ring-offset-bg-primary"
       >
         {getInitials(displayName)}
+        {hasNotifications && (
+          <span className="absolute -right-1 -top-1 flex min-w-5 items-center justify-center rounded-full bg-accent-danger px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white ring-2 ring-bg-primary">
+            {count > 99 ? "99+" : count}
+          </span>
+        )}
       </button>
 
       {open && (
@@ -76,6 +94,34 @@ export function UserMenu({ displayName, email }: UserMenuProps) {
               {email}
             </div>
           </div>
+          <div className="border-t border-border-default" />
+          <a
+            role="menuitem"
+            href="/notifications"
+            onClick={() => setOpen(false)}
+            className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-text-primary transition-colors hover:bg-bg-tertiary"
+          >
+            <svg
+              className="h-4 w-4 text-text-tertiary"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth="1.75"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a3 3 0 11-5.714 0"
+              />
+            </svg>
+            <span className="flex-1">Notifications</span>
+            {hasNotifications && (
+              <span className="rounded-full bg-accent-danger px-2 py-0.5 text-xs font-semibold text-white">
+                {count > 99 ? "99+" : count}
+              </span>
+            )}
+          </a>
           <div className="border-t border-border-default" />
           <button
             role="menuitem"

--- a/src/components/VideoCard.astro
+++ b/src/components/VideoCard.astro
@@ -21,6 +21,7 @@ interface Props {
   versionNumber?: number;
   versionCount?: number;
   folderId?: string | null;
+  spaceId?: string | null;
   /** When > 0, the space requires approvals and we render the badge. */
   requiredApprovals?: number;
   /** Number of approvals recorded so far. */
@@ -39,6 +40,7 @@ const {
   versionNumber = 1,
   versionCount = 1,
   folderId = null,
+  spaceId = null,
   requiredApprovals = 0,
   approvalCount = 0,
 } = Astro.props;
@@ -70,7 +72,7 @@ function formatDate(dateStr: string): string {
 ---
 
 <div class="group relative overflow-hidden rounded-xl border border-border-default bg-bg-secondary transition-all duration-200 hover:scale-[1.02] hover:border-border-hover hover:shadow-[0_4px_16px_rgba(0,0,0,0.3)]">
-  <a href={`/videos/${id}`} class="block">
+  <a href={spaceId ? `/videos/${id}?space=${spaceId}` : `/videos/${id}`} class="block">
     <div class="relative aspect-video bg-bg-tertiary">
       {thumbnailUrl ? (
         <img src={thumbnailUrl} alt={title} class="h-full w-full object-cover" />
@@ -141,6 +143,6 @@ function formatDate(dateStr: string): string {
     </div>
   </a>
   <div class="absolute right-2 top-2 z-10">
-    <VideoCardMenu client:load videoId={id} folderId={folderId} />
+    <VideoCardMenu client:load videoId={id} folderId={folderId} spaceId={spaceId} />
   </div>
 </div>

--- a/src/components/VideoCardMenu.tsx
+++ b/src/components/VideoCardMenu.tsx
@@ -5,9 +5,10 @@ import { MoveToFolderDialog } from "./MoveToFolderDialog";
 interface VideoCardMenuProps {
   videoId: string;
   folderId?: string | null;
+  spaceId?: string | null;
 }
 
-export function VideoCardMenu({ videoId, folderId = null }: VideoCardMenuProps) {
+export function VideoCardMenu({ videoId, folderId = null, spaceId = null }: VideoCardMenuProps) {
   const [open, setOpen] = useState(false);
   const [moveOpen, setMoveOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -130,6 +131,7 @@ export function VideoCardMenu({ videoId, folderId = null }: VideoCardMenuProps) 
         entityId={videoId}
         entityType="video"
         currentFolderId={folderId}
+        spaceId={spaceId}
         onClose={() => setMoveOpen(false)}
       />
 

--- a/src/components/VideoHeader.tsx
+++ b/src/components/VideoHeader.tsx
@@ -13,9 +13,11 @@ interface VideoHeaderProps {
   videoId: string;
   shareLink: ShareLink | null;
   appUrl: string;
+  spaceId: string;
+  backHref: string;
 }
 
-export function VideoHeader({ videoId, shareLink: initialLink, appUrl }: VideoHeaderProps) {
+export function VideoHeader({ videoId, shareLink: initialLink, appUrl, spaceId, backHref }: VideoHeaderProps) {
   const [shareLink, setShareLink] = useState(initialLink);
   const [loading, setLoading] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -84,7 +86,7 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl }: VideoHe
         const data = (await res.json().catch(() => null)) as
           | { redirectVideoId?: string | null }
           | null;
-        window.location.href = data?.redirectVideoId ? `/videos/${data.redirectVideoId}` : "/dashboard";
+        window.location.href = data?.redirectVideoId ? `/videos/${data.redirectVideoId}?space=${spaceId}` : `/dashboard?space=${spaceId}`;
         return;
       }
       const data = (await res.json().catch(() => null)) as
@@ -104,8 +106,8 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl }: VideoHe
     try {
       const res = await fetch(`/api/share/manage/${videoId}`, { method: "POST" });
       if (res.ok) {
-        const data = await res.json();
-        setShareLink(data.shareLink);
+        const data = await res.json() as { shareLink?: ShareLink };
+        setShareLink(data.shareLink ?? null);
       }
     } catch {
       // ignore
@@ -156,7 +158,7 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl }: VideoHe
     <>
     <div className="mb-6 flex flex-wrap items-center justify-between gap-2">
       <a
-        href="/dashboard"
+        href={backHref}
         className="flex h-9 w-9 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary"
         aria-label="Back to library"
       >

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import "../styles/tailwind.css";
 import { UserMenu } from "../components/UserMenu";
 import { SpaceSwitcher } from "../components/SpaceSwitcher";
 import { createDb } from "../db";
+import { getPendingInvitesForUser } from "../lib/invites";
 import { getUserSpaces } from "../lib/spaces";
 import { env } from "cloudflare:workers";
 
@@ -15,7 +16,9 @@ interface Props {
 
 const { title, description, user, selectedSpaceId } = Astro.props;
 const metaDescription = description ?? "QuickCut - Collaborative video review";
-const userSpaces = user ? await getUserSpaces(createDb(env.DB), user.id) : [];
+const db = createDb(env.DB);
+const userSpaces = user ? await getUserSpaces(db, user.id) : [];
+const pendingInviteCount = user ? (await getPendingInvitesForUser(db, user.email)).length : 0;
 const headerSpaceId = selectedSpaceId ?? Astro.url.searchParams.get("space") ?? userSpaces[0]?.id ?? null;
 ---
 
@@ -42,7 +45,7 @@ const headerSpaceId = selectedSpaceId ?? Astro.url.searchParams.get("space") ?? 
           </a>
           <div class="ml-auto flex items-center gap-3">
             <SpaceSwitcher client:load spaces={userSpaces} selectedSpaceId={headerSpaceId} />
-            <UserMenu client:load displayName={user.displayName} email={user.email} />
+            <UserMenu client:load displayName={user.displayName} email={user.email} notificationCount={pendingInviteCount} />
           </div>
         </header>
       )

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,15 +1,22 @@
 ---
 import "../styles/tailwind.css";
 import { UserMenu } from "../components/UserMenu";
+import { SpaceSwitcher } from "../components/SpaceSwitcher";
+import { createDb } from "../db";
+import { getUserSpaces } from "../lib/spaces";
+import { env } from "cloudflare:workers";
 
 interface Props {
   title: string;
   description?: string;
   user?: { id: string; email: string; displayName: string } | null;
+  selectedSpaceId?: string | null;
 }
 
-const { title, description, user } = Astro.props;
+const { title, description, user, selectedSpaceId } = Astro.props;
 const metaDescription = description ?? "QuickCut - Collaborative video review";
+const userSpaces = user ? await getUserSpaces(createDb(env.DB), user.id) : [];
+const headerSpaceId = selectedSpaceId ?? Astro.url.searchParams.get("space") ?? userSpaces[0]?.id ?? null;
 ---
 
 <!doctype html>
@@ -30,10 +37,11 @@ const metaDescription = description ?? "QuickCut - Collaborative video review";
     {
       user && (
         <header class="sticky top-0 z-50 flex h-14 items-center border-b border-border-default bg-bg-primary px-8">
-          <a href="/dashboard" class="text-lg font-bold text-text-primary">
+          <a href={headerSpaceId ? `/dashboard?space=${headerSpaceId}` : "/dashboard"} class="text-lg font-bold text-text-primary">
             QuickCut
           </a>
-          <div class="ml-auto flex items-center">
+          <div class="ml-auto flex items-center gap-3">
+            <SpaceSwitcher client:load spaces={userSpaces} selectedSpaceId={headerSpaceId} />
             <UserMenu client:load displayName={user.displayName} email={user.email} />
           </div>
         </header>

--- a/src/lib/invites.ts
+++ b/src/lib/invites.ts
@@ -1,0 +1,47 @@
+import { and, desc, eq, sql } from "drizzle-orm";
+import type { Database } from "../db";
+import { spaceInvites, spaces, users } from "../db/schema";
+
+export interface PendingInviteForUser {
+  id: string;
+  token: string;
+  spaceId: string;
+  spaceName: string;
+  email: string;
+  invitedBy: string;
+  inviterDisplayName: string;
+  inviterEmail: string;
+  createdAt: string;
+}
+
+export async function getPendingInvitesForUser(
+  db: Database,
+  email: string,
+): Promise<PendingInviteForUser[]> {
+  const normalizedEmail = email.trim().toLowerCase();
+
+  const rows = await db
+    .select({
+      id: spaceInvites.id,
+      token: spaceInvites.token,
+      spaceId: spaceInvites.spaceId,
+      spaceName: spaces.name,
+      email: spaceInvites.email,
+      invitedBy: spaceInvites.invitedBy,
+      inviterDisplayName: users.displayName,
+      inviterEmail: users.email,
+      createdAt: spaceInvites.createdAt,
+    })
+    .from(spaceInvites)
+    .innerJoin(spaces, eq(spaceInvites.spaceId, spaces.id))
+    .innerJoin(users, eq(spaceInvites.invitedBy, users.id))
+    .where(
+      and(
+        eq(spaceInvites.status, "pending"),
+        sql`lower(${spaceInvites.email}) = ${normalizedEmail}`,
+      ),
+    )
+    .orderBy(desc(spaceInvites.createdAt));
+
+  return rows;
+}

--- a/src/lib/spaces.ts
+++ b/src/lib/spaces.ts
@@ -1,4 +1,4 @@
-import { eq, and } from "drizzle-orm";
+import { eq, and, asc } from "drizzle-orm";
 import { spaces, spaceMembers } from "../db/schema";
 import type { Database } from "../db";
 
@@ -31,7 +31,8 @@ export async function getUserSpaces(
     })
     .from(spaceMembers)
     .innerJoin(spaces, eq(spaceMembers.spaceId, spaces.id))
-    .where(eq(spaceMembers.userId, userId));
+    .where(eq(spaceMembers.userId, userId))
+    .orderBy(asc(spaceMembers.createdAt));
 
   return rows as SpaceWithRole[];
 }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -34,6 +34,7 @@ export const loginSchema = z.object({
 export const uploadSchema = z.object({
   fileName: z.string().min(1, "File name is required"),
   fileSize: z.number().positive().max(5 * 1024 * 1024 * 1024, "File exceeds 5GB limit"),
+  spaceId: z.string().uuid().optional(),
   title: z.string().optional(),
   description: z.string().max(2000).optional(),
   folderId: z.string().uuid().nullable().optional(),
@@ -71,6 +72,7 @@ export const videoUpdateSchema = z.object({
 
 export const folderCreateSchema = z.object({
   name: z.string().trim().min(1, "Folder name is required").max(120),
+  spaceId: z.string().uuid().optional(),
   parentId: z.string().uuid().nullable().optional(),
 });
 
@@ -108,5 +110,4 @@ export const inviteCreateSchema = z.object({
 export const approveVideoSchema = z.object({
   comment: z.string().max(500).optional(),
 });
-
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -22,7 +22,7 @@ function parseCookies(cookieHeader: string): Record<string, string> {
   return cookies;
 }
 
-const protectedRoutes = ["/dashboard", "/upload", "/videos/", "/spaces/"];
+const protectedRoutes = ["/dashboard", "/notifications", "/upload", "/videos/", "/spaces/"];
 const authApiRoutes = ["/api/videos", "/api/comments", "/api/spaces", "/api/invites"];
 
 export const onRequest = defineMiddleware(async (context, next) => {

--- a/src/pages/api/folders/index.ts
+++ b/src/pages/api/folders/index.ts
@@ -4,7 +4,7 @@ import { and, count, eq, inArray, isNull } from "drizzle-orm";
 import { createDb } from "../../../db";
 import { folders, videos, spaceMembers } from "../../../db/schema";
 import { folderCreateSchema } from "../../../lib/validation";
-import { getDefaultSpaceForUser } from "../../../lib/spaces";
+import { getDefaultSpaceForUser, verifySpaceAccess } from "../../../lib/spaces";
 
 export const GET: APIRoute = async ({ locals, url }) => {
   if (!locals.user) {
@@ -16,6 +16,7 @@ export const GET: APIRoute = async ({ locals, url }) => {
 
   const db = createDb(env.DB);
   const parentId = url.searchParams.get("parentId");
+  const requestedSpaceId = url.searchParams.get("space");
 
   // Get all space IDs the user belongs to
   const memberRows = await db
@@ -31,7 +32,15 @@ export const GET: APIRoute = async ({ locals, url }) => {
     );
   }
 
-  const spaceFilter = inArray(folders.spaceId, spaceIds);
+  const targetSpaceIds = requestedSpaceId ? spaceIds.filter((id) => id === requestedSpaceId) : spaceIds;
+  if (requestedSpaceId && targetSpaceIds.length === 0) {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const spaceFilter = inArray(folders.spaceId, targetSpaceIds);
   const where = parentId
     ? parentId === "root"
       ? and(spaceFilter, isNull(folders.parentId))
@@ -99,15 +108,22 @@ export const POST: APIRoute = async ({ locals, request }) => {
   const db = createDb(env.DB);
   const parentId = parsed.data.parentId ?? null;
 
-  // Use the user's default space. A future PR will let the client pass a spaceId.
-  const defaultSpace = await getDefaultSpaceForUser(db, locals.user.id);
-  if (!defaultSpace) {
+  const defaultSpace = parsed.data.spaceId ? null : await getDefaultSpaceForUser(db, locals.user.id);
+  const targetSpaceId = parsed.data.spaceId ?? defaultSpace?.id;
+  if (!targetSpaceId) {
     return new Response(JSON.stringify({ error: "No space found for user" }), {
       status: 500,
       headers: { "Content-Type": "application/json" },
     });
   }
-  const targetSpaceId = defaultSpace.id;
+
+  const role = await verifySpaceAccess(db, locals.user.id, targetSpaceId);
+  if (!role) {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
 
   if (parentId) {
     const parent = await db

--- a/src/pages/api/invites/[token]/accept/index.ts
+++ b/src/pages/api/invites/[token]/accept/index.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { createDb } from "../../../../../db";
 import { spaceInvites, spaceMembers } from "../../../../../db/schema";
 
@@ -51,13 +51,25 @@ export const POST: APIRoute = async ({ params, locals }) => {
     );
   }
 
-  // Create membership
-  await db.insert(spaceMembers).values({
-    id: crypto.randomUUID(),
-    spaceId: inv.spaceId,
-    userId: locals.user.id,
-    role: "member",
-  });
+  const existingMembership = await db
+    .select({ id: spaceMembers.id })
+    .from(spaceMembers)
+    .where(
+      and(
+        eq(spaceMembers.spaceId, inv.spaceId),
+        eq(spaceMembers.userId, locals.user.id),
+      ),
+    )
+    .limit(1);
+
+  if (existingMembership.length === 0) {
+    await db.insert(spaceMembers).values({
+      id: crypto.randomUUID(),
+      spaceId: inv.spaceId,
+      userId: locals.user.id,
+      role: "member",
+    });
+  }
 
   // Mark invite as accepted
   await db

--- a/src/pages/api/videos/upload.ts
+++ b/src/pages/api/videos/upload.ts
@@ -27,7 +27,7 @@ export const POST: APIRoute = async ({ locals, request }) => {
     });
   }
 
-  const { fileName, fileSize, title, description, folderId, generateTranscript } = parsed.data;
+  const { fileName, fileSize, title, description, folderId, generateTranscript, spaceId } = parsed.data;
 
   if (!fileName || !fileSize) {
     return new Response(
@@ -70,16 +70,22 @@ export const POST: APIRoute = async ({ locals, request }) => {
       ? await isTranscriptGenerationEnabled(env, locals.user)
       : false;
 
-    // Determine the target space. For now (single-space mode) use the user's
-    // default space. A future PR will let the client pass a spaceId.
-    const defaultSpace = await getDefaultSpaceForUser(db, locals.user.id);
-    if (!defaultSpace) {
+    const defaultSpace = spaceId ? null : await getDefaultSpaceForUser(db, locals.user.id);
+    const targetSpaceId = spaceId ?? defaultSpace?.id;
+    if (!targetSpaceId) {
       return new Response(JSON.stringify({ error: "No space found for user" }), {
         status: 500,
         headers: { "Content-Type": "application/json" },
       });
     }
-    const targetSpaceId = defaultSpace.id;
+
+    const role = await verifySpaceAccess(db, locals.user.id, targetSpaceId);
+    if (!role) {
+      return new Response(JSON.stringify({ error: "Forbidden" }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
 
     if (folderId) {
       const folder = await db

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -200,11 +200,6 @@ const emptyDescription = currentFolderRecord
         <h1 class="text-2xl font-bold text-text-primary">
           {currentFolderRecord ? currentFolderRecord.name : selectedSpace.name}
         </h1>
-        {!currentFolderRecord && (
-          <p class="mt-1 text-sm text-text-secondary">
-            {selectedSpace.role === "owner" ? "Owner" : "Member"} space
-          </p>
-        )}
       </div>
       <div class="flex items-center gap-2 sm:gap-3">
         <CreateFolderDialog client:load parentId={currentFolderId} spaceId={selectedSpaceId} />

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -6,42 +6,46 @@ import Breadcrumbs from "../components/Breadcrumbs.astro";
 import { CreateFolderDialog } from "../components/CreateFolderDialog";
 import EmptyState from "../components/EmptyState.astro";
 import { createDb } from "../db";
-import { folders, videos, comments, spaceMembers, spaces, approvals } from "../db/schema";
+import { folders, videos, comments, spaceMembers, approvals } from "../db/schema";
 import { and, asc, desc, count, eq, inArray, isNull, sql } from "drizzle-orm";
 import { env } from "cloudflare:workers";
+import { getUserSpaces } from "../lib/spaces";
 
 const user = Astro.locals.user;
 if (!user) return Astro.redirect("/login");
 
 const db = createDb(env.DB);
 const currentFolderId = Astro.url.searchParams.get("folderId");
+const requestedSpaceId = Astro.url.searchParams.get("space");
 
-// Get all space IDs the user belongs to
-const memberRows = await db
-  .select({ spaceId: spaceMembers.spaceId })
-  .from(spaceMembers)
-  .where(eq(spaceMembers.userId, user.id));
-const spaceIds = memberRows.map((r) => r.spaceId);
-const spaceFilter = spaceIds.length > 0 ? inArray(folders.spaceId, spaceIds) : eq(folders.spaceId, "__none__");
-const videoSpaceFilter = spaceIds.length > 0 ? inArray(videos.spaceId, spaceIds) : eq(videos.spaceId, "__none__");
+const userSpaces = await getUserSpaces(db, user.id);
+const defaultSpace = userSpaces[0] ?? null;
+if (!defaultSpace) return Astro.redirect("/login");
+
+const selectedSpace = userSpaces.find((space) => space.id === requestedSpaceId) ?? defaultSpace;
+const selectedSpaceId = selectedSpace.id;
+if (requestedSpaceId && requestedSpaceId !== selectedSpaceId) {
+  return Astro.redirect(`/dashboard?space=${selectedSpaceId}`);
+}
+const dashboardHref = `/dashboard?space=${selectedSpaceId}`;
 
 const currentFolder = currentFolderId
   ? await db
       .select()
       .from(folders)
-      .where(and(eq(folders.id, currentFolderId), spaceFilter))
+      .where(and(eq(folders.id, currentFolderId), eq(folders.spaceId, selectedSpaceId)))
       .limit(1)
   : [];
 
 if (currentFolderId && currentFolder.length === 0) {
-  return Astro.redirect("/dashboard");
+  return Astro.redirect(dashboardHref);
 }
 
 const currentFolderRecord = currentFolder[0] || null;
 const allFolders = await db
   .select()
   .from(folders)
-  .where(spaceFilter)
+  .where(eq(folders.spaceId, selectedSpaceId))
   .orderBy(asc(folders.name));
 const folderById = new Map(allFolders.map((folder) => [folder.id, folder]));
 const folderPath = [];
@@ -65,7 +69,7 @@ if (childFolderIds.length > 0) {
   const counts = await db
     .select({ folderId: videos.folderId, count: count() })
     .from(videos)
-    .where(and(eq(videos.isCurrentVersion, true), inArray(videos.folderId, childFolderIds)))
+    .where(and(eq(videos.spaceId, selectedSpaceId), eq(videos.isCurrentVersion, true), inArray(videos.folderId, childFolderIds)))
     .groupBy(videos.folderId);
 
   folderVideoCounts = Object.fromEntries(counts.map((row) => [row.folderId || "", row.count]));
@@ -73,7 +77,7 @@ if (childFolderIds.length > 0) {
   const folderVideos = await db
     .select({ folderId: videos.folderId, thumbnailUrl: videos.thumbnailUrl })
     .from(videos)
-    .where(and(eq(videos.isCurrentVersion, true), inArray(videos.folderId, childFolderIds)))
+    .where(and(eq(videos.spaceId, selectedSpaceId), eq(videos.isCurrentVersion, true), inArray(videos.folderId, childFolderIds)))
     .orderBy(desc(videos.createdAt));
 
   folderThumbnails = folderVideos.reduce<Record<string, string[]>>((acc, video) => {
@@ -89,8 +93,8 @@ const userVideos = await db
   .from(videos)
   .where(
     currentFolderId
-      ? and(videoSpaceFilter, eq(videos.folderId, currentFolderId), eq(videos.isCurrentVersion, true))
-      : and(videoSpaceFilter, isNull(videos.folderId), eq(videos.isCurrentVersion, true)),
+      ? and(eq(videos.spaceId, selectedSpaceId), eq(videos.folderId, currentFolderId), eq(videos.isCurrentVersion, true))
+      : and(eq(videos.spaceId, selectedSpaceId), isNull(videos.folderId), eq(videos.isCurrentVersion, true)),
   )
   .orderBy(desc(videos.createdAt));
 
@@ -158,56 +162,54 @@ if (userVideos.length > 0) {
   versionCounts = Object.fromEntries(counts.map((row) => [row.versionGroupId || "", row.count]));
 }
 
-// Approval badges. Only spaces with `requiredApprovals > 0` participate; any
-// other video gets no badge. We pull the per-space threshold and the count
-// of recorded approvals per video and combine them into the props passed
-// to <VideoCard />.
-const requiredApprovalsBySpace: Record<string, number> = {};
+// Approval badges only render when the selected space enables approvals.
 const approvalCountsByVideo: Record<string, number> = {};
-if (userVideos.length > 0 && spaceIds.length > 0) {
-  const spaceRows = await db
-    .select({ id: spaces.id, requiredApprovals: spaces.requiredApprovals })
-    .from(spaces)
-    .where(inArray(spaces.id, spaceIds));
-  for (const row of spaceRows) {
-    requiredApprovalsBySpace[row.id] = row.requiredApprovals;
-  }
-
-  const approvalSpaceIds = spaceRows
-    .filter((row) => row.requiredApprovals > 0)
-    .map((row) => row.id);
-
-  const videosNeedingApproval = userVideos.filter((video) =>
-    approvalSpaceIds.includes(video.spaceId),
-  );
-
-  if (videosNeedingApproval.length > 0) {
-    const videoIds = videosNeedingApproval.map((v) => v.id);
-    const counts = await db
-      .select({ videoId: approvals.videoId, count: count() })
-      .from(approvals)
-      .where(inArray(approvals.videoId, videoIds))
-      .groupBy(approvals.videoId);
-    for (const row of counts) {
-      approvalCountsByVideo[row.videoId] = row.count;
-    }
+if (userVideos.length > 0 && selectedSpace.requiredApprovals > 0) {
+  const videoIds = userVideos.map((v) => v.id);
+  const counts = await db
+    .select({ videoId: approvals.videoId, count: count() })
+    .from(approvals)
+    .where(inArray(approvals.videoId, videoIds))
+    .groupBy(approvals.videoId);
+  for (const row of counts) {
+    approvalCountsByVideo[row.videoId] = row.count;
   }
 }
+
+const memberCountRows = await db
+  .select({ count: count() })
+  .from(spaceMembers)
+  .where(eq(spaceMembers.spaceId, selectedSpaceId));
+const memberCount = memberCountRows[0]?.count ?? 0;
+
+const uploadHref = currentFolderId
+  ? `/upload?space=${selectedSpaceId}&folderId=${currentFolderId}`
+  : `/upload?space=${selectedSpaceId}`;
+
+const emptyHeading = currentFolderRecord ? "This folder is empty" : "No videos yet";
+const emptyDescription = currentFolderRecord
+  ? "Add videos or create a nested folder here"
+  : "Upload one to get started.";
 ---
 
-<Layout title={currentFolderRecord ? currentFolderRecord.name : "My Videos"} user={user}>
+<Layout title={currentFolderRecord ? currentFolderRecord.name : selectedSpace.name} user={user} selectedSpaceId={selectedSpaceId}>
   <div class="mx-auto max-w-[1280px] px-4 py-8 sm:px-8">
     <div class="mb-8 flex flex-wrap items-center justify-between gap-4">
       <div>
         <Breadcrumbs path={folderPath} />
         <h1 class="text-2xl font-bold text-text-primary">
-          {currentFolderRecord ? currentFolderRecord.name : "My Videos"}
+          {currentFolderRecord ? currentFolderRecord.name : selectedSpace.name}
         </h1>
+        {!currentFolderRecord && (
+          <p class="mt-1 text-sm text-text-secondary">
+            {selectedSpace.role === "owner" ? "Owner" : "Member"} space
+          </p>
+        )}
       </div>
       <div class="flex items-center gap-2 sm:gap-3">
-        <CreateFolderDialog client:load parentId={currentFolderId} />
+        <CreateFolderDialog client:load parentId={currentFolderId} spaceId={selectedSpaceId} />
         <a
-          href={currentFolderId ? `/upload?folderId=${currentFolderId}` : "/upload"}
+          href={uploadHref}
           class="inline-flex items-center gap-2 rounded-lg bg-accent-primary px-3 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover hover:shadow-[0_2px_8px_rgba(108,92,231,0.3)] sm:px-5"
         >
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -220,12 +222,21 @@ if (userVideos.length > 0 && spaceIds.length > 0) {
       </div>
     </div>
 
+    {memberCount <= 1 && selectedSpace.role === "owner" && (
+      <div class="mb-6 rounded-xl border border-border-default bg-bg-secondary px-4 py-3 text-sm text-text-secondary">
+        <span>This space only has you in it.</span>
+        <a href={`/spaces/${selectedSpaceId}/settings?space=${selectedSpaceId}`} class="ml-2 font-medium text-accent-primary hover:text-accent-hover">
+          Invite members
+        </a>
+      </div>
+    )}
+
     {userVideos.length === 0 && childFolders.length === 0 ? (
       <EmptyState
-        heading={currentFolderRecord ? "This folder is empty" : "Upload your first video"}
-        description={currentFolderRecord ? "Add videos or create a nested folder here" : "Share it with your team for feedback"}
+        heading={emptyHeading}
+        description={emptyDescription}
         actionText="Upload Video"
-        actionHref={currentFolderId ? `/upload?folderId=${currentFolderId}` : "/upload"}
+        actionHref={uploadHref}
       />
     ) : (
       <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
@@ -234,6 +245,7 @@ if (userVideos.length > 0 && spaceIds.length > 0) {
             id={folder.id}
             name={folder.name}
             parentId={folder.parentId}
+            spaceId={selectedSpaceId}
             videoCount={folderVideoCounts[folder.id] || 0}
             thumbnails={folderThumbnails[folder.id] || []}
           />
@@ -243,6 +255,7 @@ if (userVideos.length > 0 && spaceIds.length > 0) {
             id={video.id}
             title={video.title}
             folderId={video.folderId}
+            spaceId={selectedSpaceId}
             thumbnailUrl={video.thumbnailUrl}
             duration={video.duration}
             status={video.status as "processing" | "ready" | "failed"}
@@ -251,7 +264,7 @@ if (userVideos.length > 0 && spaceIds.length > 0) {
             urgencyCounts={urgencyCounts[video.id] || { idea: 0, suggestion: 0, important: 0, critical: 0 }}
             versionNumber={video.versionNumber}
             versionCount={versionCounts[video.versionGroupId || video.id] || 1}
-            requiredApprovals={requiredApprovalsBySpace[video.spaceId] || 0}
+            requiredApprovals={selectedSpace.requiredApprovals}
             approvalCount={approvalCountsByVideo[video.id] || 0}
           />
         ))}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,7 @@ if (user) {
 
 <Layout
   title="Collaborative Video Review"
-  description="QuickCut is collaborative video review built on Cloudflare. Version stacks, timestamped comments, share links for clients, resumable 5GB uploads, and global HLS playback."
+  description="QuickCut is collaborative video review built on Cloudflare. Team spaces, member invites, version stacks, timestamped comments, share links for clients, resumable 5GB uploads, and global HLS playback."
 >
   <!-- Marketing nav -->
   <header class="sticky top-0 z-50 border-b border-border-default bg-bg-primary/80 backdrop-blur">
@@ -47,7 +47,7 @@ if (user) {
           class="mb-6 inline-flex items-center gap-2 rounded-full border border-border-default bg-bg-secondary px-3 py-1 text-xs text-text-secondary"
         >
           <span class="size-1.5 rounded-full bg-accent-secondary"></span>
-          Collaborative video review, built on the edge
+          Team spaces for collaborative video review
         </div>
         <h1 class="text-4xl font-bold tracking-tight text-text-primary sm:text-6xl">
           Review video together.
@@ -56,8 +56,8 @@ if (user) {
           </span>
         </h1>
         <p class="mx-auto mt-6 max-w-2xl text-lg text-text-secondary">
-          Upload up to 5GB, stack new cuts as versions, share a link, and collect timestamped feedback
-          from your team or clients — no account required for reviewers. Powered by Cloudflare.
+          Create spaces for each team or client, invite collaborators, upload up to 5GB, stack new cuts as
+          versions, and collect timestamped feedback — no account required for external reviewers.
         </p>
         <div class="mt-10 flex flex-wrap items-center justify-center gap-3">
           <a
@@ -81,16 +81,21 @@ if (user) {
           class="rounded-2xl border border-border-default bg-bg-secondary p-3 shadow-[0_24px_64px_rgba(0,0,0,0.5)]"
         >
           <!-- Mock window chrome -->
-          <div class="mb-3 flex items-center justify-between px-2">
-            <div class="flex items-center gap-1.5">
-              <span class="size-2.5 rounded-full bg-accent-danger/60"></span>
-              <span class="size-2.5 rounded-full bg-accent-warning/60"></span>
-              <span class="size-2.5 rounded-full bg-accent-secondary/60"></span>
+            <div class="mb-3 flex items-center justify-between px-2">
+              <div class="flex items-center gap-1.5">
+                <span class="size-2.5 rounded-full bg-accent-danger/60"></span>
+                <span class="size-2.5 rounded-full bg-accent-warning/60"></span>
+                <span class="size-2.5 rounded-full bg-accent-secondary/60"></span>
+              </div>
+              <div class="flex items-center gap-2">
+                <span class="rounded-full bg-accent-primary/15 px-2.5 py-0.5 text-xs font-medium text-accent-primary">
+                  Acme Launch Space
+                </span>
+                <span class="rounded-full bg-accent-secondary/15 px-2.5 py-0.5 text-xs font-medium text-accent-secondary">
+                  Approved
+                </span>
+              </div>
             </div>
-            <span class="rounded-full bg-accent-secondary/15 px-2.5 py-0.5 text-xs font-medium text-accent-secondary">
-              Approved
-            </span>
-          </div>
 
           <!-- Faux video frame -->
           <div class="relative aspect-video overflow-hidden rounded-xl bg-bg-tertiary">
@@ -239,13 +244,15 @@ if (user) {
             class="mb-4 flex size-10 items-center justify-center rounded-lg bg-accent-warning/15 text-accent-warning"
           >
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="size-5">
-              <circle cx="12" cy="12" r="10"></circle>
-              <polyline points="12 6 12 12 16 14"></polyline>
+              <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+              <circle cx="9" cy="7" r="4"></circle>
+              <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+              <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
             </svg>
           </div>
-          <h3 class="font-semibold text-text-primary">Review statuses</h3>
+          <h3 class="font-semibold text-text-primary">Team spaces</h3>
           <p class="mt-2 text-sm text-text-secondary">
-            Move clips through Needs Review → In Progress → Approved. Always know what's blocking the cut.
+            Separate every client, channel, or project into its own space with members, invites, and settings.
           </p>
         </div>
 
@@ -275,15 +282,94 @@ if (user) {
             class="mb-4 flex size-10 items-center justify-center rounded-lg bg-accent-info/15 text-accent-info"
           >
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="size-5">
-              <circle cx="12" cy="12" r="10"></circle>
-              <line x1="2" y1="12" x2="22" y2="12"></line>
-              <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
+              <path d="M9 11l3 3L22 4"></path>
+              <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path>
             </svg>
           </div>
-          <h3 class="font-semibold text-text-primary">Global HLS playback</h3>
+          <h3 class="font-semibold text-text-primary">Approval workflows</h3>
           <p class="mt-2 text-sm text-text-secondary">
-            Adaptive streaming powered by Cloudflare Stream. Smooth playback for every reviewer, anywhere.
+            Set required approvals per space so every team has the right sign-off process before a cut ships.
           </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Spaces -->
+  <section class="border-t border-border-default bg-bg-secondary/30">
+    <div class="mx-auto grid max-w-[1280px] gap-10 px-6 py-20 sm:px-8 sm:py-24 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
+      <div>
+        <div class="mb-4 inline-flex items-center gap-2 rounded-full border border-border-default bg-bg-primary px-3 py-1 text-xs text-text-secondary">
+          <span class="size-1.5 rounded-full bg-accent-primary"></span>
+          New: Spaces
+        </div>
+        <h2 class="text-3xl font-bold tracking-tight text-text-primary sm:text-4xl">
+          Keep every review group in its own space
+        </h2>
+        <p class="mt-4 text-text-secondary">
+          Spaces give each team, client, or project a dedicated home for videos, members, approvals, and invite notifications.
+          Switch contexts without mixing feedback, files, or access.
+        </p>
+        <div class="mt-8 grid gap-3 sm:grid-cols-2">
+          <div class="rounded-xl border border-border-default bg-bg-primary p-4">
+            <h3 class="text-sm font-semibold text-text-primary">Invite teammates</h3>
+            <p class="mt-2 text-sm text-text-secondary">
+              Send space invites by email and let users accept from their notifications page.
+            </p>
+          </div>
+          <div class="rounded-xl border border-border-default bg-bg-primary p-4">
+            <h3 class="text-sm font-semibold text-text-primary">Scope access</h3>
+            <p class="mt-2 text-sm text-text-secondary">
+              Videos, folders, members, and approval settings stay tied to the selected space.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="rounded-2xl border border-border-default bg-bg-primary p-3 shadow-[0_24px_64px_rgba(0,0,0,0.35)]">
+        <div class="rounded-xl border border-border-default bg-bg-secondary p-5">
+          <div class="flex flex-wrap items-center justify-between gap-3 border-b border-border-default pb-4">
+            <div>
+              <p class="text-xs font-medium uppercase tracking-wide text-text-tertiary">Current space</p>
+              <h3 class="mt-1 text-lg font-semibold text-text-primary">Acme Launch</h3>
+            </div>
+            <span class="rounded-full bg-accent-primary/15 px-3 py-1 text-xs font-medium text-accent-primary">
+              4 members
+            </span>
+          </div>
+
+          <div class="mt-5 space-y-3">
+            <div class="flex items-center justify-between rounded-lg border border-border-default bg-bg-tertiary/60 p-3">
+              <div class="flex items-center gap-3">
+                <div class="flex size-9 items-center justify-center rounded-lg bg-accent-primary/15 text-accent-primary">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="size-4">
+                    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                    <circle cx="9" cy="7" r="4"></circle>
+                    <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+                    <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+                  </svg>
+                </div>
+                <div>
+                  <p class="text-sm font-medium text-text-primary">Invite pending</p>
+                  <p class="text-xs text-text-tertiary">maya@example.com</p>
+                </div>
+              </div>
+              <span class="rounded-full bg-accent-warning/15 px-2.5 py-0.5 text-xs font-medium text-accent-warning">
+                Pending
+              </span>
+            </div>
+
+            <div class="grid gap-3 sm:grid-cols-2">
+              <div class="rounded-lg border border-border-default bg-bg-tertiary/60 p-3">
+                <p class="text-xs font-medium text-text-tertiary">Required approvals</p>
+                <p class="mt-2 text-2xl font-bold text-text-primary">2</p>
+              </div>
+              <div class="rounded-lg border border-border-default bg-bg-tertiary/60 p-3">
+                <p class="text-xs font-medium text-text-tertiary">Videos in review</p>
+                <p class="mt-2 text-2xl font-bold text-text-primary">12</p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -346,10 +432,10 @@ if (user) {
             >
               2
             </span>
-            <h3 class="font-semibold text-text-primary">Share</h3>
+            <h3 class="font-semibold text-text-primary">Invite or share</h3>
           </div>
           <p class="mt-3 text-sm text-text-secondary">
-            Generate a link. Reviewers don't need an account — just a name.
+            Invite teammates into a space or generate a public link for clients who only need to review.
           </p>
           <!-- Mock share card -->
           <div class="mt-5 rounded-lg border border-border-default bg-bg-tertiary/50 p-4">
@@ -594,6 +680,27 @@ if (user) {
           <p class="mt-3 text-sm text-text-secondary">
             No. Anyone with a share link can leave timestamped comments after entering a display name. You
             stay in control — revoke any link at any time.
+          </p>
+        </details>
+
+        <details
+          class="group rounded-xl border border-border-default bg-bg-primary p-5 transition-colors hover:border-border-hover"
+        >
+          <summary class="flex cursor-pointer items-center justify-between text-sm font-semibold text-text-primary">
+            What are spaces for?
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              class="size-4 text-text-tertiary transition-transform group-open:rotate-180"
+            >
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </summary>
+          <p class="mt-3 text-sm text-text-secondary">
+            Spaces keep videos, folders, members, invites, and approval settings grouped by team, client, or project.
+            Use public share links when someone only needs temporary review access.
           </p>
         </details>
 

--- a/src/pages/notifications.astro
+++ b/src/pages/notifications.astro
@@ -1,0 +1,26 @@
+---
+import Layout from "../layouts/Layout.astro";
+import { PendingInvitesList } from "../components/PendingInvitesList";
+import { createDb } from "../db";
+import { getPendingInvitesForUser } from "../lib/invites";
+import { env } from "cloudflare:workers";
+
+const user = Astro.locals.user;
+if (!user) return Astro.redirect("/login");
+
+const db = createDb(env.DB);
+const pendingInvites = await getPendingInvitesForUser(db, user.email);
+---
+
+<Layout title="Notifications" user={user}>
+  <div class="mx-auto max-w-3xl px-4 py-8 sm:px-8">
+    <div class="mb-8">
+      <h1 class="text-2xl font-bold text-text-primary">Notifications</h1>
+      <p class="mt-1 text-sm text-text-secondary">
+        Review pending space invites for your account.
+      </p>
+    </div>
+
+    <PendingInvitesList client:load invites={pendingInvites} />
+  </div>
+</Layout>

--- a/src/pages/spaces/[id]/settings.astro
+++ b/src/pages/spaces/[id]/settings.astro
@@ -58,7 +58,7 @@ const isDefaultSpace = firstOwned.length > 0 && firstOwned[0].id === id;
 ---
 
 <Layout title={`${space[0].name} Settings`} user={user} selectedSpaceId={id}>
-  <div class="mx-auto max-w-[720px] px-4 py-8 sm:px-8">
+  <div class="mx-auto max-w-[1280px] px-4 py-8 sm:px-8">
     <div class="mb-6">
       <a
         href={`/dashboard?space=${id}`}

--- a/src/pages/spaces/[id]/settings.astro
+++ b/src/pages/spaces/[id]/settings.astro
@@ -57,11 +57,11 @@ const firstOwned = await db
 const isDefaultSpace = firstOwned.length > 0 && firstOwned[0].id === id;
 ---
 
-<Layout title={`${space[0].name} Settings`} user={user}>
+<Layout title={`${space[0].name} Settings`} user={user} selectedSpaceId={id}>
   <div class="mx-auto max-w-[720px] px-4 py-8 sm:px-8">
     <div class="mb-6">
       <a
-        href="/dashboard"
+        href={`/dashboard?space=${id}`}
         class="inline-flex items-center gap-1 text-sm text-text-secondary transition-colors hover:text-text-primary"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/src/pages/upload.astro
+++ b/src/pages/upload.astro
@@ -47,7 +47,7 @@ const transcriptsEnabled = await isTranscriptGenerationEnabled(env, user);
 ---
 
 <Layout title="Upload Video" user={user} selectedSpaceId={selectedSpaceId}>
-  <div class="mx-auto max-w-[1280px] px-8 py-8">
+  <div class="mx-auto max-w-[1280px] px-4 py-8 sm:px-8">
     <div class="mb-8">
       <a href={backHref} class="text-sm text-text-tertiary transition-colors hover:text-text-primary">
         &larr; Back to Library

--- a/src/pages/upload.astro
+++ b/src/pages/upload.astro
@@ -2,43 +2,51 @@
 import Layout from "../layouts/Layout.astro";
 import { UploadForm } from "../components/UploadForm";
 import { createDb } from "../db";
-import { folders, spaceMembers } from "../db/schema";
-import { and, eq, inArray } from "drizzle-orm";
+import { folders } from "../db/schema";
+import { and, eq } from "drizzle-orm";
 import { env } from "cloudflare:workers";
 import { isTranscriptGenerationEnabled } from "../lib/flags";
+import { getUserSpaces } from "../lib/spaces";
 
 const user = Astro.locals.user;
 if (!user) return Astro.redirect("/login");
 
 const folderId = Astro.url.searchParams.get("folderId");
-const backHref = folderId ? `/dashboard?folderId=${folderId}` : "/dashboard";
+const requestedSpaceId = Astro.url.searchParams.get("space");
 
 const db = createDb(env.DB);
 
-// Get spaces the user belongs to for folder validation
-const memberRows = await db
-  .select({ spaceId: spaceMembers.spaceId })
-  .from(spaceMembers)
-  .where(eq(spaceMembers.userId, user.id));
-const spaceIds = memberRows.map((r) => r.spaceId);
+const userSpaces = await getUserSpaces(db, user.id);
+const defaultSpace = userSpaces[0] ?? null;
+if (!defaultSpace) return Astro.redirect("/dashboard");
 
-const folderResult = folderId && spaceIds.length > 0
+const selectedSpace = userSpaces.find((space) => space.id === requestedSpaceId) ?? defaultSpace;
+const selectedSpaceId = selectedSpace.id;
+if (requestedSpaceId && requestedSpaceId !== selectedSpaceId) {
+  return Astro.redirect(`/upload?space=${selectedSpaceId}`);
+}
+
+const backHref = folderId
+  ? `/dashboard?space=${selectedSpaceId}&folderId=${folderId}`
+  : `/dashboard?space=${selectedSpaceId}`;
+
+const folderResult = folderId
   ? await db
       .select({ id: folders.id, name: folders.name })
       .from(folders)
-      .where(and(eq(folders.id, folderId), inArray(folders.spaceId, spaceIds)))
+      .where(and(eq(folders.id, folderId), eq(folders.spaceId, selectedSpaceId)))
       .limit(1)
   : [];
 
 if (folderId && folderResult.length === 0) {
-  return Astro.redirect("/upload");
+  return Astro.redirect(`/upload?space=${selectedSpaceId}`);
 }
 
 const targetFolder = folderResult[0] || null;
 const transcriptsEnabled = await isTranscriptGenerationEnabled(env, user);
 ---
 
-<Layout title="Upload Video" user={user}>
+<Layout title="Upload Video" user={user} selectedSpaceId={selectedSpaceId}>
   <div class="mx-auto max-w-[1280px] px-8 py-8">
     <div class="mb-8">
       <a href={backHref} class="text-sm text-text-tertiary transition-colors hover:text-text-primary">
@@ -50,9 +58,9 @@ const transcriptsEnabled = await isTranscriptGenerationEnabled(env, user);
           <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V6.75A2.25 2.25 0 014.5 4.5h5.379c.596 0 1.169.237 1.591.659l1.122 1.122c.422.422.995.659 1.591.659H19.5a2.25 2.25 0 012.25 2.25v8.06A2.25 2.25 0 0119.5 19.5h-15a2.25 2.25 0 01-2.25-2.25v-4.5z" />
         </svg>
         <span>Uploading to</span>
-        <span class="font-medium text-text-primary">{targetFolder ? targetFolder.name : "All Videos"}</span>
+        <span class="font-medium text-text-primary">{selectedSpace.name}{targetFolder ? ` / ${targetFolder.name}` : " / All Videos"}</span>
       </div>
     </div>
-    <UploadForm client:load folderId={folderId} transcriptsEnabled={transcriptsEnabled} />
+    <UploadForm client:load folderId={folderId} spaces={userSpaces} selectedSpaceId={selectedSpaceId} transcriptsEnabled={transcriptsEnabled} />
   </div>
 </Layout>

--- a/src/pages/videos/[id].astro
+++ b/src/pages/videos/[id].astro
@@ -3,7 +3,7 @@ import Layout from "../../layouts/Layout.astro";
 import { VideoDetailView } from "../../components/VideoDetailView";
 import { VideoHeader } from "../../components/VideoHeader";
 import { createDb } from "../../db";
-import { videos, shareLinks } from "../../db/schema";
+import { videos, shareLinks, spaces } from "../../db/schema";
 import { eq } from "drizzle-orm";
 import { env } from "cloudflare:workers";
 import { getCommentsWithNames } from "../../lib/comments";
@@ -43,9 +43,17 @@ const transcriptsEnabled = await isTranscriptGenerationEnabled(env, user);
 // workflow enabled (requiredApprovals > 0).
 const approvalStatus = await getApprovalStatus(db, video.id, video.spaceId);
 const showApprovals = approvalStatus.requiredApprovals > 0;
+
+const spaceResult = await db
+  .select({ id: spaces.id, name: spaces.name })
+  .from(spaces)
+  .where(eq(spaces.id, video.spaceId))
+  .limit(1);
+const videoSpace = spaceResult[0] ?? { id: video.spaceId, name: "Space" };
+const backHref = `/dashboard?space=${video.spaceId}${video.folderId ? `&folderId=${video.folderId}` : ""}`;
 ---
 
-<Layout title={video.title} user={user}>
+<Layout title={video.title} user={user} selectedSpaceId={video.spaceId}>
   <script src="https://embed.cloudflarestream.com/embed/sdk.latest.js" is:inline></script>
   <div class="mx-auto max-w-[1280px] px-4 py-6 sm:px-8 sm:py-8">
     <VideoHeader
@@ -53,7 +61,16 @@ const showApprovals = approvalStatus.requiredApprovals > 0;
       videoId={video.id}
       shareLink={shareLink}
       appUrl={appUrl}
+      spaceId={video.spaceId}
+      backHref={backHref}
     />
+
+    <div class="mb-4 inline-flex items-center gap-2 rounded-full border border-border-default bg-bg-secondary px-3 py-1.5 text-sm text-text-secondary">
+      <span class="text-text-tertiary">Space</span>
+      <a href={`/dashboard?space=${videoSpace.id}`} class="font-medium text-text-primary transition-colors hover:text-accent-primary">
+        {videoSpace.name}
+      </a>
+    </div>
 
     <VideoDetailView
       client:load


### PR DESCRIPTION
## Summary
- Add a compact React space switcher in the authenticated header with settings and create-space flows.
- Scope dashboard, folder, upload, move, and video-detail navigation to the selected `space` query param.
- Add upload-space selection, space-aware empty states, member invite prompts, and space labels/back links on video pages.

## Verification
- `npx tsc --noEmit` still fails on pre-existing repo-wide errors in `CommentThread`, `VersionSwitcher`, `VideoDetailView`, `useStreamPlayer`, auth/comment/share APIs, and `lib/flags`; no new touched-file errors remain.
- `git diff --check`