### PR TITLE
Add Cloudflare docs links for referenced products on home page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -535,7 +535,7 @@ if (user) {
         </p>
       </div>
 
-      <div class="mt-14 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+      <div class="mt-14 grid gap-5 sm:grid-cols-2">
         <!-- Workers -->
         <div
           class="rounded-xl border border-border-default bg-bg-secondary p-6 transition-colors hover:border-border-hover"
@@ -650,37 +650,6 @@ if (user) {
           </p>
           <p class="mt-3 text-sm font-medium text-accent-secondary">
             Why it matters: free, fast, automatic — no separate CDN to wire up.
-          </p>
-        </div>
-
-        <!-- Workflows -->
-        <div
-          class="rounded-xl border border-border-default bg-bg-secondary p-6 transition-colors hover:border-border-hover"
-        >
-          <div class="flex items-start justify-between">
-            <div
-              class="flex size-10 items-center justify-center rounded-lg bg-accent-warning/15 text-accent-warning"
-            >
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="size-5">
-                <polyline points="16 3 21 3 21 8"></polyline>
-                <line x1="4" y1="20" x2="21" y2="3"></line>
-                <polyline points="21 16 21 21 16 21"></polyline>
-                <line x1="15" y1="15" x2="21" y2="21"></line>
-                <line x1="4" y1="4" x2="9" y2="9"></line>
-              </svg>
-            </div>
-            <span class="rounded-full bg-accent-warning/15 px-2.5 py-0.5 text-xs font-medium text-accent-warning">
-              Durable execution
-            </span>
-          </div>
-          <h3 class="mt-4 text-lg font-semibold text-text-primary">
-            <a href="https://developers.cloudflare.com/workflows/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-accent-warning">Workflows</a>
-          </h3>
-          <p class="mt-2 text-sm text-text-secondary">
-            Transcript generation runs as a durable, multi-step workflow — AI transcription with automatic retries and state tracking, all without managing queues or infrastructure.
-          </p>
-          <p class="mt-3 text-sm font-medium text-accent-warning">
-            Why it matters: reliable background jobs with zero ops overhead.
           </p>
         </div>
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -552,7 +552,9 @@ if (user) {
               Edge compute
             </span>
           </div>
-          <h3 class="mt-4 text-lg font-semibold text-text-primary">Workers</h3>
+          <h3 class="mt-4 text-lg font-semibold text-text-primary">
+            <a href="https://developers.cloudflare.com/workers/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-accent-primary">Workers</a>
+          </h3>
           <p class="mt-2 text-sm text-text-secondary">
             The entire Astro app runs at the edge — auth, API routes, page rendering. Sub-50ms cold starts
             in 300+ cities means reviewers never wait on the network.
@@ -580,7 +582,9 @@ if (user) {
               Serverless SQL
             </span>
           </div>
-          <h3 class="mt-4 text-lg font-semibold text-text-primary">D1</h3>
+          <h3 class="mt-4 text-lg font-semibold text-text-primary">
+            <a href="https://developers.cloudflare.com/d1/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-accent-info">D1</a>
+          </h3>
           <p class="mt-2 text-sm text-text-secondary">
             Users, sessions, videos, version groups, comments, share links — all in serverless SQLite.
             We use Drizzle ORM for type-safe queries with zero infrastructure to manage.
@@ -607,7 +611,9 @@ if (user) {
               Video infra
             </span>
           </div>
-          <h3 class="mt-4 text-lg font-semibold text-text-primary">Stream</h3>
+          <h3 class="mt-4 text-lg font-semibold text-text-primary">
+            <a href="https://developers.cloudflare.com/stream/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-accent-primary">Stream</a>
+          </h3>
           <p class="mt-2 text-sm text-text-secondary">
             Direct-to-Stream TUS uploads, automatic transcoding, thumbnail generation, and adaptive
             HLS/DASH delivery. We never touch the bytes ourselves.
@@ -635,7 +641,9 @@ if (user) {
               Static assets
             </span>
           </div>
-          <h3 class="mt-4 text-lg font-semibold text-text-primary">Workers Assets</h3>
+          <h3 class="mt-4 text-lg font-semibold text-text-primary">
+            <a href="https://developers.cloudflare.com/workers/static-assets/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-accent-secondary">Workers Assets</a>
+          </h3>
           <p class="mt-2 text-sm text-text-secondary">
             The static Astro build is served straight from Cloudflare's network, cached at every edge POP
             for instant page loads worldwide.
@@ -647,7 +655,7 @@ if (user) {
       </div>
 
       <p class="mt-8 text-center text-sm text-text-tertiary">
-        Plus Workers Observability for production telemetry.
+        Plus <a href="https://developers.cloudflare.com/workers/observability/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-text-secondary">Workers Observability</a> for production telemetry.
       </p>
     </div>
   </section>
@@ -784,8 +792,8 @@ if (user) {
             </svg>
           </summary>
           <p class="mt-3 text-sm text-text-secondary">
-            Entirely on Cloudflare's global network — Workers for compute, D1 for data, Stream for video,
-            Workers Assets for the static frontend. No origin servers, no separate CDN.
+            Entirely on Cloudflare's global network — <a href="https://developers.cloudflare.com/workers/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-text-primary">Workers</a> for compute, <a href="https://developers.cloudflare.com/d1/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-text-primary">D1</a> for data, <a href="https://developers.cloudflare.com/stream/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-text-primary">Stream</a> for video,
+            <a href="https://developers.cloudflare.com/workers/static-assets/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-text-primary">Workers Assets</a> for the static frontend. No origin servers, no separate CDN.
           </p>
         </details>
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -535,7 +535,7 @@ if (user) {
         </p>
       </div>
 
-      <div class="mt-14 grid gap-5 sm:grid-cols-2">
+      <div class="mt-14 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
         <!-- Workers -->
         <div
           class="rounded-xl border border-border-default bg-bg-secondary p-6 transition-colors hover:border-border-hover"
@@ -650,6 +650,37 @@ if (user) {
           </p>
           <p class="mt-3 text-sm font-medium text-accent-secondary">
             Why it matters: free, fast, automatic — no separate CDN to wire up.
+          </p>
+        </div>
+
+        <!-- Workflows -->
+        <div
+          class="rounded-xl border border-border-default bg-bg-secondary p-6 transition-colors hover:border-border-hover"
+        >
+          <div class="flex items-start justify-between">
+            <div
+              class="flex size-10 items-center justify-center rounded-lg bg-accent-warning/15 text-accent-warning"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="size-5">
+                <polyline points="16 3 21 3 21 8"></polyline>
+                <line x1="4" y1="20" x2="21" y2="3"></line>
+                <polyline points="21 16 21 21 16 21"></polyline>
+                <line x1="15" y1="15" x2="21" y2="21"></line>
+                <line x1="4" y1="4" x2="9" y2="9"></line>
+              </svg>
+            </div>
+            <span class="rounded-full bg-accent-warning/15 px-2.5 py-0.5 text-xs font-medium text-accent-warning">
+              Durable execution
+            </span>
+          </div>
+          <h3 class="mt-4 text-lg font-semibold text-text-primary">
+            <a href="https://developers.cloudflare.com/workflows/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-accent-warning">Workflows</a>
+          </h3>
+          <p class="mt-2 text-sm text-text-secondary">
+            Transcript generation runs as a durable, multi-step workflow — AI transcription with automatic retries and state tracking, all without managing queues or infrastructure.
+          </p>
+          <p class="mt-3 text-sm font-medium text-accent-warning">
+            Why it matters: reliable background jobs with zero ops overhead.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Links each Cloudflare product name in the **Built on Cloudflare** stack section to its official docs page (Workers, D1, Stream, Workers Assets)
- Links the **Workers Observability** footnote to its docs page
- Links the product names in the **FAQ** answer for "Where is QuickCut hosted?"

## Docs links added
| Product | URL |
|---|---|
| Workers | https://developers.cloudflare.com/workers/ |
| D1 | https://developers.cloudflare.com/d1/ |
| Stream | https://developers.cloudflare.com/stream/ |
| Workers Assets | https://developers.cloudflare.com/workers/static-assets/ |
| Workers Observability | https://developers.cloudflare.com/workers/observability/ |

All links open in a new tab (`target="_blank"`) with `rel="noopener noreferrer"`. Underline styling matches the existing design system using `decoration-text-tertiary` with a hover accent color transition.