### PR TITLE
Expand shared video guest view

### DIFF
--- a/src/components/ScriptWorkspace.tsx
+++ b/src/components/ScriptWorkspace.tsx
@@ -181,12 +181,14 @@ const CommentHighlight = Mark.create({
 
 interface ScriptWorkspaceProps {
   videoId: string;
-  spaceId: string;
+  spaceId?: string;
   initialContent: string;
   initialComments: Comment[];
-  currentUserId: string;
+  currentUserId?: string;
   currentUserName: string;
   readOnly: boolean;
+  shareToken?: string;
+  anonymousName?: string;
 }
 
 function parseInitialContent(content: string): JSONContent {
@@ -234,7 +236,14 @@ export function ScriptWorkspace({
   currentUserId,
   currentUserName,
   readOnly,
+  shareToken,
+  anonymousName,
 }: ScriptWorkspaceProps) {
+  const isShareMode = !!shareToken;
+  const viewerName = anonymousName || currentUserName;
+  const canEditScript = !readOnly && !isShareMode;
+  const canComment = !readOnly && (!isShareMode || !!anonymousName);
+  const canResolve = !readOnly && !isShareMode;
   const [comments, setComments] = useState(() => initialComments.filter((comment) => comment.phase === "script"));
   const [selectedRange, setSelectedRange] = useState<TextRange | null>(null);
   const [commentText, setCommentText] = useState("");
@@ -285,6 +294,8 @@ export function ScriptWorkspace({
   const saveScript = async (content: string, plainText: string) => {
     setSaveState("saving");
     try {
+      if (!canEditScript) return;
+
       const res = await fetch(`/api/videos/${videoId}/script`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
@@ -310,7 +321,7 @@ export function ScriptWorkspace({
 
   const editor = useEditor({
     immediatelyRender: false,
-    editable: !readOnly,
+    editable: canEditScript,
     extensions: [
       StarterKit.configure({ heading: { levels: [1, 2, 3] } }),
       Placeholder.configure({ placeholder: "Write the hook, outline, or full script here..." }),
@@ -325,7 +336,7 @@ export function ScriptWorkspace({
     },
     onSelectionUpdate({ editor }) {
       const { from, to, empty } = editor.state.selection;
-      if (empty || readOnly || !isReviewModeRef.current) {
+      if (empty || !canComment || !isReviewModeRef.current) {
         setSelectedRange(null);
         return;
       }
@@ -333,7 +344,7 @@ export function ScriptWorkspace({
       setSelectedRange(quote ? { from, to, quote } : null);
     },
     onUpdate({ editor }) {
-      if (readOnly) return;
+      if (!canEditScript) return;
       setHasScriptText(editor.getText().trim().length > 0);
       setSaveState("saving");
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
@@ -344,8 +355,8 @@ export function ScriptWorkspace({
   });
 
   useEffect(() => {
-    if (editor) editor.setEditable(!readOnly);
-  }, [editor, readOnly]);
+    if (editor) editor.setEditable(canEditScript);
+  }, [editor, canEditScript]);
 
   useEffect(() => () => {
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
@@ -362,8 +373,9 @@ export function ScriptWorkspace({
     const conn = connectVideoRoom(
       videoId,
       {
-        viewerName: currentUserName,
-        viewerUserId: currentUserId,
+        viewerName,
+        viewerUserId: isShareMode ? undefined : currentUserId,
+        shareToken,
       },
       {
         onPresence: (incomingViewers) => {
@@ -378,13 +390,13 @@ export function ScriptWorkspace({
       setViewers([]);
       setPresenceLoading(false);
     };
-  }, [currentUserId, currentUserName, isReviewMode, videoId]);
+  }, [currentUserId, isReviewMode, isShareMode, shareToken, videoId, viewerName]);
 
   const createScriptComment = async () => {
-    if (!editor || !selectedRange || !commentText.trim() || !isReviewMode) return;
+    if (!editor || !selectedRange || !commentText.trim() || !isReviewMode || !canComment) return;
     setSubmittingComment(true);
     try {
-      const res = await fetch(`/api/videos/${videoId}/comments`, {
+      const res = await fetch(shareToken ? `/api/share/${shareToken}/comments` : `/api/videos/${videoId}/comments`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -393,18 +405,21 @@ export function ScriptWorkspace({
           phase: "script",
           timestamp: null,
           textRange: selectedRange,
+          name: anonymousName,
         }),
       });
       const data = (await res.json().catch(() => null)) as { error?: string; comment?: Comment } | null;
       if (!res.ok || !data?.comment) throw new Error(data?.error || "Failed to create comment");
 
-      editor
-        .chain()
-        .focus()
-        .setTextSelection({ from: selectedRange.from, to: selectedRange.to })
-        .setMark("commentHighlight", { commentId: data.comment.id })
-        .run();
-      await saveScript(JSON.stringify(editor.getJSON()), editor.getText());
+      if (canEditScript) {
+        editor
+          .chain()
+          .focus()
+          .setTextSelection({ from: selectedRange.from, to: selectedRange.to })
+          .setMark("commentHighlight", { commentId: data.comment.id })
+          .run();
+        await saveScript(JSON.stringify(editor.getJSON()), editor.getText());
+      }
 
       setComments((current) => [...current, data.comment!]);
       setCommentText("");
@@ -417,6 +432,7 @@ export function ScriptWorkspace({
   };
 
   const toggleResolved = async (comment: Comment) => {
+    if (!canResolve) return;
     const nextResolved = !comment.isResolved;
     setComments((current) =>
       current.map((item) =>
@@ -439,14 +455,16 @@ export function ScriptWorkspace({
   };
 
   const submitReply = async (parentId: string) => {
-    if (!replyText.trim()) return;
+    if (!replyText.trim() || (isShareMode && !anonymousName)) return;
 
     setSubmittingReply(true);
     try {
-      const res = await fetch(`/api/comments/${parentId}/reply`, {
+      const res = await fetch(shareToken ? `/api/share/${shareToken}/comments` : `/api/comments/${parentId}/reply`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text: replyText.trim() }),
+        body: JSON.stringify(shareToken
+          ? { text: replyText.trim(), name: anonymousName, parentId }
+          : { text: replyText.trim() }),
       });
       const data = (await res.json().catch(() => null)) as { error?: string; comment?: Comment } | null;
       if (!res.ok || !data?.comment) throw new Error(data?.error || "Failed to post reply");
@@ -474,11 +492,15 @@ export function ScriptWorkspace({
             <div>
               <h2 className="text-sm font-semibold text-text-primary">Script</h2>
               <p className="text-xs text-text-tertiary">
-                Write the script here. Select text to attach feedback directly to a passage.
+                {canEditScript
+                  ? "Write the script here. Select text to attach feedback directly to a passage."
+                  : canComment
+                    ? "Select text to attach feedback directly to a passage."
+                    : "Read-only view of the project script."}
               </p>
             </div>
             <div className="flex items-center gap-2">
-              {!readOnly && (
+              {canEditScript && (
                 <span className={`text-xs ${saveState === "error" ? "text-accent-danger" : "text-text-tertiary"}`}>
                   {saveState === "saving" ? "Saving..." : saveState === "error" ? "Save failed" : "Saved"}
                 </span>
@@ -529,14 +551,14 @@ export function ScriptWorkspace({
               </p>
               {filter === "all" && (
                 <p className="mt-1 text-xs text-text-tertiary">
-                  Be the first to leave feedback
+                  {canComment ? "Select text in the script to leave feedback" : "No feedback has been left yet"}
                 </p>
               )}
             </div>
           ) : (
             filteredComments.map((comment) => {
               const meta = URGENCY_META[comment.urgency];
-              const displayName = comment.name || currentUserName;
+              const displayName = comment.name || viewerName;
               const replies = getReplies(comment.id);
               return (
                 <article
@@ -570,7 +592,7 @@ export function ScriptWorkspace({
                         <p className="mt-1 whitespace-pre-wrap text-sm text-text-secondary">{comment.text}</p>
                       </button>
                       <div className="mt-2 flex flex-wrap gap-3">
-                        {!readOnly && (
+                        {canComment && (
                           <button
                             type="button"
                             onClick={() => setReplyingTo((current) => (current === comment.id ? null : comment.id))}
@@ -579,7 +601,7 @@ export function ScriptWorkspace({
                             Reply
                           </button>
                         )}
-                        {!readOnly ? (
+                        {canResolve ? (
                           <button
                             type="button"
                             onClick={() => toggleResolved(comment)}
@@ -600,7 +622,7 @@ export function ScriptWorkspace({
                       {replies.length > 0 && (
                         <div className="mt-3 space-y-3 border-l border-border-default pl-4">
                           {replies.map((reply) => {
-                            const replyDisplayName = reply.name || currentUserName;
+                            const replyDisplayName = reply.name || viewerName;
                             return (
                               <div key={reply.id} className="flex gap-3">
                                 <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-primary/60 text-[10px] font-medium text-white">
@@ -656,7 +678,7 @@ export function ScriptWorkspace({
           <div className="border-t border-border-default px-4 py-3 text-center text-xs text-text-tertiary">
             Comments are locked on published projects.
           </div>
-        ) : (
+        ) : canComment ? (
           <div className="border-t border-border-default p-4">
             <div className="mb-2 flex items-center gap-2">
               <ScriptUrgencyPicker
@@ -681,7 +703,7 @@ export function ScriptWorkspace({
                   }
                 }}
                 disabled={!selectedRange || submittingComment}
-                placeholder="Add a comment..."
+                placeholder={selectedRange ? "Add a comment..." : "Select text to comment..."}
                 className="min-w-0 flex-1 rounded-lg border border-border-default bg-bg-input px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent-primary focus:outline-none disabled:opacity-50"
               />
               <button
@@ -694,7 +716,7 @@ export function ScriptWorkspace({
               </button>
             </div>
           </div>
-        )}
+        ) : null}
         </div>
       </aside>}
     </div>

--- a/src/components/ShareView.tsx
+++ b/src/components/ShareView.tsx
@@ -1,72 +1,53 @@
-import { useState, useEffect, useCallback } from "react";
-import { CommentTimeline } from "./CommentTimeline";
-import { CommentThread } from "./CommentThread";
+import { useEffect, useState } from "react";
 import { NamePromptModal } from "./NamePromptModal";
-import { VideoPlayer } from "./VideoPlayer";
-import { VideoPageLayout } from "./VideoPageLayout";
-import { AnnotationOverlay } from "./AnnotationOverlay";
-import { ApprovalSection, type ApprovalStatus } from "./ApprovalSection";
-import { useStreamPlayer } from "../hooks/useStreamPlayer";
-import type { Annotation, Comment } from "../types";
-import type { AnnotationTool } from "./AnnotationOverlay";
+import { ScriptWorkspace } from "./ScriptWorkspace";
+import { VideoDetailView } from "./VideoDetailView";
+import type { ApprovalStatus } from "./ApprovalSection";
+import type { Comment } from "../types";
+import type { ProjectActivityItem } from "../lib/activity";
 
 interface Video {
   id: string;
+  spaceId: string;
   title: string;
-  description: string | null;
   status: string;
   streamVideoId: string | null;
   duration: number | null;
-  versionNumber: number;
+  fileName: string | null;
+  targetDate: string | null;
+  uploadedBy: string | null;
+  createdAt: string;
+  phase: string;
 }
 
 interface ShareViewProps {
+  activeTab: "script" | "video";
   video: Video;
-  versionCount: number;
+  initialScriptContent: string;
   initialComments: Comment[];
   shareToken: string;
-  /** Null when the space has no approval workflow; the section is hidden. */
   initialApprovalStatus: ApprovalStatus | null;
+  initialActivity: ProjectActivityItem[];
+  pipelineEnabled: boolean;
 }
 
 const ANON_NAME_KEY = "quickcut_anonymous_name";
 
-export function ShareView({ video, versionCount, initialComments, shareToken, initialApprovalStatus }: ShareViewProps) {
+export function ShareView({
+  activeTab,
+  video,
+  initialScriptContent,
+  initialComments,
+  shareToken,
+  initialApprovalStatus,
+  initialActivity,
+  pipelineEnabled,
+}: ShareViewProps) {
   const [anonymousName, setAnonymousName] = useState<string | null>(() => {
     if (typeof window === "undefined") return null;
     return localStorage.getItem(ANON_NAME_KEY);
   });
-  const [liveComments, setLiveComments] = useState(initialComments);
-  const [focusRequest, setFocusRequest] = useState<{ id: string; nonce: number } | null>(null);
-  const [activeTool, setActiveTool] = useState<AnnotationTool>("none");
-  const [pendingAnnotation, setPendingAnnotation] = useState<Annotation | null>(null);
-  const [highlightedCommentId, setHighlightedCommentId] = useState<string | null>(null);
 
-  const { iframeRef, currentTime, videoDuration, handleSeek } = useStreamPlayer({
-    status: video.status,
-    streamVideoId: video.streamVideoId,
-    initialDuration: video.duration || 0,
-    enabled: !!anonymousName,
-  });
-
-  const handleCommentClick = useCallback((commentId: string) => {
-    setFocusRequest({ id: commentId, nonce: Date.now() });
-  }, []);
-
-  const handleAnnotationCreate = useCallback((annotation: Annotation) => {
-    setPendingAnnotation(annotation);
-  }, []);
-
-  const handleAnnotationClick = useCallback((commentId: string) => {
-    setFocusRequest({ id: commentId, nonce: Date.now() });
-  }, []);
-
-  const handleAnnotationClear = useCallback(() => {
-    setPendingAnnotation(null);
-    setActiveTool("none");
-  }, []);
-
-  // Track view (only after the user has cleared the name gate).
   useEffect(() => {
     if (!anonymousName) return;
     fetch(`/api/share/${shareToken}/view`, { method: "POST" }).catch(() => {});
@@ -77,7 +58,6 @@ export function ShareView({ video, versionCount, initialComments, shareToken, in
     setAnonymousName(name);
   };
 
-  // Hard gate: no name yet means the page renders nothing but the modal.
   if (!anonymousName) {
     return (
       <NamePromptModal
@@ -86,92 +66,48 @@ export function ShareView({ video, versionCount, initialComments, shareToken, in
         onClose={() => {}}
         dismissable={false}
         title="Welcome"
-        description="Enter your name to view this video and leave comments."
+        description="Enter your name to view this project and leave comments."
       />
     );
   }
 
-  const annotationOverlay = video.status === "ready" ? (
-    <AnnotationOverlay
-      comments={liveComments}
-      currentTime={currentTime}
-      activeTool={activeTool}
-      onAnnotationCreate={handleAnnotationCreate}
-      onAnnotationClick={handleAnnotationClick}
-      highlightedCommentId={highlightedCommentId}
-    />
-  ) : undefined;
-
-  const leftColumn = (
-    <>
-      <VideoPlayer
-        status={video.status}
-        streamVideoId={video.streamVideoId}
-        iframeRef={iframeRef}
-        overlay={annotationOverlay}
+  if (activeTab === "script") {
+    return (
+      <ScriptWorkspace
+        videoId={video.id}
+        spaceId={video.spaceId}
+        initialContent={initialScriptContent}
+        initialComments={initialComments}
+        currentUserName={anonymousName}
+        readOnly={video.phase === "published"}
+        shareToken={shareToken}
+        anonymousName={anonymousName}
       />
+    );
+  }
 
-      {/* Timeline row */}
-      {video.status === "ready" && videoDuration > 0 && (
-        <CommentTimeline
-          comments={liveComments.filter((c) => !c.parentId && c.timestamp != null)}
-          duration={videoDuration}
-          currentTime={currentTime}
-          onSeek={handleSeek}
-          onCommentClick={handleCommentClick}
-        />
-      )}
-
-      <div>
-        {versionCount > 1 && (
-          <div className="mb-2 inline-flex rounded-full border border-border-default bg-bg-secondary px-2.5 py-1 text-xs font-medium text-text-secondary">
-            V{video.versionNumber} of {versionCount}
-          </div>
-        )}
-        <h1 className="text-xl font-bold text-text-primary sm:text-2xl">{video.title}</h1>
-        {video.description && (
-          <p className="mt-2 text-sm text-text-secondary">{video.description}</p>
-        )}
-      </div>
-
-      {/* Read-only approval status for external reviewers. They can see who
-          has signed off, but cannot approve or undo. */}
-      {initialApprovalStatus && (
-        <ApprovalSection
-          videoId={video.id}
-          initialStatus={initialApprovalStatus}
-          currentUserId={null}
-          isSpaceMember={false}
-          uploadedBy={null}
-          readOnly
-          viewerName={anonymousName}
-          shareToken={shareToken}
-        />
-      )}
-    </>
-  );
-
-  const rightColumn = (
-    <CommentThread
+  return (
+    <VideoDetailView
       videoId={video.id}
+      spaceId={video.spaceId}
+      streamVideoId={video.streamVideoId}
+      status={video.status}
+      duration={video.duration}
       initialComments={initialComments}
-      isAuthenticated={false}
-      duration={videoDuration}
-      videoStatus={video.status}
-      currentTime={currentTime}
+      currentUserId=""
+      currentUserName={anonymousName}
+      title={video.title}
+      uploadDate={video.createdAt}
+      fileName={video.fileName}
+      targetDate={video.targetDate}
+      transcriptsEnabled={false}
+      uploadedBy={video.uploadedBy}
+      initialApprovalStatus={initialApprovalStatus}
+      initialPhase={video.phase}
+      pipelineEnabled={pipelineEnabled}
+      userRole="guest"
       shareToken={shareToken}
-      anonymousName={anonymousName}
-      liveEnabled
-      onSeek={handleSeek}
-      onCommentsChange={setLiveComments}
-      focusRequest={focusRequest}
-      pendingAnnotation={pendingAnnotation}
-      onAnnotationClear={handleAnnotationClear}
-      onCommentHover={setHighlightedCommentId}
-      activeTool={activeTool}
-      onToolChange={setActiveTool}
+      initialActivity={initialActivity}
     />
   );
-
-  return <VideoPageLayout leftColumn={leftColumn} rightColumn={rightColumn} />;
 }

--- a/src/components/TranscriptPanel.tsx
+++ b/src/components/TranscriptPanel.tsx
@@ -19,6 +19,8 @@ interface TranscriptPanelProps {
   videoId: string;
   videoTitle: string;
   transcriptsEnabled: boolean;
+  apiUrl?: string;
+  canManageTranscript?: boolean;
 }
 
 const statusCopy: Record<TranscriptStatus, { title: string; body: string }> = {
@@ -83,7 +85,13 @@ function getPollInterval(status: TranscriptStatus): number | null {
   return null;
 }
 
-export function TranscriptPanel({ videoId, videoTitle, transcriptsEnabled }: TranscriptPanelProps) {
+export function TranscriptPanel({
+  videoId,
+  videoTitle,
+  transcriptsEnabled,
+  apiUrl,
+  canManageTranscript = true,
+}: TranscriptPanelProps) {
   const [data, setData] = useState<TranscriptResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [generating, setGenerating] = useState(false);
@@ -93,7 +101,7 @@ export function TranscriptPanel({ videoId, videoTitle, transcriptsEnabled }: Tra
 
   const load = useCallback(async () => {
     try {
-      const response = await fetch(`/api/videos/${videoId}/transcript`);
+      const response = await fetch(apiUrl ?? `/api/videos/${videoId}/transcript`);
       if (!response.ok) throw new Error("Failed to load transcript");
       const next = (await response.json()) as TranscriptResponse;
       setData(next);
@@ -103,7 +111,7 @@ export function TranscriptPanel({ videoId, videoTitle, transcriptsEnabled }: Tra
     } finally {
       setLoading(false);
     }
-  }, [videoId]);
+  }, [apiUrl, videoId]);
 
   useEffect(() => {
     void load();
@@ -158,13 +166,13 @@ export function TranscriptPanel({ videoId, videoTitle, transcriptsEnabled }: Tra
   const text = data?.transcript?.cleanedText || data?.transcript?.rawText || "";
 
   // Hide the panel entirely when transcripts aren't enabled and no transcript exists
-  if (!transcriptsEnabled && !text) {
+  if (!transcriptsEnabled && !text && status === "not_requested") {
     return null;
   }
 
   const copy = statusCopy[status];
-  const canGenerate = data?.transcriptsEnabled && status === "not_requested" && data.videoStatus === "ready";
-  const canRetry = data?.transcriptsEnabled && status === "failed" && data.videoStatus === "ready";
+  const canGenerate = canManageTranscript && data?.transcriptsEnabled && status === "not_requested" && data.videoStatus === "ready";
+  const canRetry = canManageTranscript && data?.transcriptsEnabled && status === "failed" && data.videoStatus === "ready";
 
   return (
     <section className="rounded-xl border border-border-default bg-bg-secondary p-4">

--- a/src/components/VideoDetailView.tsx
+++ b/src/components/VideoDetailView.tsx
@@ -8,10 +8,12 @@ import { TranscriptPanel } from "./TranscriptPanel";
 import { ApprovalSection, type ApprovalStatus } from "./ApprovalSection";
 import { ProjectPhaseControls } from "./ProjectPhaseControls";
 import { TargetDateEditor } from "./TargetDateEditor";
+import { ProjectActivityTimeline } from "./ProjectActivityTimeline";
 import { useStreamPlayer } from "../hooks/useStreamPlayer";
-import { normalizeVideoPhase, type Annotation, type Comment, type VideoPhase } from "../types";
+import { normalizeVideoPhase, PROJECT_STATUS_LABELS, type Annotation, type Comment, type VideoPhase } from "../types";
 import type { AnnotationTool } from "./AnnotationOverlay";
 import type { PipelineStep } from "./PhaseStepper";
+import type { ProjectActivityItem } from "../lib/activity";
 
 interface VideoDetailViewProps {
   videoId: string;
@@ -40,6 +42,8 @@ interface VideoDetailViewProps {
   currentStep?: PipelineStep;
   /** Steps the user can currently navigate to in the guided workflow. */
   enabledSteps?: PipelineStep[];
+  shareToken?: string;
+  initialActivity?: ProjectActivityItem[];
 }
 
 function formatDate(dateStr: string): string {
@@ -77,14 +81,17 @@ export function VideoDetailView({
   userRole,
   currentStep,
   enabledSteps,
+  shareToken,
+  initialActivity = [],
 }: VideoDetailViewProps) {
+  const isShareMode = !!shareToken;
   const initialReviewComments = initialComments.filter((comment) => comment.phase !== "script");
   const [processingStatus, setProcessingStatus] = useState(status);
   const [currentPhase, setCurrentPhase] = useState<VideoPhase>(() => normalizeVideoPhase(initialPhase));
   const [approvalStatus, setApprovalStatus] = useState(initialApprovalStatus);
   const [liveComments, setLiveComments] = useState(initialReviewComments);
   const isPublished = currentPhase === "published";
-  const canChangePhase = pipelineEnabled && (userRole === "owner" || uploadedBy === currentUserId);
+  const canChangePhase = !isShareMode && pipelineEnabled && (userRole === "owner" || uploadedBy === currentUserId);
   const scriptLockedMessage = "This script is read-only because a video has been uploaded. Use the Video step for feedback on the cut.";
   const canMarkAsPublished = !isPublished && canChangePhase && (!approvalStatus || approvalStatus.isApproved);
   const primaryAction = canMarkAsPublished
@@ -127,6 +134,7 @@ export function VideoDetailView({
 
   // Poll for video status when processing
   useEffect(() => {
+    if (isShareMode) return;
     if (processingStatus !== "processing") return;
 
     const poll = async () => {
@@ -154,7 +162,7 @@ export function VideoDetailView({
     return () => {
       if (pollIntervalRef.current) clearInterval(pollIntervalRef.current);
     };
-  }, [processingStatus, videoId, setVideoDuration]);
+  }, [isShareMode, processingStatus, videoId, setVideoDuration]);
 
   const annotationOverlay = processingStatus === "ready" ? (
     <AnnotationOverlay
@@ -167,7 +175,12 @@ export function VideoDetailView({
     />
   ) : undefined;
 
-  const topContent = pipelineEnabled ? (
+  const topContent = pipelineEnabled && isShareMode ? (
+    <div className="rounded-xl border border-border-default bg-bg-secondary p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-text-tertiary">Project phase</p>
+      <p className="mt-1 text-sm font-medium text-text-primary">{PROJECT_STATUS_LABELS[currentPhase]}</p>
+    </div>
+  ) : pipelineEnabled ? (
     <div className="space-y-6">
       <ProjectPhaseControls
         videoId={videoId}
@@ -238,11 +251,12 @@ export function VideoDetailView({
         <ApprovalSection
           videoId={videoId}
           initialStatus={approvalStatus}
-          currentUserId={currentUserId}
-          isSpaceMember={true}
+          currentUserId={isShareMode ? null : currentUserId}
+          isSpaceMember={!isShareMode}
           uploadedBy={uploadedBy}
           viewerName={currentUserName}
-          readOnly={isPublished}
+          readOnly={isShareMode || isPublished}
+          shareToken={shareToken}
           onStatusChange={setApprovalStatus}
         />
       )}
@@ -251,7 +265,14 @@ export function VideoDetailView({
 
   const bottomContent = (
     <div className="space-y-6">
-      <TranscriptPanel videoId={videoId} videoTitle={title} transcriptsEnabled={transcriptsEnabled} />
+      <TranscriptPanel
+        videoId={videoId}
+        videoTitle={title}
+        transcriptsEnabled={transcriptsEnabled}
+        apiUrl={isShareMode ? `/api/share/${shareToken}/transcript` : undefined}
+        canManageTranscript={!isShareMode}
+      />
+      {initialActivity.length > 0 && <ProjectActivityTimeline activity={initialActivity} />}
     </div>
   );
 
@@ -259,13 +280,15 @@ export function VideoDetailView({
     <CommentThread
       videoId={videoId}
       initialComments={initialReviewComments}
-      currentUserId={currentUserId}
+      currentUserId={isShareMode ? undefined : currentUserId}
       currentUserName={currentUserName}
-      isAuthenticated={true}
+      isAuthenticated={!isShareMode}
       duration={videoDuration}
       videoStatus={processingStatus}
       currentTime={currentTime}
-      liveEnabled={processingStatus === "ready"}
+      shareToken={shareToken}
+      anonymousName={isShareMode ? currentUserName : undefined}
+      liveEnabled={isShareMode || processingStatus === "ready"}
       onSeek={handleSeek}
       onCommentsChange={setLiveComments}
       focusRequest={focusRequest}

--- a/src/pages/api/share/[token]/comments.ts
+++ b/src/pages/api/share/[token]/comments.ts
@@ -64,6 +64,7 @@ export const GET: APIRoute = async ({ params, url }) => {
     allComments.map((c) => ({
       ...c,
       annotation: c.annotation ? JSON.parse(c.annotation) : null,
+      textRange: c.textRange ? JSON.parse(c.textRange) : null,
       name:
         c.authorType === "user" && c.authorUserId
           ? userMap[c.authorUserId] || "Unknown"
@@ -102,7 +103,7 @@ export const POST: APIRoute = async ({ params, request }) => {
 
   const videoId = shareLinkResult[0].videoId;
   const body = await request.json();
-  const { text, timestamp, name, parentId, annotation, urgency } = body;
+  const { text, timestamp, name, parentId, annotation, urgency, phase, textRange } = body;
 
   if (!text || !text.trim()) {
     return new Response(JSON.stringify({ error: "Comment text is required" }), {
@@ -135,7 +136,12 @@ export const POST: APIRoute = async ({ params, request }) => {
       : "suggestion";
 
   const commentId = crypto.randomUUID();
-  let parentPhase: "script" | "review" = "review";
+
+  // Determine the comment phase:
+  // - Replies inherit the parent comment's phase.
+  // - Top-level comments use the explicit `phase` field if provided.
+  // - Default to "review" for backward compatibility.
+  let commentPhase: "script" | "review" = phase === "script" ? "script" : "review";
   if (isReply && parentId) {
     const parentRows = await db
       .select({ phase: comments.phase })
@@ -149,7 +155,7 @@ export const POST: APIRoute = async ({ params, request }) => {
         headers: { "Content-Type": "application/json" },
       });
     }
-    parentPhase = parentRows[0].phase;
+    commentPhase = parentRows[0].phase;
   }
 
   const newComment = {
@@ -167,8 +173,8 @@ export const POST: APIRoute = async ({ params, request }) => {
     resolvedReason: null,
     annotation: annotation ? JSON.stringify(annotation) : null,
     urgency: commentUrgency,
-    phase: parentPhase,
-    textRange: null,
+    phase: commentPhase,
+    textRange: textRange ? JSON.stringify(textRange) : null,
   };
 
   await db.insert(comments).values(newComment);
@@ -190,6 +196,7 @@ export const POST: APIRoute = async ({ params, request }) => {
   const responseComment = {
     ...newComment,
     annotation: annotation || null,
+    textRange: textRange || null,
     createdAt: new Date().toISOString(),
     name: name.trim(),
     reactions: [],

--- a/src/pages/api/share/[token]/comments.ts
+++ b/src/pages/api/share/[token]/comments.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
 import { createDb } from "../../../../db";
-import { shareLinks, comments, users } from "../../../../db/schema";
+import { shareLinks, comments, users, videos } from "../../../../db/schema";
 import { eq, asc, gt, and } from "drizzle-orm";
 import { broadcastNewComment } from "../../../../lib/broadcast";
 import { addReactionSummaries } from "../../../../lib/comments";
@@ -104,6 +104,26 @@ export const POST: APIRoute = async ({ params, request }) => {
   const videoId = shareLinkResult[0].videoId;
   const body = await request.json();
   const { text, timestamp, name, parentId, annotation, urgency, phase, textRange } = body;
+
+  const videoResult = await db
+    .select({ phase: videos.phase })
+    .from(videos)
+    .where(eq(videos.id, videoId))
+    .limit(1);
+
+  if (videoResult.length === 0) {
+    return new Response(JSON.stringify({ error: "Video not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (videoResult[0].phase === "published") {
+    return new Response(JSON.stringify({ error: "Cannot comment on published videos" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
 
   if (!text || !text.trim()) {
     return new Response(JSON.stringify({ error: "Comment text is required" }), {

--- a/src/pages/api/share/[token]/transcript.ts
+++ b/src/pages/api/share/[token]/transcript.ts
@@ -1,0 +1,55 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { eq } from "drizzle-orm";
+import { createDb } from "../../../../db";
+import { shareLinks, transcripts, videos } from "../../../../db/schema";
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const GET: APIRoute = async ({ params }) => {
+  const { token } = params;
+  if (!token) return json({ error: "Token required" }, 400);
+
+  const db = createDb(env.DB);
+
+  const shareLinkResult = await db
+    .select()
+    .from(shareLinks)
+    .where(eq(shareLinks.token, token))
+    .limit(1);
+
+  if (shareLinkResult.length === 0 || shareLinkResult[0].status === "revoked") {
+    return json({ error: "Link not available" }, 403);
+  }
+
+  const videoId = shareLinkResult[0].videoId;
+
+  const videoResult = await db
+    .select({ status: videos.status, transcriptRequested: videos.transcriptRequested })
+    .from(videos)
+    .where(eq(videos.id, videoId))
+    .limit(1);
+
+  if (videoResult.length === 0) return json({ error: "Video not found" }, 404);
+
+  const transcriptResult = await db
+    .select()
+    .from(transcripts)
+    .where(eq(transcripts.videoId, videoId))
+    .limit(1);
+
+  const transcript = transcriptResult[0] || null;
+
+  return json({
+    transcript,
+    transcriptRequested: videoResult[0].transcriptRequested,
+    // Guests cannot trigger generation, so this is always false for them
+    transcriptsEnabled: false,
+    videoStatus: videoResult[0].status,
+  });
+};

--- a/src/pages/s/[token].astro
+++ b/src/pages/s/[token].astro
@@ -2,11 +2,13 @@
 import Layout from "../../layouts/Layout.astro";
 import { ShareView } from "../../components/ShareView";
 import { createDb } from "../../db";
-import { shareLinks, videos } from "../../db/schema";
+import { shareLinks, scripts, spaces, videos } from "../../db/schema";
 import { and, count, eq } from "drizzle-orm";
 import { env } from "cloudflare:workers";
 import { getCommentsWithNames } from "../../lib/comments";
 import { getApprovalStatus, type ApprovalStatus } from "../../lib/approvals";
+import { getProjectActivity } from "../../lib/activity";
+import { normalizeVideoPhase } from "../../types";
 
 const { token } = Astro.params;
 if (!token) return Astro.redirect("/");
@@ -28,11 +30,14 @@ const shareLink = shareLinkResult[0];
 
 const isRevoked = shareLink.status === "revoked";
 
-// Get video
+// Get video and associated data
 let video = null;
 let allComments: any[] = [];
 let versionCount = 1;
 let approvalStatus: ApprovalStatus | null = null;
+let script: { content: string; plainText: string; status: string } | null = null;
+let projectActivityItems: any[] = [];
+let videoSpace: { id: string; name: string; pipelineEnabled: boolean } | null = null;
 
 if (!isRevoked) {
   const videoResult = await db
@@ -55,15 +60,38 @@ if (!isRevoked) {
     .where(and(eq(videos.spaceId, video.spaceId), eq(videos.versionGroupId, versionGroupId)));
   versionCount = versionCountResult[0]?.count || 1;
 
-  // Surface approval state to anonymous reviewers as a read-only signal,
-  // but only when the workflow is enabled on the owning space.
   const status = await getApprovalStatus(db, video.id, video.spaceId);
   approvalStatus = status.requiredApprovals > 0 ? status : null;
+
+  // Fetch script
+  const scriptResult = await db.select().from(scripts).where(eq(scripts.videoId, video.id)).limit(1);
+  script = scriptResult[0] || null;
+
+  // Fetch project activity
+  projectActivityItems = await getProjectActivity(db, video.id);
+
+  // Fetch space info
+  const spaceResult = await db
+    .select({ id: spaces.id, name: spaces.name, pipelineEnabled: spaces.pipelineEnabled })
+    .from(spaces)
+    .where(eq(spaces.id, video.spaceId))
+    .limit(1);
+  videoSpace = spaceResult[0] ?? null;
 }
+
+const hasVideo = !!video?.streamVideoId;
+const activeTab = Astro.url.searchParams.get("tab") === "video" ? "video" : "script";
+const tabHref = (tab: "script" | "video") => {
+  const params = new URLSearchParams(Astro.url.searchParams);
+  params.set("tab", tab);
+  return `/s/${token}?${params.toString()}`;
+};
+const phase = video ? normalizeVideoPhase(video.phase) : "reviewing_video";
+const isPublished = phase === "published";
 ---
 
 <Layout title={video ? video.title : "Link Unavailable"}>
-  {!isRevoked && video && (
+  {!isRevoked && video && hasVideo && (
     <script src="https://embed.cloudflarestream.com/embed/sdk.latest.js" is:inline></script>
   )}
   {isRevoked ? (
@@ -76,15 +104,81 @@ if (!isRevoked) {
       </div>
     </div>
   ) : video ? (
-    <div class="mx-auto max-w-[1280px] px-4 py-6 sm:px-8 sm:py-8">
-      <ShareView
-        client:load
-        video={video}
-        versionCount={versionCount}
-        initialComments={allComments}
-        shareToken={token}
-        initialApprovalStatus={approvalStatus}
-      />
+    <div class="mx-auto max-w-[1180px] px-4 py-6 sm:px-8 sm:py-8">
+      <div class="space-y-6">
+        <!-- Project overview -->
+        <section class="rounded-2xl border border-border-default bg-bg-secondary p-5 sm:p-6">
+          <div class="min-w-0">
+            <p class="text-xs font-semibold uppercase tracking-wide text-text-tertiary">Project overview</p>
+            <div class="mt-2 flex flex-wrap items-start gap-x-6 gap-y-3">
+              <h1 class="min-w-0 break-words text-2xl font-bold text-text-primary sm:text-3xl">{video.title}</h1>
+              {versionCount > 1 && (
+                <span class="inline-flex rounded-full border border-border-default bg-bg-primary px-2.5 py-1 text-xs font-medium text-text-secondary">
+                  V{video.versionNumber} of {versionCount}
+                </span>
+              )}
+            </div>
+            {video.description && (
+              <p class="mt-4 max-w-2xl break-words text-sm text-text-secondary">{video.description}</p>
+            )}
+          </div>
+          {isPublished && (
+            <div class="mt-5 rounded-lg border border-accent-secondary/30 bg-accent-secondary/10 px-4 py-2 text-sm text-accent-secondary">
+              This project is published. Script, comments, and versions are read-only.
+            </div>
+          )}
+        </section>
+
+        <!-- Tab navigation -->
+        <div class="border-b border-border-default">
+          <nav class="flex gap-2" aria-label="Project sections">
+            <a
+              href={tabHref("script")}
+              class={`rounded-t-lg px-4 py-2 text-sm font-medium transition-colors ${activeTab === "script" ? "border-b-2 border-accent-primary text-text-primary" : "text-text-tertiary hover:text-text-secondary"}`}
+              aria-current={activeTab === "script" ? "page" : undefined}
+            >
+              Script
+            </a>
+            <a
+              href={tabHref("video")}
+              class={`rounded-t-lg px-4 py-2 text-sm font-medium transition-colors ${activeTab === "video" ? "border-b-2 border-accent-primary text-text-primary" : "text-text-tertiary hover:text-text-secondary"}`}
+              aria-current={activeTab === "video" ? "page" : undefined}
+            >
+              Video
+            </a>
+          </nav>
+        </div>
+
+        <!-- Tab content -->
+        {activeTab === "script" || hasVideo ? (
+          <ShareView
+            client:load
+            activeTab={activeTab}
+            video={video}
+            initialScriptContent={script?.content || ""}
+            initialComments={allComments}
+            shareToken={token}
+            initialApprovalStatus={approvalStatus}
+            initialActivity={projectActivityItems}
+            pipelineEnabled={videoSpace?.pipelineEnabled || false}
+          />
+        ) : (
+          <div class="rounded-xl border border-border-default bg-bg-secondary p-5 text-sm text-text-secondary">
+            No video has been uploaded yet for this project.
+          </div>
+        )}
+
+        <!-- Approvals summary at bottom -->
+        {approvalStatus && (
+          <section class="rounded-xl border border-border-default bg-bg-secondary p-5">
+            <p class="text-sm font-semibold text-text-primary">Approvals</p>
+            <p class="mt-2 text-sm text-text-secondary">
+              {approvalStatus.currentApprovals} of {approvalStatus.requiredApprovals} approvals complete.
+              {approvalStatus.isApproved ? " This project is cleared to publish." : " Publishing is locked until approvals are complete."}
+            </p>
+          </section>
+        )}
+      </div>
     </div>
   ) : (
     <div class="flex min-h-[60vh] items-center justify-center">


### PR DESCRIPTION
## Summary
- Rework shared video links to use the same project tabs as authenticated project pages.
- Reuse `ScriptWorkspace`, `VideoDetailView`, and `TranscriptPanel` for guest read-only access with token-scoped comment support.
- Add guest transcript access and support script comments with text ranges through the share comments API.

## Verification
- `CLOUDFLARE_ACCOUNT_ID=4426cbeacb457b1ca1b865d6c36ced0d npx astro build`

Closes #40