### PR TITLE
fix(space-settings): replace native confirm with typed-name ConfirmDialog and post-delete toast

### DIFF
--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { Modal } from "./Modal";
 
 type ConfirmVariant = "danger" | "primary";
@@ -11,6 +11,8 @@ interface ConfirmDialogProps {
   cancelLabel?: string;
   variant?: ConfirmVariant;
   loading?: boolean;
+  requireTypedConfirmation?: string;
+  typedConfirmationLabel?: string;
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -23,20 +25,42 @@ export function ConfirmDialog({
   cancelLabel = "Cancel",
   variant = "primary",
   loading = false,
+  requireTypedConfirmation,
+  typedConfirmationLabel,
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
   const headingId = useId();
+  const inputId = useId();
   const cancelRef = useRef<HTMLButtonElement>(null);
   const confirmRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  // Auto-focus the safer action per variant when the dialog opens.
+  const [typedValue, setTypedValue] = useState("");
+
+  // Clear the typed-confirmation input each time the dialog reopens.
+  useEffect(() => {
+    if (isOpen) setTypedValue("");
+  }, [isOpen]);
+
+  // Auto-focus the safer action per variant when the dialog opens. When a
+  // typed confirmation is required, focus the input instead so the user can
+  // start typing immediately.
   useEffect(() => {
     if (!isOpen) return;
-    const target = variant === "danger" ? cancelRef.current : confirmRef.current;
-    // Defer to ensure the element is mounted and visible.
+    const target = requireTypedConfirmation
+      ? inputRef.current
+      : variant === "danger"
+        ? cancelRef.current
+        : confirmRef.current;
     requestAnimationFrame(() => target?.focus());
-  }, [isOpen, variant]);
+  }, [isOpen, variant, requireTypedConfirmation]);
+
+  const typedMatches =
+    !requireTypedConfirmation ||
+    typedValue.trim() === requireTypedConfirmation;
+
+  const confirmDisabled = loading || !typedMatches;
 
   const confirmClass =
     variant === "danger"
@@ -47,6 +71,12 @@ export function ConfirmDialog({
     if (loading) return;
     onCancel();
   };
+
+  const resolvedTypedLabel =
+    typedConfirmationLabel ??
+    (requireTypedConfirmation
+      ? `Type "${requireTypedConfirmation}" to confirm`
+      : "");
 
   return (
     <Modal
@@ -64,6 +94,29 @@ export function ConfirmDialog({
       {description && (
         <p className="mt-1 text-sm text-text-secondary">{description}</p>
       )}
+      {requireTypedConfirmation && (
+        <div className="mt-4">
+          <label
+            htmlFor={inputId}
+            className="mb-1 block text-sm font-medium text-text-secondary"
+          >
+            {resolvedTypedLabel}
+          </label>
+          <input
+            id={inputId}
+            ref={inputRef}
+            type="text"
+            value={typedValue}
+            onChange={(e) => setTypedValue(e.target.value)}
+            disabled={loading}
+            autoComplete="off"
+            autoCapitalize="off"
+            autoCorrect="off"
+            spellCheck={false}
+            className="w-full rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent-primary focus:outline-none disabled:opacity-50"
+          />
+        </div>
+      )}
       <div className="mt-5 flex gap-3">
         <button
           ref={cancelRef}
@@ -78,7 +131,7 @@ export function ConfirmDialog({
           ref={confirmRef}
           type="button"
           onClick={onConfirm}
-          disabled={loading}
+          disabled={confirmDisabled}
           className={confirmClass}
         >
           {loading ? `${confirmLabel}…` : confirmLabel}

--- a/src/components/PendingToast.tsx
+++ b/src/components/PendingToast.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import { ToastViewport, useToast, type ToastVariant } from "./Toast";
+
+interface PendingToastPayload {
+  message: string;
+  variant?: ToastVariant;
+}
+
+const STORAGE_KEY = "pendingToast";
+
+function readPendingToast(): PendingToastPayload | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    sessionStorage.removeItem(STORAGE_KEY);
+    const parsed = JSON.parse(raw) as PendingToastPayload;
+    if (!parsed || typeof parsed.message !== "string") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Mounts a toast viewport that consumes a one-shot toast persisted to
+ * `sessionStorage` under the `pendingToast` key. This lets pages that perform
+ * a full-page navigation (e.g. after deleting a resource) still surface a
+ * confirmation toast on the destination page.
+ */
+export function PendingToast() {
+  const { toasts, showToast, dismissToast } = useToast();
+
+  useEffect(() => {
+    const pending = readPendingToast();
+    if (!pending) return;
+    showToast(pending.message, pending.variant ?? "success");
+    // showToast is stable for our purposes — only run on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return <ToastViewport toasts={toasts} onDismiss={dismissToast} />;
+}

--- a/src/components/SpaceSettings.tsx
+++ b/src/components/SpaceSettings.tsx
@@ -1,5 +1,6 @@
 import { actions } from "astro:actions";
 import { useState } from "react";
+import { ConfirmDialog } from "./ConfirmDialog";
 import { ToastViewport, useToast } from "./Toast";
 
 interface Space {
@@ -68,6 +69,12 @@ export function SpaceSettings({
 
   // General action state
   const [actionError, setActionError] = useState("");
+
+  // Destructive-action dialog state
+  const [leaveOpen, setLeaveOpen] = useState(false);
+  const [leaveLoading, setLeaveLoading] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleteLoading, setDeleteLoading] = useState(false);
 
   const handleSaveSettings = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -144,27 +151,45 @@ export function SpaceSettings({
     }
   };
 
-  const handleLeave = async () => {
-    if (!confirm("Are you sure you want to leave this space?")) return;
+  const confirmLeave = async () => {
     setActionError("");
+    setLeaveLoading(true);
     try {
       const { error } = await actions.space.leave({ id: space.id });
       if (error) throw new Error(error.message || "Failed to leave space");
       window.location.href = "/dashboard";
     } catch (err) {
       setActionError(err instanceof Error ? err.message : "Failed to leave");
+      setLeaveLoading(false);
+      setLeaveOpen(false);
     }
   };
 
-  const handleDelete = async () => {
-    if (!confirm(`Are you sure you want to delete "${space.name}"? All videos and folders in this space will be permanently deleted.`)) return;
+  const confirmDelete = async () => {
     setActionError("");
+    setDeleteLoading(true);
     try {
       const { error } = await actions.space.delete({ id: space.id });
       if (error) throw new Error(error.message || "Failed to delete space");
+      // Persist a toast across the navigation to /dashboard. The dashboard
+      // page mounts a <PendingToast /> that consumes and displays this.
+      try {
+        sessionStorage.setItem(
+          "pendingToast",
+          JSON.stringify({
+            message: `Deleted "${space.name}"`,
+            variant: "success",
+          }),
+        );
+      } catch {
+        // Ignore storage failures (private mode, quota, etc.) — the redirect
+        // still succeeds, only the toast is lost.
+      }
       window.location.href = "/dashboard";
     } catch (err) {
       setActionError(err instanceof Error ? err.message : "Failed to delete");
+      setDeleteLoading(false);
+      setDeleteOpen(false);
     }
   };
 
@@ -290,7 +315,7 @@ export function SpaceSettings({
           <div className="mt-4 border-t border-border-default pt-4">
             <button
               type="button"
-              onClick={handleLeave}
+              onClick={() => setLeaveOpen(true)}
               className="rounded-lg border border-accent-danger px-4 py-2 text-sm font-medium text-accent-danger transition-colors hover:bg-accent-danger/15"
             >
               Leave Space
@@ -360,13 +385,36 @@ export function SpaceSettings({
           </p>
           <button
             type="button"
-            onClick={handleDelete}
+            onClick={() => setDeleteOpen(true)}
             className="mt-4 rounded-lg bg-accent-danger px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-danger/90"
           >
             Delete Space
           </button>
         </section>
       )}
+
+      <ConfirmDialog
+        isOpen={leaveOpen}
+        title="Leave this space?"
+        description="You'll lose access to all videos and folders in this space."
+        confirmLabel="Leave space"
+        variant="danger"
+        loading={leaveLoading}
+        onConfirm={confirmLeave}
+        onCancel={() => setLeaveOpen(false)}
+      />
+
+      <ConfirmDialog
+        isOpen={deleteOpen}
+        title={`Delete "${space.name}"?`}
+        description="All videos, folders, and data in this space will be permanently deleted. This cannot be undone."
+        confirmLabel="Delete space"
+        variant="danger"
+        loading={deleteLoading}
+        requireTypedConfirmation={space.name}
+        onConfirm={confirmDelete}
+        onCancel={() => setDeleteOpen(false)}
+      />
     </div>
   );
 }

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -5,6 +5,7 @@ import FolderCard from "../components/FolderCard.astro";
 import Breadcrumbs from "../components/Breadcrumbs.astro";
 import { CreateFolderDialog } from "../components/CreateFolderDialog";
 import { NewProjectDialog } from "../components/NewProjectDialog";
+import { PendingToast } from "../components/PendingToast";
 import EmptyState from "../components/EmptyState.astro";
 import { createDb } from "../db";
 import { folders, videos, comments, spaceMembers, approvals } from "../db/schema";
@@ -191,6 +192,7 @@ const emptyDescription = currentFolderRecord
 ---
 
 <Layout title={currentFolderRecord ? currentFolderRecord.name : selectedSpace.name} user={user} selectedSpaceId={selectedSpaceId}>
+  <PendingToast client:load />
   <div class="mx-auto max-w-[1280px] px-4 py-8 sm:px-8">
     <div class="mb-8 flex flex-wrap items-center justify-between gap-4">
       <div>


### PR DESCRIPTION
Closes #76.

## Summary

- Extends `ConfirmDialog` with optional typed-name confirmation so the confirm button stays disabled until the user types the exact required string.
- Replaces both `window.confirm()` calls in `SpaceSettings` with `ConfirmDialog` instances and gives Delete a loading state plus a typed-name guard against the space name.
- Adds a one-shot `pendingToast` mechanism (sessionStorage + `<PendingToast />`) so the success toast survives the post-delete navigation to `/dashboard`.

## Changes

### `src/components/ConfirmDialog.tsx`
- New optional props: `requireTypedConfirmation?: string`, `typedConfirmationLabel?: string`.
- When `requireTypedConfirmation` is set:
  - Renders a labeled text input below the description.
  - Confirm button is disabled until `value.trim() === requireTypedConfirmation` (case-sensitive).
  - Input clears every time the dialog reopens.
  - Auto-focuses the input on open instead of the cancel/confirm button.
- All existing call sites (`VideoCardMenu`, `VideoHeader`, `FolderCardMenu`) are unaffected — the new props are optional.

### `src/components/SpaceSettings.tsx`
- Removes both `confirm(...)` calls.
- Adds `leaveOpen` / `leaveLoading` and `deleteOpen` / `deleteLoading` state.
- Buttons now open the relevant `ConfirmDialog`; the `actions.space.leave` / `actions.space.delete` calls run inside `onConfirm` handlers with proper loading state.
- After a successful delete, writes `pendingToast` to `sessionStorage` then redirects to `/dashboard`.

### `src/components/PendingToast.tsx` (new)
- Small client component that reads `sessionStorage.pendingToast` on mount, removes it, and shows the toast via the existing `useToast` / `ToastViewport` system.

### `src/pages/dashboard.astro`
- Mounts `<PendingToast client:load />` so toasts queued before navigation are surfaced on arrival.

## Acceptance criteria

- [x] No `window.confirm` / `confirm()` calls remain in `SpaceSettings.tsx`.
- [x] Leaving a space uses `ConfirmDialog` with a loading state on the confirm button.
- [x] Deleting a space uses `ConfirmDialog` with a typed-name confirmation input.
- [x] The Delete confirm button is disabled until the typed value exactly matches the space name (after trimming).
- [x] The typed-confirmation input resets when the dialog reopens.
- [x] Cancel button, Escape, and backdrop click close the dialog without triggering the action (and not while loading) — inherited from `Modal` / existing `ConfirmDialog` behavior.
- [x] After successful deletion, a toast `Deleted "<space name>"` is shown on `/dashboard` via the new `PendingToast` consumer.
- [x] Existing `ConfirmDialog` consumers (`VideoCardMenu`, `VideoHeader`, `FolderCardMenu`) continue to work without changes.

## Verification

- `pnpm build` passes locally.