### PR TITLE
feat: add logo SVG to navigation bar

### DIFF
--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -1,0 +1,12 @@
+---
+interface Props {
+  class?: string;
+}
+
+const { class: className = "size-7" } = Astro.props;
+---
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class={className} aria-hidden="true">
+  <rect x="8" y="8" width="112" height="112" rx="24" fill="#6c5ce7" />
+  <polygon points="50,32 50,96 98,64" fill="#f0f0f3" />
+</svg>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import "../styles/tailwind.css";
 import { UserMenu } from "../components/UserMenu";
 import { SpaceSwitcher } from "../components/SpaceSwitcher";
+import Logo from "../components/Logo.astro";
 import { createDb } from "../db";
 import { getPendingInvitesForUser } from "../lib/invites";
 import { getUserSpaces } from "../lib/spaces";
@@ -41,7 +42,8 @@ const headerSpaceId = selectedSpaceId ?? Astro.url.searchParams.get("space") ?? 
     {
       user && (
         <header class="sticky top-0 z-50 flex h-14 items-center border-b border-border-default bg-bg-primary px-8">
-          <a href={headerSpaceId ? `/dashboard?space=${headerSpaceId}` : "/dashboard"} class="text-lg font-bold text-text-primary">
+          <a href={headerSpaceId ? `/dashboard?space=${headerSpaceId}` : "/dashboard"} class="flex items-center gap-2 text-lg font-bold text-text-primary">
+            <Logo />
             Quick Cuts
           </a>
           <div class="ml-auto flex items-center gap-3">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "../layouts/Layout.astro";
+import Logo from "../components/Logo.astro";
 
 const user = Astro.locals.user;
 if (user) {
@@ -14,7 +15,10 @@ if (user) {
   <!-- Marketing nav -->
   <header class="sticky top-0 z-50 border-b border-border-default bg-bg-primary/80 backdrop-blur">
     <div class="mx-auto flex h-14 max-w-[1280px] items-center px-6 sm:px-8">
-      <a href="/" class="text-lg font-bold text-text-primary">Quick Cuts</a>
+      <a href="/" class="flex items-center gap-2 text-lg font-bold text-text-primary">
+        <Logo />
+        Quick Cuts
+      </a>
       <nav class="ml-10 hidden items-center gap-6 md:flex">
         <a href="#features" class="text-sm text-text-secondary transition-colors hover:text-text-primary">Features</a>
         <a href="#workflow" class="text-sm text-text-secondary transition-colors hover:text-text-primary">Workflow</a>


### PR DESCRIPTION
## Summary
- Creates a reusable `Logo.astro` component that renders the favicon SVG (purple rounded square with white play triangle) inline as a navigation-sized icon
- Adds the logo alongside the "Quick Cuts" text in the authenticated app header (`Layout.astro`), linking to the dashboard
- Adds the logo alongside the "Quick Cuts" text in the marketing page header (`index.astro`), linking to the home page