### PR TITLE
Add comment notifications

### DIFF
--- a/migrations/0018_create_notifications.sql
+++ b/migrations/0018_create_notifications.sql
@@ -1,0 +1,19 @@
+CREATE TABLE `notifications` (
+  `id` text PRIMARY KEY NOT NULL,
+  `user_id` text NOT NULL REFERENCES `users`(`id`) ON DELETE CASCADE,
+  `actor_user_id` text REFERENCES `users`(`id`) ON DELETE SET NULL,
+  `actor_display_name` text NOT NULL,
+  `type` text NOT NULL,
+  `video_id` text NOT NULL REFERENCES `videos`(`id`) ON DELETE CASCADE,
+  `comment_id` text NOT NULL REFERENCES `comments`(`id`) ON DELETE CASCADE,
+  `parent_comment_id` text REFERENCES `comments`(`id`) ON DELETE CASCADE,
+  `space_id` text NOT NULL REFERENCES `spaces`(`id`) ON DELETE CASCADE,
+  `title` text NOT NULL,
+  `body` text,
+  `href` text NOT NULL,
+  `read_at` text,
+  `created_at` text DEFAULT (datetime('now')) NOT NULL
+);
+
+CREATE INDEX `notifications_user_read_idx` ON `notifications` (`user_id`, `read_at`);
+CREATE INDEX `notifications_created_at_idx` ON `notifications` (`created_at`);

--- a/src/components/NotificationCenter.tsx
+++ b/src/components/NotificationCenter.tsx
@@ -1,0 +1,248 @@
+import { useState } from "react";
+import type { PendingInviteForUser } from "../lib/invites";
+import type { UserNotification } from "../lib/notifications";
+import { ToastViewport, useToast } from "./Toast";
+
+interface NotificationCenterProps {
+  invites: PendingInviteForUser[];
+  notifications: UserNotification[];
+}
+
+interface AcceptInviteResponse {
+  success?: boolean;
+  spaceId?: string;
+  error?: string;
+}
+
+interface AcceptedSpace {
+  id: string;
+  name: string;
+}
+
+function formatDate(value: string): string {
+  return new Date(value).toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function getNotificationLabel(type: UserNotification["type"]): string {
+  if (type.startsWith("script_comment")) return "Script feedback";
+  if (type.endsWith("reply")) return "Reply";
+  return "Video comment";
+}
+
+export function NotificationCenter({ invites, notifications }: NotificationCenterProps) {
+  const [pendingInvites, setPendingInvites] = useState(invites);
+  const [commentNotifications, setCommentNotifications] = useState(notifications);
+  const [loadingToken, setLoadingToken] = useState<string | null>(null);
+  const [markingId, setMarkingId] = useState<string | null>(null);
+  const [acceptedSpaces, setAcceptedSpaces] = useState<AcceptedSpace[]>([]);
+  const { toasts, showToast, dismissToast } = useToast();
+
+  const markRead = async (notificationId: string) => {
+    const wasUnread = commentNotifications.some(
+      (notification) => notification.id === notificationId && !notification.readAt,
+    );
+    setMarkingId(notificationId);
+    try {
+      const res = await fetch(`/api/notifications/${notificationId}/read`, {
+        method: "POST",
+      });
+      if (!res.ok) throw new Error("Failed to mark notification read");
+      setCommentNotifications((current) =>
+        current.map((notification) =>
+          notification.id === notificationId
+            ? { ...notification, readAt: notification.readAt ?? new Date().toISOString() }
+            : notification,
+        ),
+      );
+      if (wasUnread) window.dispatchEvent(new CustomEvent("quickcut:notification-read"));
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : "Failed to update notification", "error");
+      throw err;
+    } finally {
+      setMarkingId(null);
+    }
+  };
+
+  const handleOpenNotification = async (notification: UserNotification) => {
+    if (!notification.readAt) {
+      try {
+        await markRead(notification.id);
+      } catch {
+        return;
+      }
+    }
+    window.location.assign(notification.href);
+  };
+
+  const handleAccept = async (invite: PendingInviteForUser) => {
+    setLoadingToken(invite.token);
+
+    try {
+      const res = await fetch(`/api/invites/${invite.token}/accept`, {
+        method: "POST",
+      });
+      const data = (await res.json().catch(() => null)) as AcceptInviteResponse | null;
+
+      if (!res.ok) throw new Error(data?.error || "Failed to accept invite");
+
+      setPendingInvites((current) => current.filter((item) => item.token !== invite.token));
+      setAcceptedSpaces((current) => [
+        { id: data?.spaceId || invite.spaceId, name: invite.spaceName },
+        ...current,
+      ]);
+      window.dispatchEvent(new CustomEvent("quickcut:invite-accepted"));
+      showToast(`Joined ${invite.spaceName}`);
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : "Failed to accept invite", "error");
+    } finally {
+      setLoadingToken(null);
+    }
+  };
+
+  const hasAnyNotifications = pendingInvites.length > 0 || commentNotifications.length > 0;
+
+  return (
+    <>
+      <ToastViewport toasts={toasts} onDismiss={dismissToast} />
+
+      {acceptedSpaces.length > 0 && (
+        <div className="mb-6 space-y-2">
+          {acceptedSpaces.map((space) => (
+            <div key={space.id} className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-accent-success/30 bg-accent-success/10 px-4 py-3 text-sm text-text-primary">
+              <span>
+                You joined <span className="font-medium">{space.name}</span>.
+              </span>
+              <a
+                href={`/dashboard?space=${space.id}`}
+                className="rounded-lg bg-accent-primary px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-accent-hover"
+              >
+                Open space
+              </a>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!hasAnyNotifications ? (
+        <div className="rounded-2xl border border-border-default bg-bg-secondary p-8 text-center">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-bg-tertiary text-text-tertiary">
+            <svg className="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a3 3 0 11-5.714 0" />
+            </svg>
+          </div>
+          <h2 className="text-lg font-semibold text-text-primary">No pending notifications</h2>
+          <p className="mt-2 text-sm text-text-secondary">
+            Space invites, comment activity, and replies will appear here.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-8">
+          {pendingInvites.length > 0 && (
+            <section>
+              <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-text-tertiary">Invites</h2>
+              <ul className="space-y-3">
+                {pendingInvites.map((invite) => {
+                  const isLoading = loadingToken === invite.token;
+
+                  return (
+                    <li key={invite.id} className="rounded-2xl border border-border-default bg-bg-secondary p-5">
+                      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                          <p className="text-sm font-medium text-text-primary">
+                            Invitation to join {invite.spaceName}
+                          </p>
+                          <p className="mt-1 text-sm text-text-secondary">
+                            {invite.inviterDisplayName} invited you to collaborate in this space.
+                          </p>
+                          <p className="mt-1 text-xs text-text-tertiary">
+                            Invited {new Date(invite.createdAt).toLocaleDateString()} by {invite.inviterEmail}
+                          </p>
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                          <a
+                            href={`/invites/${invite.token}`}
+                            className="rounded-lg border border-border-default px-3 py-2 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary"
+                          >
+                            View invite
+                          </a>
+                          <button
+                            type="button"
+                            onClick={() => handleAccept(invite)}
+                            disabled={isLoading || loadingToken !== null}
+                            className="rounded-lg bg-accent-primary px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-50"
+                          >
+                            {isLoading ? "Accepting..." : "Accept Invite"}
+                          </button>
+                        </div>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          )}
+
+          {commentNotifications.length > 0 && (
+            <section>
+              <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-text-tertiary">Comment activity</h2>
+              <ul className="space-y-3">
+                {commentNotifications.map((notification) => {
+                  const unread = !notification.readAt;
+                  const isMarking = markingId === notification.id;
+
+                  return (
+                    <li key={notification.id} className={`rounded-2xl border p-5 ${unread ? "border-accent-primary/40 bg-accent-primary/10" : "border-border-default bg-bg-secondary"}`}>
+                      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                        <button
+                          type="button"
+                          onClick={() => handleOpenNotification(notification)}
+                          className="min-w-0 flex-1 text-left"
+                        >
+                          <div className="flex flex-wrap items-center gap-2">
+                            {unread && <span className="h-2 w-2 rounded-full bg-accent-primary" aria-label="Unread" />}
+                            <span className="rounded-full bg-bg-tertiary px-2 py-0.5 text-xs font-medium text-text-secondary">
+                              {getNotificationLabel(notification.type)}
+                            </span>
+                            <span className="text-xs text-text-tertiary">{formatDate(notification.createdAt)}</span>
+                          </div>
+                          <p className="mt-2 text-sm font-semibold text-text-primary">{notification.title}</p>
+                          {notification.body && (
+                            <p className="mt-1 line-clamp-2 text-sm text-text-secondary">{notification.body}</p>
+                          )}
+                        </button>
+                        <div className="flex flex-wrap gap-2">
+                          {!notification.readAt && (
+                            <button
+                              type="button"
+                              onClick={() => markRead(notification.id)}
+                              disabled={isMarking}
+                              className="rounded-lg border border-border-default px-3 py-2 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary disabled:opacity-50"
+                            >
+                              {isMarking ? "Marking..." : "Mark read"}
+                            </button>
+                          )}
+                          <button
+                            type="button"
+                            onClick={() => handleOpenNotification(notification)}
+                            className="rounded-lg bg-accent-primary px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover"
+                          >
+                            Open
+                          </button>
+                        </div>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -29,7 +29,11 @@ export function UserMenu({ name, email, notificationCount = 0 }: UserMenuProps) 
   useEffect(() => {
     const handler = () => setCount((current) => Math.max(0, current - 1));
     window.addEventListener("quickcut:invite-accepted", handler);
-    return () => window.removeEventListener("quickcut:invite-accepted", handler);
+    window.addEventListener("quickcut:notification-read", handler);
+    return () => {
+      window.removeEventListener("quickcut:invite-accepted", handler);
+      window.removeEventListener("quickcut:notification-read", handler);
+    };
   }, []);
 
   // Close on outside click

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, real, uniqueIndex, type AnySQLiteColumn } from "drizzle-orm/sqlite-core";
+import { index, sqliteTable, text, integer, real, uniqueIndex, type AnySQLiteColumn } from "drizzle-orm/sqlite-core";
 import { sql } from "drizzle-orm";
 
 export const users = sqliteTable("users", {
@@ -344,6 +344,51 @@ export const comments = sqliteTable("comments", {
     .notNull()
     .default(sql`(datetime('now'))`),
 });
+
+export const notifications = sqliteTable(
+  "notifications",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    actorUserId: text("actor_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    actorDisplayName: text("actor_display_name").notNull(),
+    type: text("type", {
+      enum: [
+        "comment.created",
+        "comment.reply",
+        "script_comment.created",
+        "script_comment.reply",
+      ],
+    }).notNull(),
+    videoId: text("video_id")
+      .notNull()
+      .references(() => videos.id, { onDelete: "cascade" }),
+    commentId: text("comment_id")
+      .notNull()
+      .references(() => comments.id, { onDelete: "cascade" }),
+    parentCommentId: text("parent_comment_id").references(() => comments.id, {
+      onDelete: "cascade",
+    }),
+    spaceId: text("space_id")
+      .notNull()
+      .references(() => spaces.id, { onDelete: "cascade" }),
+    title: text("title").notNull(),
+    body: text("body"),
+    href: text("href").notNull(),
+    readAt: text("read_at"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    index("notifications_user_read_idx").on(table.userId, table.readAt),
+    index("notifications_created_at_idx").on(table.createdAt),
+  ],
+);
 
 export const commentReactions = sqliteTable(
   "comment_reactions",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,6 +5,7 @@ import { SpaceSwitcher } from "../components/SpaceSwitcher";
 import Logo from "../components/Logo.astro";
 import { createDb } from "../db";
 import { getPendingInvitesForUser } from "../lib/invites";
+import { getUnreadNotificationCount } from "../lib/notifications";
 import { getUserSpaces } from "../lib/spaces";
 import { env } from "cloudflare:workers";
 
@@ -20,6 +21,7 @@ const metaDescription = description ?? "Quick Cuts - Collaborative video review"
 const db = createDb(env.DB);
 const userSpaces = user ? await getUserSpaces(db, user.id) : [];
 const pendingInviteCount = user ? (await getPendingInvitesForUser(db, user.email)).length : 0;
+const unreadNotificationCount = user ? await getUnreadNotificationCount(db, user.id) : 0;
 const headerSpaceId = selectedSpaceId ?? Astro.url.searchParams.get("space") ?? userSpaces[0]?.id ?? null;
 ---
 
@@ -48,7 +50,7 @@ const headerSpaceId = selectedSpaceId ?? Astro.url.searchParams.get("space") ?? 
           </a>
           <div class="ml-auto flex items-center gap-3">
             <SpaceSwitcher client:load spaces={userSpaces} selectedSpaceId={headerSpaceId} />
-            <UserMenu client:load name={user.name} email={user.email} notificationCount={pendingInviteCount} />
+            <UserMenu client:load name={user.name} email={user.email} notificationCount={pendingInviteCount + unreadNotificationCount} />
           </div>
         </header>
       )

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,199 @@
+import { and, desc, eq, inArray, isNull } from "drizzle-orm";
+import type { Database } from "../db";
+import { comments, notifications, spaceMembers, spaces, videos } from "../db/schema";
+
+export type NotificationType =
+  | "comment.created"
+  | "comment.reply"
+  | "script_comment.created"
+  | "script_comment.reply";
+
+export interface CommentNotificationInput {
+  commentId: string;
+  videoId: string;
+  actorUserId: string | null;
+  actorDisplayName: string;
+  text: string;
+  parentCommentId: string | null;
+  phase: "script" | "review";
+}
+
+export interface UserNotification {
+  id: string;
+  actorDisplayName: string;
+  type: NotificationType;
+  videoId: string;
+  commentId: string;
+  parentCommentId: string | null;
+  spaceId: string;
+  title: string;
+  body: string | null;
+  href: string;
+  readAt: string | null;
+  createdAt: string;
+}
+
+function snippet(text: string): string {
+  const normalized = text.trim().replace(/\s+/g, " ");
+  return normalized.length > 160 ? `${normalized.slice(0, 157)}...` : normalized;
+}
+
+function getNotificationType(input: CommentNotificationInput): NotificationType {
+  if (input.phase === "script") {
+    return input.parentCommentId ? "script_comment.reply" : "script_comment.created";
+  }
+
+  return input.parentCommentId ? "comment.reply" : "comment.created";
+}
+
+function getTitle(type: NotificationType, actorName: string, videoTitle: string): string {
+  if (type === "script_comment.created") return `${actorName} left script feedback on "${videoTitle}"`;
+  if (type === "script_comment.reply") return `${actorName} replied to your script comment on "${videoTitle}"`;
+  if (type === "comment.reply") return `${actorName} replied to your comment on "${videoTitle}"`;
+  return `${actorName} commented on "${videoTitle}"`;
+}
+
+async function filterRecipientsWithSpaceAccess(
+  db: Database,
+  recipientIds: string[],
+  spaceId: string,
+): Promise<string[]> {
+  const uniqueRecipientIds = [...new Set(recipientIds.filter(Boolean))];
+  if (uniqueRecipientIds.length === 0) return [];
+
+  const rows = await db
+    .select({ userId: spaceMembers.userId })
+    .from(spaceMembers)
+    .where(
+      and(
+        eq(spaceMembers.spaceId, spaceId),
+        inArray(spaceMembers.userId, uniqueRecipientIds),
+      ),
+    );
+
+  return rows.map((row) => row.userId);
+}
+
+export async function createCommentNotifications(
+  db: Database,
+  input: CommentNotificationInput,
+): Promise<void> {
+  const videoRows = await db
+    .select({
+      id: videos.id,
+      title: videos.title,
+      uploadedBy: videos.uploadedBy,
+      spaceId: videos.spaceId,
+      spaceOwnerId: spaces.ownerId,
+    })
+    .from(videos)
+    .innerJoin(spaces, eq(videos.spaceId, spaces.id))
+    .where(eq(videos.id, input.videoId))
+    .limit(1);
+
+  const video = videoRows[0];
+  if (!video) return;
+
+  let candidateRecipientIds: string[] = [];
+  if (input.parentCommentId) {
+    const parentRows = await db
+      .select({ authorUserId: comments.authorUserId })
+      .from(comments)
+      .where(eq(comments.id, input.parentCommentId))
+      .limit(1);
+    const parentAuthorId = parentRows[0]?.authorUserId;
+    if (parentAuthorId) candidateRecipientIds = [parentAuthorId];
+  } else {
+    candidateRecipientIds = [video.uploadedBy, video.spaceOwnerId].filter(
+      (id): id is string => Boolean(id),
+    );
+  }
+
+  const recipientIds = await filterRecipientsWithSpaceAccess(
+    db,
+    candidateRecipientIds.filter((id) => id !== input.actorUserId),
+    video.spaceId,
+  );
+
+  if (recipientIds.length === 0) return;
+
+  const type = getNotificationType(input);
+  const href = `/videos/${video.id}?tab=${input.phase === "script" ? "script" : "video"}&comment=${input.commentId}`;
+  const title = getTitle(type, input.actorDisplayName, video.title);
+  const body = snippet(input.text);
+
+  await db.insert(notifications).values(
+    recipientIds.map((userId) => ({
+      id: crypto.randomUUID(),
+      userId,
+      actorUserId: input.actorUserId,
+      actorDisplayName: input.actorDisplayName,
+      type,
+      videoId: video.id,
+      commentId: input.commentId,
+      parentCommentId: input.parentCommentId,
+      spaceId: video.spaceId,
+      title,
+      body,
+      href,
+    })),
+  );
+}
+
+export async function getNotificationsForUser(
+  db: Database,
+  userId: string,
+): Promise<UserNotification[]> {
+  return db
+    .select({
+      id: notifications.id,
+      actorDisplayName: notifications.actorDisplayName,
+      type: notifications.type,
+      videoId: notifications.videoId,
+      commentId: notifications.commentId,
+      parentCommentId: notifications.parentCommentId,
+      spaceId: notifications.spaceId,
+      title: notifications.title,
+      body: notifications.body,
+      href: notifications.href,
+      readAt: notifications.readAt,
+      createdAt: notifications.createdAt,
+    })
+    .from(notifications)
+    .where(eq(notifications.userId, userId))
+    .orderBy(desc(notifications.createdAt));
+}
+
+export async function getUnreadNotificationCount(
+  db: Database,
+  userId: string,
+): Promise<number> {
+  const rows = await db
+    .select({ id: notifications.id })
+    .from(notifications)
+    .where(and(eq(notifications.userId, userId), isNull(notifications.readAt)));
+
+  return rows.length;
+}
+
+export async function markNotificationRead(
+  db: Database,
+  notificationId: string,
+  userId: string,
+): Promise<boolean> {
+  const existing = await db
+    .select({ id: notifications.id, readAt: notifications.readAt })
+    .from(notifications)
+    .where(and(eq(notifications.id, notificationId), eq(notifications.userId, userId)))
+    .limit(1);
+
+  if (existing.length === 0) return false;
+  if (!existing[0].readAt) {
+    await db
+      .update(notifications)
+      .set({ readAt: new Date().toISOString() })
+      .where(eq(notifications.id, notificationId));
+  }
+
+  return true;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,7 +13,7 @@ declare global {
 }
 
 const protectedRoutes = ["/dashboard", "/notifications", "/upload", "/videos/", "/spaces/"];
-const authApiRoutes = ["/api/videos", "/api/comments", "/api/spaces", "/api/invites"];
+const authApiRoutes = ["/api/videos", "/api/comments", "/api/spaces", "/api/invites", "/api/notifications"];
 
 export const onRequest = defineMiddleware(async (context, next) => {
   context.locals.user = null;

--- a/src/pages/api/comments/[id]/reply.ts
+++ b/src/pages/api/comments/[id]/reply.ts
@@ -4,6 +4,7 @@ import { createDb } from "../../../../db";
 import { comments, videos } from "../../../../db/schema";
 import { eq } from "drizzle-orm";
 import { broadcastNewComment } from "../../../../lib/broadcast";
+import { createCommentNotifications } from "../../../../lib/notifications";
 import { verifySpaceAccess } from "../../../../lib/spaces";
 
 export const POST: APIRoute = async ({ params, locals, request }) => {
@@ -91,6 +92,20 @@ export const POST: APIRoute = async ({ params, locals, request }) => {
   };
 
   await db.insert(comments).values(newReply);
+
+  try {
+    await createCommentNotifications(db, {
+      commentId,
+      videoId: parent[0].videoId,
+      actorUserId: locals.user.id,
+      actorDisplayName: locals.user.name,
+      text: newReply.text,
+      parentCommentId: parentId,
+      phase: parent[0].phase,
+    });
+  } catch (err) {
+    console.error("Failed to create reply notification", err);
+  }
 
   const responseComment = {
     ...newReply,

--- a/src/pages/api/notifications/[id]/read.ts
+++ b/src/pages/api/notifications/[id]/read.ts
@@ -1,0 +1,35 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { createDb } from "../../../../db";
+import { markNotificationRead } from "../../../../lib/notifications";
+
+export const POST: APIRoute = async ({ params, locals }) => {
+  if (!locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { id } = params;
+  if (!id) {
+    return new Response(JSON.stringify({ error: "Notification ID required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const db = createDb(env.DB);
+  const found = await markNotificationRead(db, id, locals.user.id);
+
+  if (!found) {
+    return new Response(JSON.stringify({ error: "Notification not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  return new Response(JSON.stringify({ success: true }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/src/pages/api/share/[token]/comments.ts
+++ b/src/pages/api/share/[token]/comments.ts
@@ -5,6 +5,7 @@ import { shareLinks, comments, users } from "../../../../db/schema";
 import { eq, asc, gt, and } from "drizzle-orm";
 import { broadcastNewComment } from "../../../../lib/broadcast";
 import { addReactionSummaries } from "../../../../lib/comments";
+import { createCommentNotifications } from "../../../../lib/notifications";
 
 export const GET: APIRoute = async ({ params, url }) => {
   const { token } = params;
@@ -134,6 +135,23 @@ export const POST: APIRoute = async ({ params, request }) => {
       : "suggestion";
 
   const commentId = crypto.randomUUID();
+  let parentPhase: "script" | "review" = "review";
+  if (isReply && parentId) {
+    const parentRows = await db
+      .select({ phase: comments.phase })
+      .from(comments)
+      .where(and(eq(comments.id, parentId), eq(comments.videoId, videoId)))
+      .limit(1);
+
+    if (parentRows.length === 0) {
+      return new Response(JSON.stringify({ error: "Parent comment not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    parentPhase = parentRows[0].phase;
+  }
+
   const newComment = {
     id: commentId,
     videoId,
@@ -146,11 +164,28 @@ export const POST: APIRoute = async ({ params, request }) => {
     isResolved: false,
     resolvedBy: null,
     resolvedAt: null,
+    resolvedReason: null,
     annotation: annotation ? JSON.stringify(annotation) : null,
     urgency: commentUrgency,
+    phase: parentPhase,
+    textRange: null,
   };
 
   await db.insert(comments).values(newComment);
+
+  try {
+    await createCommentNotifications(db, {
+      commentId,
+      videoId,
+      actorUserId: null,
+      actorDisplayName: newComment.authorDisplayName,
+      text: newComment.text,
+      parentCommentId: newComment.parentId,
+      phase: newComment.phase,
+    });
+  } catch (err) {
+    console.error("Failed to create share comment notification", err);
+  }
 
   const responseComment = {
     ...newComment,

--- a/src/pages/api/videos/[id]/comments.ts
+++ b/src/pages/api/videos/[id]/comments.ts
@@ -6,6 +6,7 @@ import { eq, asc, gt, and } from "drizzle-orm";
 import { broadcastNewComment } from "../../../../lib/broadcast";
 import { verifySpaceAccess } from "../../../../lib/spaces";
 import { addReactionSummaries } from "../../../../lib/comments";
+import { createCommentNotifications } from "../../../../lib/notifications";
 import { commentSchema } from "../../../../lib/validation";
 
 export const GET: APIRoute = async ({ params, locals, url }) => {
@@ -173,6 +174,20 @@ export const POST: APIRoute = async ({ params, locals, request }) => {
   };
 
   await db.insert(comments).values(newComment);
+
+  try {
+    await createCommentNotifications(db, {
+      commentId,
+      videoId: id,
+      actorUserId: locals.user.id,
+      actorDisplayName: locals.user.name,
+      text: newComment.text,
+      parentCommentId: null,
+      phase,
+    });
+  } catch (err) {
+    console.error("Failed to create comment notification", err);
+  }
 
   const responseComment = {
     ...newComment,

--- a/src/pages/notifications.astro
+++ b/src/pages/notifications.astro
@@ -1,8 +1,9 @@
 ---
 import Layout from "../layouts/Layout.astro";
-import { PendingInvitesList } from "../components/PendingInvitesList";
+import { NotificationCenter } from "../components/NotificationCenter";
 import { createDb } from "../db";
 import { getPendingInvitesForUser } from "../lib/invites";
+import { getNotificationsForUser } from "../lib/notifications";
 import { env } from "cloudflare:workers";
 
 const user = Astro.locals.user;
@@ -10,6 +11,7 @@ if (!user) return Astro.redirect("/login");
 
 const db = createDb(env.DB);
 const pendingInvites = await getPendingInvitesForUser(db, user.email);
+const notifications = await getNotificationsForUser(db, user.id);
 ---
 
 <Layout title="Notifications" user={user}>
@@ -17,10 +19,10 @@ const pendingInvites = await getPendingInvitesForUser(db, user.email);
     <div class="mb-8">
       <h1 class="text-2xl font-bold text-text-primary">Notifications</h1>
       <p class="mt-1 text-sm text-text-secondary">
-        Review pending space invites for your account.
+        Review pending invites and recent comment activity.
       </p>
     </div>
 
-    <PendingInvitesList client:load invites={pendingInvites} />
+    <NotificationCenter client:load invites={pendingInvites} notifications={notifications} />
   </div>
 </Layout>


### PR DESCRIPTION
## Summary
- Add persisted in-app notifications for video comments, script feedback, and replies.
- Update the notification center and header badge to include unread comment notifications alongside pending invites.
- Add read-state handling and protect the notification read API.

## Verification
- `CLOUDFLARE_ACCOUNT_ID=4426cbeacb457b1ca1b865d6c36ced0d pnpm build`

Closes #42

Follow-up: #45 tracks future email notification delivery.