### PR TITLE
Replace status saving text with toast feedback

### DIFF
--- a/src/components/ProjectStatusControls.tsx
+++ b/src/components/ProjectStatusControls.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { PROJECT_STATUS_LABELS, PROJECT_STATUSES, normalizeVideoPhase, type ProjectStatus } from "../types";
+import { ToastViewport, useToast } from "./Toast";
 
 interface ProjectStatusControlsProps {
   videoId: string;
@@ -16,7 +17,16 @@ export function ProjectStatusControls({
 }: ProjectStatusControlsProps) {
   const [status, setStatus] = useState<ProjectStatus>(() => normalizeVideoPhase(initialStatus));
   const [saving, setSaving] = useState(false);
+  const { toasts, showToast, dismissToast } = useToast();
   const isPublished = status === "published";
+
+  useEffect(() => {
+    const message = window.sessionStorage.getItem("quickcut:status-toast");
+    if (!message) return;
+
+    window.sessionStorage.removeItem("quickcut:status-toast");
+    showToast(message);
+  }, [showToast]);
 
   const updateStatus = async (nextStatus: ProjectStatus) => {
     if (nextStatus === status || saving) return;
@@ -34,9 +44,11 @@ export function ProjectStatusControls({
       if (!res.ok) throw new Error("Failed to update project status");
       setStatus(nextStatus);
       onStatusChange?.(nextStatus);
+      window.sessionStorage.setItem("quickcut:status-toast", "Status successfully updated");
       window.location.reload();
     } catch (err) {
       console.error(err);
+      showToast("Failed to update status", "error");
     } finally {
       setSaving(false);
     }
@@ -44,6 +56,7 @@ export function ProjectStatusControls({
 
   return (
     <div className="flex flex-col gap-1.5">
+      <ToastViewport toasts={toasts} onDismiss={dismissToast} />
       <label htmlFor="project-status" className="sr-only">
         Status
       </label>
@@ -61,7 +74,6 @@ export function ProjectStatusControls({
             </option>
           ))}
         </select>
-        {saving && <span className="text-xs text-text-tertiary">Saving...</span>}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Remove the inline `Saving...` text from the project status select.
- Show toast feedback when status updates succeed or fail.
- Preserve the existing status update API call and reload behavior.

## Verification
- `CLOUDFLARE_ACCOUNT_ID=4426cbeacb457b1ca1b865d6c36ced0d pnpm build`

Closes #41