### PR TITLE
Fix status dropdown spacing and create reusable Dropdown component

### DIFF
--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,0 +1,216 @@
+import { useState, useRef, useEffect, useCallback, type ReactNode } from "react";
+
+export interface DropdownOption<T extends string = string> {
+  value: T;
+  label: string;
+  disabled?: boolean;
+  icon?: ReactNode;
+  iconRight?: ReactNode;
+}
+
+type DropdownSize = "sm" | "md";
+
+interface DropdownProps<T extends string = string> {
+  options: DropdownOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  disabled?: boolean;
+  size?: DropdownSize;
+  placeholder?: string;
+  className?: string;
+  menuAlign?: "left" | "right";
+  menuWidth?: string;
+  id?: string;
+}
+
+const sizeClasses: Record<DropdownSize, { trigger: string; option: string }> = {
+  sm: {
+    trigger: "px-3 py-1.5 text-xs",
+    option: "px-3 py-1.5 text-xs",
+  },
+  md: {
+    trigger: "px-4 py-2 text-sm",
+    option: "px-3 py-2 text-sm",
+  },
+};
+
+export function Dropdown<T extends string = string>({
+  options,
+  value,
+  onChange,
+  disabled = false,
+  size = "md",
+  placeholder = "Select...",
+  className = "",
+  menuAlign = "right",
+  menuWidth = "w-48",
+  id,
+}: DropdownProps<T>) {
+  const [open, setOpen] = useState(false);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const selected = options.find((opt) => opt.value === value);
+  const enabledOptions = options.filter((opt) => !opt.disabled);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  // Scroll focused option into view
+  useEffect(() => {
+    if (!open || focusedIndex < 0 || !listRef.current) return;
+    const items = listRef.current.querySelectorAll('[role="option"]');
+    items[focusedIndex]?.scrollIntoView({ block: "nearest" });
+  }, [focusedIndex, open]);
+
+  const handleSelect = useCallback(
+    (optionValue: T) => {
+      if (optionValue === value) {
+        setOpen(false);
+        return;
+      }
+      onChange(optionValue);
+      setOpen(false);
+    },
+    [onChange, value],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (disabled) return;
+
+      switch (e.key) {
+        case "Enter":
+        case " ": {
+          e.preventDefault();
+          if (!open) {
+            setOpen(true);
+            setFocusedIndex(enabledOptions.findIndex((opt) => opt.value === value));
+          } else if (focusedIndex >= 0 && focusedIndex < enabledOptions.length) {
+            handleSelect(enabledOptions[focusedIndex].value);
+          }
+          break;
+        }
+        case "Escape": {
+          e.preventDefault();
+          setOpen(false);
+          break;
+        }
+        case "ArrowDown": {
+          e.preventDefault();
+          if (!open) {
+            setOpen(true);
+            setFocusedIndex(enabledOptions.findIndex((opt) => opt.value === value));
+          } else {
+            setFocusedIndex((prev) => Math.min(prev + 1, enabledOptions.length - 1));
+          }
+          break;
+        }
+        case "ArrowUp": {
+          e.preventDefault();
+          if (open) {
+            setFocusedIndex((prev) => Math.max(prev - 1, 0));
+          }
+          break;
+        }
+      }
+    },
+    [disabled, enabledOptions, focusedIndex, handleSelect, open, value],
+  );
+
+  const toggle = () => {
+    if (disabled) return;
+    setOpen((prev) => {
+      if (!prev) {
+        setFocusedIndex(enabledOptions.findIndex((opt) => opt.value === value));
+      }
+      return !prev;
+    });
+  };
+
+  const styles = sizeClasses[size];
+
+  return (
+    <div ref={containerRef} className={`relative ${className}`}>
+      <button
+        type="button"
+        id={id}
+        onClick={toggle}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className={`inline-flex w-full items-center justify-between gap-2 rounded-lg border border-border-default bg-bg-secondary font-medium text-text-secondary transition-colors hover:border-border-hover hover:text-text-primary disabled:opacity-50 ${styles.trigger}`}
+      >
+        <span className="truncate">{selected?.label ?? placeholder}</span>
+        <svg
+          className="h-3.5 w-3.5 shrink-0"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {open && (
+        <ul
+          ref={listRef}
+          role="listbox"
+          aria-activedescendant={
+            focusedIndex >= 0 ? `dropdown-option-${enabledOptions[focusedIndex]?.value}` : undefined
+          }
+          className={`absolute ${menuAlign === "right" ? "right-0" : "left-0"} z-30 mt-1 ${menuWidth} overflow-auto rounded-lg border border-border-default bg-bg-secondary py-1 shadow-lg`}
+        >
+          {options.map((option) => {
+            const isCurrent = option.value === value;
+            const enabledIdx = enabledOptions.indexOf(option);
+            const isFocused = enabledIdx === focusedIndex;
+
+            return (
+              <li
+                key={option.value}
+                id={`dropdown-option-${option.value}`}
+                role="option"
+                aria-selected={isCurrent}
+                aria-disabled={option.disabled}
+                onClick={() => {
+                  if (!option.disabled) handleSelect(option.value);
+                }}
+                onMouseEnter={() => {
+                  if (!option.disabled && enabledIdx >= 0) setFocusedIndex(enabledIdx);
+                }}
+                className={`flex w-full cursor-pointer items-center gap-2 transition-colors ${styles.option} ${
+                  isCurrent
+                    ? "font-medium text-accent-primary"
+                    : option.disabled
+                      ? "cursor-not-allowed text-text-tertiary opacity-50"
+                      : isFocused
+                        ? "bg-bg-tertiary text-text-primary"
+                        : "text-text-secondary hover:bg-bg-tertiary hover:text-text-primary"
+                }`}
+              >
+                {option.icon}
+                <span className="flex-1 truncate">{option.label}</span>
+                {option.iconRight}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/MoveToFolderDialog.tsx
+++ b/src/components/MoveToFolderDialog.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useId, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import { Modal } from "./Modal";
+import { Dropdown, type DropdownOption } from "./Dropdown";
 
 interface Folder {
   id: string;
@@ -110,7 +111,18 @@ export function MoveToFolderDialog({
     }
   };
 
-  const options = buildFolderOptions(folders, entityType === "folder" ? entityId : undefined);
+  const treeOptions = buildFolderOptions(folders, entityType === "folder" ? entityId : undefined);
+
+  const dropdownOptions: DropdownOption[] = useMemo(
+    () => [
+      { value: "root", label: "All Videos" },
+      ...treeOptions.map((folder) => ({
+        value: folder.id,
+        label: `${"  ".repeat(folder.depth)}${folder.depth > 0 ? "- " : ""}${folder.name}`,
+      })),
+    ],
+    [treeOptions],
+  );
 
   return (
     <Modal
@@ -133,20 +145,15 @@ export function MoveToFolderDialog({
         <label className="block text-sm font-medium text-text-secondary" htmlFor="folder-select">
           Destination
         </label>
-        <select
+        <Dropdown
           id="folder-select"
+          options={dropdownOptions}
           value={selectedFolderId}
-          onChange={(e) => setSelectedFolderId(e.target.value)}
+          onChange={setSelectedFolderId}
           disabled={loading || saving}
-          className="w-full rounded-lg border border-border-default bg-bg-input px-3 py-2.5 text-sm text-text-primary focus:border-accent-primary focus:outline-none disabled:opacity-50"
-        >
-          <option value="root">All Videos</option>
-          {options.map((folder) => (
-            <option key={folder.id} value={folder.id}>
-              {`${"  ".repeat(folder.depth)}${folder.depth > 0 ? "- " : ""}${folder.name}`}
-            </option>
-          ))}
-        </select>
+          menuAlign="left"
+          menuWidth="w-full"
+        />
       </div>
 
       {error && (

--- a/src/components/PhaseDropdown.tsx
+++ b/src/components/PhaseDropdown.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { VIDEO_PHASES, PHASE_LABELS, normalizeVideoPhase, type VideoPhase } from "../types";
+import { Dropdown, type DropdownOption } from "./Dropdown";
 
 interface PhaseDropdownProps {
   videoId: string;
@@ -16,40 +17,37 @@ export function PhaseDropdown({
   enabledPhases,
   onPhaseChange,
 }: PhaseDropdownProps) {
-  const [open, setOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [confirmPublish, setConfirmPublish] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
+  const confirmRef = useRef<HTMLDivElement>(null);
   const normalizedPhase = normalizeVideoPhase(currentPhase);
   const enabledPhaseSet = new Set(enabledPhases ?? VIDEO_PHASES);
 
-  // Close dropdown on outside click
+  // Close publish confirmation on outside click
   useEffect(() => {
+    if (!confirmPublish) return;
     const handleClickOutside = (e: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setOpen(false);
+      if (confirmRef.current && !confirmRef.current.contains(e.target as Node)) {
         setConfirmPublish(false);
       }
     };
-    if (open) {
-      document.addEventListener("mousedown", handleClickOutside);
-      return () => document.removeEventListener("mousedown", handleClickOutside);
-    }
-  }, [open]);
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [confirmPublish]);
 
   const handleSelect = async (phase: VideoPhase) => {
-    if (phase === normalizedPhase) {
-      setOpen(false);
-      return;
-    }
+    if (phase === normalizedPhase) return;
     if (!enabledPhaseSet.has(phase)) return;
 
-    // Confirm before publishing
-    if (phase === "published" && !confirmPublish) {
+    if (phase === "published") {
       setConfirmPublish(true);
       return;
     }
 
+    await savePhase(phase);
+  };
+
+  const savePhase = async (phase: VideoPhase) => {
     setSaving(true);
     setConfirmPublish(false);
 
@@ -66,93 +64,80 @@ export function PhaseDropdown({
       console.error("Phase update failed:", err);
     } finally {
       setSaving(false);
-      setOpen(false);
     }
   };
 
   if (!canChangePhase) return null;
 
-  return (
-    <div ref={dropdownRef} className="relative w-full sm:flex-1 lg:w-44 lg:flex-none">
-      <button
-        type="button"
-        onClick={() => {
-          setOpen(!open);
-          setConfirmPublish(false);
-        }}
-        disabled={saving}
-        className="inline-flex w-full items-center justify-center gap-1.5 rounded-lg border border-border-default bg-bg-secondary px-4 py-2 text-sm font-medium text-text-secondary transition-colors hover:border-border-hover hover:text-text-primary disabled:opacity-50"
-      >
-        {saving ? "Saving..." : PHASE_LABELS[normalizedPhase]}
-        <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <polyline points="6 9 12 15 18 9" />
+  const options: DropdownOption<VideoPhase>[] = VIDEO_PHASES.map((phase) => ({
+    value: phase,
+    label: saving && phase === normalizedPhase ? "Saving..." : PHASE_LABELS[phase],
+    disabled: !enabledPhaseSet.has(phase) || phase === normalizedPhase,
+    icon:
+      phase === normalizedPhase ? (
+        <svg className="h-3 w-3 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+          <path
+            fillRule="evenodd"
+            d="M16.704 5.296a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L8 12.586l7.29-7.29a1 1 0 011.414 0z"
+            clipRule="evenodd"
+          />
         </svg>
-      </button>
+      ) : (
+        <span className="inline-block w-3" />
+      ),
+    iconRight:
+      phase === "published" ? (
+        <svg
+          className="h-3 w-3 text-text-tertiary"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+          <path d="M7 11V7a5 5 0 0110 0v4" />
+        </svg>
+      ) : undefined,
+  }));
 
-      {open && (
-        <div className="absolute right-0 z-20 mt-1 w-48 rounded-lg border border-border-default bg-bg-secondary shadow-lg">
-          {confirmPublish ? (
-            <div className="p-3">
-              <p className="text-xs text-text-secondary">
-                Marking this project as published locks the script, comments, and versions. This assumes you have published the video manually elsewhere.
-              </p>
-              <div className="mt-2 flex gap-2">
-                <button
-                  type="button"
-                  onClick={() => handleSelect("published")}
-                  className="rounded-md bg-accent-secondary px-2.5 py-1 text-xs font-medium text-white hover:bg-accent-secondary/90"
-                >
-                  Confirm
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setConfirmPublish(false)}
-                  className="rounded-md px-2.5 py-1 text-xs text-text-tertiary hover:text-text-secondary"
-                >
-                  Cancel
-                </button>
-              </div>
-            </div>
-          ) : (
-            <ul className="py-1">
-              {VIDEO_PHASES.map((phase) => {
-                const isEnabled = enabledPhaseSet.has(phase);
-                return <li key={phase}>
-                  <button
-                    type="button"
-                    onClick={() => handleSelect(phase)}
-                    disabled={phase === normalizedPhase || !isEnabled}
-                    className={`flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors ${
-                      phase === normalizedPhase
-                        ? "text-accent-primary font-medium cursor-default"
-                        : !isEnabled
-                          ? "cursor-not-allowed text-text-tertiary opacity-50"
-                        : "text-text-secondary hover:bg-bg-tertiary hover:text-text-primary"
-                    }`}
-                  >
-                    {phase === normalizedPhase && (
-                      <svg className="h-3 w-3 shrink-0" viewBox="0 0 20 20" fill="currentColor">
-                        <path
-                          fillRule="evenodd"
-                          d="M16.704 5.296a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L8 12.586l7.29-7.29a1 1 0 011.414 0z"
-                          clipRule="evenodd"
-                        />
-                      </svg>
-                    )}
-                    <span className={phase !== normalizedPhase ? "ml-5" : ""}>
-                      {PHASE_LABELS[phase]}
-                    </span>
-                    {phase === "published" && (
-                      <svg className="ml-auto h-3 w-3 text-text-tertiary" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-                        <path d="M7 11V7a5 5 0 0110 0v4" />
-                      </svg>
-                    )}
-                  </button>
-                </li>;
-              })}
-            </ul>
-          )}
+  return (
+    <div className="relative w-full sm:flex-1 lg:w-44 lg:flex-none">
+      <Dropdown
+        options={options}
+        value={normalizedPhase}
+        onChange={handleSelect}
+        disabled={saving}
+        size="md"
+        menuWidth="w-48"
+      />
+
+      {confirmPublish && (
+        <div
+          ref={confirmRef}
+          className="absolute right-0 z-30 mt-1 w-48 rounded-lg border border-border-default bg-bg-secondary p-3 shadow-lg"
+        >
+          <p className="text-xs text-text-secondary">
+            Marking this project as published locks the script, comments, and versions. This assumes
+            you have published the video manually elsewhere.
+          </p>
+          <div className="mt-2 flex gap-2">
+            <button
+              type="button"
+              onClick={() => savePhase("published")}
+              className="rounded-md bg-accent-secondary px-2.5 py-1 text-xs font-medium text-white hover:bg-accent-secondary/90"
+            >
+              Confirm
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirmPublish(false)}
+              className="rounded-md px-2.5 py-1 text-xs text-text-tertiary hover:text-text-secondary"
+            >
+              Cancel
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/src/components/PipelineBoard.tsx
+++ b/src/components/PipelineBoard.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { PHASE_LABELS, VIDEO_PHASES, type VideoPhase } from "../types";
 import type { DashboardVideo } from "./dashboard-types";
+import { Dropdown, type DropdownOption } from "./Dropdown";
 
 interface PipelineBoardProps {
   initialVideos: DashboardVideo[];
@@ -34,6 +35,11 @@ function getRiskLabel(video: DashboardVideo) {
   if (daysUntil <= 3 && video.phase !== "published") return "At risk";
   return null;
 }
+
+const phaseOptions: DropdownOption<VideoPhase>[] = VIDEO_PHASES.map((phase) => ({
+  value: phase,
+  label: PHASE_LABELS[phase],
+}));
 
 export function PipelineBoard({ initialVideos, spaceId }: PipelineBoardProps) {
   const [videos, setVideos] = useState(initialVideos);
@@ -118,19 +124,20 @@ export function PipelineBoard({ initialVideos, spaceId }: PipelineBoardProps) {
                           </div>
                         </div>
                       </a>
-                      <label className="mt-3 block text-xs text-text-tertiary">
-                        Move to
-                        <select
-                          value={video.phase}
-                          onChange={(event) => moveVideo(video, event.target.value as VideoPhase)}
-                          disabled={movingId === video.id}
-                          className="mt-1 w-full rounded-md border border-border-default bg-bg-input px-2 py-1.5 text-xs text-text-primary focus:border-accent-primary focus:outline-none disabled:opacity-50"
-                        >
-                          {VIDEO_PHASES.map((option) => (
-                            <option key={option} value={option}>{PHASE_LABELS[option]}</option>
-                          ))}
-                        </select>
-                      </label>
+                      <div className="mt-3">
+                        <span className="block text-xs text-text-tertiary">Move to</span>
+                        <div className="mt-1">
+                          <Dropdown
+                            options={phaseOptions}
+                            value={video.phase as VideoPhase}
+                            onChange={(phase) => moveVideo(video, phase)}
+                            disabled={movingId === video.id}
+                            size="sm"
+                            menuAlign="left"
+                            menuWidth="w-full"
+                          />
+                        </div>
+                      </div>
                     </article>
                   );
                 })}

--- a/src/components/ProjectStatusControls.tsx
+++ b/src/components/ProjectStatusControls.tsx
@@ -75,7 +75,6 @@ export function ProjectStatusControls({
           disabled={!canEdit || saving || isPublished}
           menuAlign="left"
         />
-        {saving && <span className="text-xs text-text-tertiary">Saving...</span>}
       </div>
     </div>
   );

--- a/src/components/ProjectStatusControls.tsx
+++ b/src/components/ProjectStatusControls.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { PROJECT_STATUS_LABELS, PROJECT_STATUSES, normalizeVideoPhase, type ProjectStatus } from "../types";
+import { Dropdown, type DropdownOption } from "./Dropdown";
 
 interface ProjectStatusControlsProps {
   videoId: string;
@@ -42,25 +43,25 @@ export function ProjectStatusControls({
     }
   };
 
+  const options: DropdownOption<ProjectStatus>[] = PROJECT_STATUSES.map((option) => ({
+    value: option,
+    label: PROJECT_STATUS_LABELS[option],
+  }));
+
   return (
     <div className="flex flex-col gap-1.5">
       <label htmlFor="project-status" className="sr-only">
         Status
       </label>
       <div className="flex items-center gap-2">
-        <select
+        <Dropdown
           id="project-status"
+          options={options}
           value={status}
-          onChange={(event) => updateStatus(event.target.value as ProjectStatus)}
+          onChange={updateStatus}
           disabled={!canEdit || saving || isPublished}
-          className="rounded-lg border border-border-default bg-bg-input px-3 py-2 text-sm text-text-primary focus:border-accent-primary focus:outline-none disabled:opacity-50"
-        >
-          {PROJECT_STATUSES.map((option) => (
-            <option key={option} value={option}>
-              {PROJECT_STATUS_LABELS[option]}
-            </option>
-          ))}
-        </select>
+          menuAlign="left"
+        />
         {saving && <span className="text-xs text-text-tertiary">Saving...</span>}
       </div>
     </div>

--- a/src/components/ProjectStatusControls.tsx
+++ b/src/components/ProjectStatusControls.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { PROJECT_STATUS_LABELS, PROJECT_STATUSES, normalizeVideoPhase, type ProjectStatus } from "../types";
 import { Dropdown, type DropdownOption } from "./Dropdown";
 import { ToastViewport, useToast } from "./Toast";
@@ -21,14 +21,6 @@ export function ProjectStatusControls({
   const { toasts, showToast, dismissToast } = useToast();
   const isPublished = status === "published";
 
-  useEffect(() => {
-    const message = window.sessionStorage.getItem("quickcut:status-toast");
-    if (!message) return;
-
-    window.sessionStorage.removeItem("quickcut:status-toast");
-    showToast(message);
-  }, [showToast]);
-
   const updateStatus = async (nextStatus: ProjectStatus) => {
     if (nextStatus === status || saving) return;
     if (nextStatus === "published" && !window.confirm("Publishing locks the project. Script, comments, and video versions become read-only.")) {
@@ -45,8 +37,7 @@ export function ProjectStatusControls({
       if (!res.ok) throw new Error("Failed to update project status");
       setStatus(nextStatus);
       onStatusChange?.(nextStatus);
-      window.sessionStorage.setItem("quickcut:status-toast", "Status successfully updated");
-      window.location.reload();
+      showToast("Status successfully updated");
     } catch (err) {
       console.error(err);
       showToast("Failed to update status", "error");

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -18,7 +18,7 @@ export function useToast() {
   const showToast = (message: string, variant: ToastVariant = "success") => {
     const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
     setToasts((current) => [...current, { id, message, variant }]);
-    setTimeout(() => dismissToast(id), 3000);
+    setTimeout(() => dismissToast(id), 5000);
   };
 
   return { toasts, showToast, dismissToast };

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -18,7 +18,7 @@ export function useToast() {
   const showToast = (message: string, variant: ToastVariant = "success") => {
     const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
     setToasts((current) => [...current, { id, message, variant }]);
-    setTimeout(() => dismissToast(id), 5000);
+    setTimeout(() => dismissToast(id), 3000);
   };
 
   return { toasts, showToast, dismissToast };

--- a/src/components/UploadForm.tsx
+++ b/src/components/UploadForm.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useMemo } from "react";
+import { Dropdown, type DropdownOption } from "./Dropdown";
 
 const ALLOWED_EXTENSIONS = ["mp4", "mov", "webm", "avi", "mkv"];
 const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024; // 5GB
@@ -23,6 +24,11 @@ export function UploadForm({ folderId = null, spaces, selectedSpaceId, transcrip
   const [error, setError] = useState("");
   const [dragOver, setDragOver] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const spaceOptions: DropdownOption[] = useMemo(
+    () => spaces.map((space) => ({ value: space.id, label: `${space.name} (${space.role})` })),
+    [spaces],
+  );
 
   const validateFile = (f: File): string | null => {
     const ext = f.name.split(".").pop()?.toLowerCase();
@@ -223,19 +229,15 @@ export function UploadForm({ folderId = null, spaces, selectedSpaceId, transcrip
           <div className="space-y-4">
             <div>
               <label className="mb-1 block text-sm font-medium text-text-secondary" htmlFor="upload-space">Space</label>
-              <select
+              <Dropdown
                 id="upload-space"
+                options={spaceOptions}
                 value={spaceId}
-                onChange={(e) => setSpaceId(e.target.value)}
+                onChange={setSpaceId}
                 disabled={state === "uploading"}
-                className="w-full rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary focus:border-accent-primary focus:outline-none disabled:opacity-50"
-              >
-                {spaces.map((space) => (
-                  <option key={space.id} value={space.id}>
-                    {space.name} ({space.role})
-                  </option>
-                ))}
-              </select>
+                menuAlign="left"
+                menuWidth="w-full"
+              />
             </div>
             <div>
               <label className="mb-1 block text-sm font-medium text-text-secondary">Title</label>


### PR DESCRIPTION
## Summary

- Creates a reusable `Dropdown` component (`src/components/Dropdown.tsx`) with consistent padding between the label and chevron icon, keyboard navigation (Arrow keys, Enter, Space, Escape), and proper ARIA attributes (`role="listbox"`, `aria-expanded`, `aria-selected`)
- Replaces all 5 inline dropdown implementations with the reusable component: `PhaseDropdown`, `ProjectStatusControls`, `PipelineBoard`, `UploadForm`, and `MoveToFolderDialog`
- Fixes the caret/chevron spacing issue by using `justify-between` with `gap-2` on the trigger button, ensuring consistent right padding across all dropdowns

## Changes

| File | What changed |
|------|-------------|
| `src/components/Dropdown.tsx` | New reusable component with configurable size, alignment, icons, and disabled states |
| `src/components/PhaseDropdown.tsx` | Refactored to use `Dropdown`; preserves publish confirmation flow |
| `src/components/ProjectStatusControls.tsx` | Replaced native `<select>` with `Dropdown` |
| `src/components/PipelineBoard.tsx` | Replaced "Move to" native `<select>` with `Dropdown` |
| `src/components/UploadForm.tsx` | Replaced space picker native `<select>` with `Dropdown` |
| `src/components/MoveToFolderDialog.tsx` | Replaced folder destination native `<select>` with `Dropdown` |

Closes #46