### PR TITLE
Send space invite emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .DS_Store
 *.log
 worker-configuration.d.ts
+.worktrees/

--- a/src/components/InviteResponse.tsx
+++ b/src/components/InviteResponse.tsx
@@ -28,7 +28,7 @@ export function InviteResponse({ token, spaceName, spaceId }: InviteResponseProp
       if (action === "accept") {
         // Redirect to dashboard after a short delay
         setTimeout(() => {
-          window.location.href = "/dashboard";
+          window.location.href = `/dashboard?space=${encodeURIComponent(spaceId)}`;
         }, 1500);
       }
     } catch (err) {

--- a/src/components/LoginOtpForm.tsx
+++ b/src/components/LoginOtpForm.tsx
@@ -1,10 +1,23 @@
 import { useState } from "react";
+import { getSafeReturnUrl } from "../lib/urls";
 
 type Step = "email" | "code";
 type OtpMode = "login" | "register";
 
 interface LoginOtpFormProps {
+  email?: string;
   mode: OtpMode;
+  returnUrl?: string;
+}
+
+function buildAuthModeHref(mode: OtpMode, email: string, returnUrl: string | null): string {
+  const params = new URLSearchParams();
+  if (email) params.set("email", email);
+  if (returnUrl) params.set("returnUrl", returnUrl);
+
+  const path = mode === "register" ? "/login" : "/register";
+  const query = params.toString();
+  return query ? `${path}?${query}` : path;
 }
 
 function getErrorMessage(error: unknown, fallback: string): string {
@@ -22,9 +35,9 @@ async function getJsonError(response: Response, fallback: string): Promise<strin
   return typeof message === "string" && message.trim() ? message : fallback;
 }
 
-export function LoginOtpForm({ mode }: LoginOtpFormProps) {
+export function LoginOtpForm({ email: initialEmail = "", mode, returnUrl }: LoginOtpFormProps) {
   const [step, setStep] = useState<Step>("email");
-  const [email, setEmail] = useState("");
+  const [email, setEmail] = useState(initialEmail);
   const [name, setName] = useState("");
   const [otp, setOtp] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -32,6 +45,8 @@ export function LoginOtpForm({ mode }: LoginOtpFormProps) {
 
   const normalizedEmail = email.trim().toLowerCase();
   const trimmedName = name.trim();
+  const safeReturnUrl = getSafeReturnUrl(returnUrl);
+  const alternateModeHref = buildAuthModeHref(mode, normalizedEmail, safeReturnUrl);
 
   async function handleSendCode(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -100,7 +115,7 @@ export function LoginOtpForm({ mode }: LoginOtpFormProps) {
         return;
       }
 
-      window.location.assign("/dashboard");
+      window.location.assign(safeReturnUrl || "/dashboard");
     } catch (err) {
       setError(getErrorMessage(err, "Invalid or expired code."));
     } finally {
@@ -212,7 +227,7 @@ export function LoginOtpForm({ mode }: LoginOtpFormProps) {
 
       <p className="text-center text-sm text-text-tertiary">
         {mode === "register" ? "Already have an account?" : "Need an account?"}{" "}
-        <a className="text-accent-primary transition-colors hover:text-accent-hover" href={mode === "register" ? "/login" : "/register"}>
+        <a className="text-accent-primary transition-colors hover:text-accent-hover" href={alternateModeHref}>
           {mode === "register" ? "Sign in" : "Sign up"}
         </a>
       </p>

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,60 @@
+interface InviteEmailParams {
+  inviteUrl: string;
+  inviterName: string;
+  spaceName: string;
+}
+
+interface InviteAuthPathParams {
+  email: string;
+  hasAccount: boolean;
+  token: string;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function sanitizeSubjectPart(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").trim();
+}
+
+export function buildInviteAuthPath({ email, hasAccount, token }: InviteAuthPathParams): string {
+  const params = new URLSearchParams({
+    email,
+    returnUrl: `/invites/${token}`,
+  });
+
+  return `${hasAccount ? "/login" : "/register"}?${params.toString()}`;
+}
+
+export function buildInviteEmail({ inviteUrl, inviterName, spaceName }: InviteEmailParams) {
+  const safeInviteUrl = escapeHtml(inviteUrl);
+  const safeInviterName = escapeHtml(inviterName);
+  const safeSpaceName = escapeHtml(spaceName);
+  const subject = `${sanitizeSubjectPart(inviterName)} invited you to ${sanitizeSubjectPart(spaceName)} on Quick Cuts`;
+  const text = `${inviterName} invited you to join ${spaceName} on Quick Cuts.\n\nAccept your invite: ${inviteUrl}\n\nIf you were not expecting this invite, you can ignore this email.`;
+  const html = `
+    <div style="font-family: Inter, Arial, sans-serif; color: #111827; line-height: 1.5; background: #f9fafb; padding: 32px;">
+      <div style="max-width: 520px; margin: 0 auto; background: #ffffff; border: 1px solid #e5e7eb; border-radius: 18px; padding: 32px;">
+        <p style="margin: 0 0 8px; color: #6c5ce7; font-size: 14px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;">Quick Cuts</p>
+        <h1 style="font-size: 24px; line-height: 1.25; margin: 0 0 16px; color: #111827;">You're invited to ${safeSpaceName}</h1>
+        <p style="margin: 0 0 24px; color: #4b5563; font-size: 16px;">
+          ${safeInviterName} invited you to join <strong style="color: #111827;">${safeSpaceName}</strong> so you can review videos, leave comments, and collaborate with the team.
+        </p>
+        <a href="${safeInviteUrl}" style="display: inline-block; background: #6c5ce7; color: #ffffff; text-decoration: none; font-weight: 700; border-radius: 10px; padding: 12px 18px;">Accept invite</a>
+        <p style="margin: 24px 0 0; color: #6b7280; font-size: 13px;">
+          If the button does not work, copy and paste this link into your browser:<br />
+          <a href="${safeInviteUrl}" style="color: #6c5ce7; word-break: break-all;">${safeInviteUrl}</a>
+        </p>
+        <p style="margin: 24px 0 0; color: #9ca3af; font-size: 12px;">If you were not expecting this invite, you can ignore this email.</p>
+      </div>
+    </div>
+  `;
+
+  return { subject, text, html };
+}

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -1,0 +1,10 @@
+export function getSafeReturnUrl(returnUrl: string | null | undefined): string | null {
+  if (!returnUrl || /[\u0000-\u001F\u007F\\]/.test(returnUrl)) return null;
+
+  const base = "https://quickcuts.local";
+  const url = new URL(returnUrl, base);
+
+  if (url.origin !== base) return null;
+
+  return `${url.pathname}${url.search}${url.hash}`;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,7 @@
 import { defineMiddleware } from "astro:middleware";
 import { env } from "cloudflare:workers";
 import { createAuth } from "./lib/auth";
+import { getSafeReturnUrl } from "./lib/urls";
 
 // Extend Astro locals type
 declare global {
@@ -50,7 +51,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
   // Redirect authenticated users away from auth pages
   if (context.locals.user && (pathname === "/login" || pathname === "/register")) {
-    return context.redirect("/dashboard");
+    return context.redirect(getSafeReturnUrl(context.url.searchParams.get("returnUrl")) || "/dashboard");
   }
 
   // Protect routes
@@ -58,7 +59,11 @@ export const onRequest = defineMiddleware(async (context, next) => {
     pathname.startsWith(route),
   );
   if (isProtectedPage && !context.locals.user) {
-    return context.redirect("/login?message=Your session has expired. Please sign in again.");
+    const params = new URLSearchParams({
+      message: "Your session has expired. Please sign in again.",
+      returnUrl: `${context.url.pathname}${context.url.search}`,
+    });
+    return context.redirect(`/login?${params.toString()}`);
   }
 
   // Protect API routes. The /live WebSocket upgrade endpoint does its own

--- a/src/pages/api/spaces/[id]/invites/index.ts
+++ b/src/pages/api/spaces/[id]/invites/index.ts
@@ -3,7 +3,8 @@ import { env } from "cloudflare:workers";
 import { and, eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { createDb } from "../../../../../db";
-import { spaceInvites } from "../../../../../db/schema";
+import { spaceInvites, spaces, users } from "../../../../../db/schema";
+import { buildInviteAuthPath, buildInviteEmail } from "../../../../../lib/email";
 import { inviteCreateSchema } from "../../../../../lib/validation";
 import { verifySpaceAccess } from "../../../../../lib/spaces";
 
@@ -79,6 +80,19 @@ export const POST: APIRoute = async ({ params, locals, request }) => {
     });
   }
 
+  const space = await db
+    .select({ name: spaces.name })
+    .from(spaces)
+    .where(eq(spaces.id, spaceId))
+    .limit(1);
+
+  if (space.length === 0) {
+    return new Response(JSON.stringify({ error: "Space not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   // Check for duplicate pending invite for same email + space
   const existing = await db
     .select({ id: spaceInvites.id })
@@ -109,6 +123,41 @@ export const POST: APIRoute = async ({ params, locals, request }) => {
   };
 
   await db.insert(spaceInvites).values(invite);
+
+  const existingUser = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, parsed.data.email))
+    .limit(1);
+
+  const invitePath = buildInviteAuthPath({
+    email: parsed.data.email,
+    hasAccount: existingUser.length > 0,
+    token: invite.token,
+  });
+  const inviteUrl = new URL(invitePath, new URL(request.url).origin).toString();
+  const email = buildInviteEmail({
+    inviteUrl,
+    inviterName: locals.user.name,
+    spaceName: space[0].name,
+  });
+
+  try {
+    await env.EMAIL.send({
+      to: parsed.data.email,
+      from: env.OTP_EMAIL_FROM,
+      subject: email.subject,
+      text: email.text,
+      html: email.html,
+    });
+  } catch (error) {
+    await db.delete(spaceInvites).where(eq(spaceInvites.id, invite.id));
+    console.error("Failed to send invite email", error);
+    return new Response(JSON.stringify({ error: "Failed to send invite email" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
 
   const created = await db
     .select()

--- a/src/pages/invites/[token].astro
+++ b/src/pages/invites/[token].astro
@@ -2,7 +2,8 @@
 import Layout from "../../layouts/Layout.astro";
 import { InviteResponse } from "../../components/InviteResponse";
 import { createDb } from "../../db";
-import { spaceInvites, spaces } from "../../db/schema";
+import { spaceInvites, spaces, users } from "../../db/schema";
+import { buildInviteAuthPath } from "../../lib/email";
 import { eq } from "drizzle-orm";
 import { env } from "cloudflare:workers";
 
@@ -11,12 +12,6 @@ const { token } = Astro.params;
 
 if (!token) {
   return Astro.redirect("/login");
-}
-
-// If not logged in, redirect to login with return URL
-if (!user) {
-  const returnUrl = encodeURIComponent(`/invites/${token}`);
-  return Astro.redirect(`/login?message=Sign in to accept your invite&returnUrl=${returnUrl}`);
 }
 
 const db = createDb(env.DB);
@@ -36,7 +31,20 @@ const invite = await db
   .limit(1);
 
 const inv = invite[0] ?? null;
-const emailMatch = inv ? user.email.toLowerCase() === inv.email.toLowerCase() : false;
+if (inv && inv.status === "pending" && !user) {
+  const existingUser = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, inv.email))
+    .limit(1);
+  return Astro.redirect(buildInviteAuthPath({
+    email: inv.email,
+    hasAccount: existingUser.length > 0,
+    token,
+  }));
+}
+
+const emailMatch = inv && user ? user.email.toLowerCase() === inv.email.toLowerCase() : false;
 ---
 
 <Layout title="Space Invite" user={user}>

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -9,6 +9,8 @@ if (user) {
 
 const error = Astro.url.searchParams.get("error");
 const message = Astro.url.searchParams.get("message");
+const email = Astro.url.searchParams.get("email") ?? undefined;
+const returnUrl = Astro.url.searchParams.get("returnUrl") ?? undefined;
 ---
 
 <Layout title="Sign In">
@@ -37,7 +39,7 @@ const message = Astro.url.searchParams.get("message");
           Sign in with a one-time code sent to your email.
         </p>
 
-        <LoginOtpForm mode="login" client:load />
+        <LoginOtpForm mode="login" email={email} returnUrl={returnUrl} client:load />
 
       </div>
     </div>

--- a/src/pages/register.astro
+++ b/src/pages/register.astro
@@ -9,6 +9,8 @@ if (user) {
 
 const error = Astro.url.searchParams.get("error");
 const message = Astro.url.searchParams.get("message");
+const email = Astro.url.searchParams.get("email") ?? undefined;
+const returnUrl = Astro.url.searchParams.get("returnUrl") ?? undefined;
 ---
 
 <Layout title="Create Account">
@@ -37,7 +39,7 @@ const message = Astro.url.searchParams.get("message");
           Create your account with a one-time code sent to your email.
         </p>
 
-        <LoginOtpForm mode="register" client:load />
+        <LoginOtpForm mode="register" email={email} returnUrl={returnUrl} client:load />
 
         <p class="mt-6 text-center text-xs text-text-tertiary">
           Use an email address where you can receive your sign-up code.


### PR DESCRIPTION
## Summary
- Send branded space invite emails when owners create invites.
- Route invited users through login or registration with email prefill and safe returnUrl handling.
- Redirect accepted invites to the invited space dashboard.

## Test Plan
- [x] `CLOUDFLARE_ACCOUNT_ID=4426cbeacb457b1ca1b865d6c36ced0d pnpm build`

## Notes
- `feat/better-auth-otp` was merged into `main`, so this PR targets `main` directly.
- `pnpm exec tsc --noEmit` still reports existing project-wide TypeScript errors outside this change set.

Closes #44