### PR TITLE
feat(dialog): pass folders to MoveToFolderDialog server-side

### DIFF
--- a/src/components/FolderCard.astro
+++ b/src/components/FolderCard.astro
@@ -1,6 +1,12 @@
 ---
 import { FolderCardMenu } from "./FolderCardMenu";
 
+interface FolderOption {
+  id: string;
+  name: string;
+  parentId: string | null;
+}
+
 interface Props {
   id: string;
   name: string;
@@ -8,9 +14,11 @@ interface Props {
   spaceId: string;
   videoCount: number;
   thumbnails: string[];
+  /** All folders in the space; used by the move-to-folder dialog. */
+  folders?: FolderOption[];
 }
 
-const { id, name, parentId, spaceId, videoCount, thumbnails } = Astro.props;
+const { id, name, parentId, spaceId, videoCount, thumbnails, folders = [] } = Astro.props;
 const remaining = Math.max(videoCount - thumbnails.length, 0);
 ---
 
@@ -43,6 +51,6 @@ const remaining = Math.max(videoCount - thumbnails.length, 0);
     </div>
   </a>
   <div class="absolute right-2 top-2 z-10">
-    <FolderCardMenu client:load folderId={id} folderName={name} parentId={parentId} spaceId={spaceId} />
+    <FolderCardMenu client:load folderId={id} folderName={name} parentId={parentId} spaceId={spaceId} folders={folders} />
   </div>
 </div>

--- a/src/components/FolderCardMenu.tsx
+++ b/src/components/FolderCardMenu.tsx
@@ -4,14 +4,21 @@ import { ConfirmDialog } from "./ConfirmDialog";
 import { Modal } from "./Modal";
 import { MoveToFolderDialog } from "./MoveToFolderDialog";
 
+interface Folder {
+  id: string;
+  name: string;
+  parentId: string | null;
+}
+
 interface FolderCardMenuProps {
   folderId: string;
   folderName: string;
   parentId?: string | null;
   spaceId: string;
+  folders: Folder[];
 }
 
-export function FolderCardMenu({ folderId, folderName, parentId = null, spaceId }: FolderCardMenuProps) {
+export function FolderCardMenu({ folderId, folderName, parentId = null, spaceId, folders }: FolderCardMenuProps) {
   const headingId = useId();
   const [open, setOpen] = useState(false);
   const [renameOpen, setRenameOpen] = useState(false);
@@ -193,7 +200,7 @@ export function FolderCardMenu({ folderId, folderName, parentId = null, spaceId 
         entityId={folderId}
         entityType="folder"
         currentFolderId={parentId}
-        spaceId={spaceId}
+        folders={folders}
         onClose={() => setMoveOpen(false)}
       />
 

--- a/src/components/MoveToFolderDialog.tsx
+++ b/src/components/MoveToFolderDialog.tsx
@@ -14,7 +14,7 @@ interface MoveToFolderDialogProps {
   entityId: string;
   entityType: "video" | "folder";
   currentFolderId?: string | null;
-  spaceId?: string | null;
+  folders: Folder[];
   onClose: () => void;
 }
 
@@ -63,13 +63,11 @@ export function MoveToFolderDialog({
   entityId,
   entityType,
   currentFolderId = null,
-  spaceId = null,
+  folders,
   onClose,
 }: MoveToFolderDialogProps) {
   const headingId = useId();
-  const [folders, setFolders] = useState<Folder[]>([]);
   const [selectedFolderId, setSelectedFolderId] = useState<string>(currentFolderId ?? "root");
-  const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
 
@@ -77,17 +75,7 @@ export function MoveToFolderDialog({
     if (!isOpen) return;
     setSelectedFolderId(currentFolderId ?? "root");
     setError("");
-    setLoading(true);
-
-    fetch(spaceId ? `/api/folders?space=${spaceId}` : "/api/folders")
-      .then(async (res) => await res.json() as { folders?: Folder[]; error?: string })
-      .then((data) => {
-        if (data.error) throw new Error(data.error);
-        setFolders(data.folders || []);
-      })
-      .catch((err) => setError(err instanceof Error ? err.message : "Failed to load folders"))
-      .finally(() => setLoading(false));
-  }, [currentFolderId, isOpen, spaceId]);
+  }, [currentFolderId, isOpen]);
 
   const handleMove = async () => {
     setSaving(true);
@@ -110,7 +98,10 @@ export function MoveToFolderDialog({
     }
   };
 
-  const treeOptions = buildFolderOptions(folders, entityType === "folder" ? entityId : undefined);
+  const treeOptions = useMemo(
+    () => buildFolderOptions(folders, entityType === "folder" ? entityId : undefined),
+    [folders, entityType, entityId],
+  );
 
   const dropdownOptions: DropdownOption[] = useMemo(
     () => [
@@ -149,7 +140,7 @@ export function MoveToFolderDialog({
           options={dropdownOptions}
           value={selectedFolderId}
           onChange={setSelectedFolderId}
-          disabled={loading || saving}
+          disabled={saving}
           menuAlign="left"
           menuWidth="w-full"
         />
@@ -173,7 +164,7 @@ export function MoveToFolderDialog({
         <button
           type="button"
           onClick={handleMove}
-          disabled={loading || saving}
+          disabled={saving}
           className="flex-1 rounded-lg bg-accent-primary px-4 py-2 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover disabled:opacity-50"
         >
           {saving ? "Moving..." : "Move"}

--- a/src/components/VideoCard.astro
+++ b/src/components/VideoCard.astro
@@ -9,6 +9,12 @@ interface UrgencyCounts {
   critical: number;
 }
 
+interface FolderOption {
+  id: string;
+  name: string;
+  parentId: string | null;
+}
+
 interface Props {
   id: string;
   title: string;
@@ -28,6 +34,8 @@ interface Props {
   approvalCount?: number;
   /** Project status. */
   phase?: string | null;
+  /** All folders in the space; used by the move-to-folder dialog. */
+  folders?: FolderOption[];
 }
 
 const {
@@ -46,6 +54,7 @@ const {
   requiredApprovals = 0,
   approvalCount = 0,
   phase = null,
+  folders = [],
 } = Astro.props;
 
 const phaseStyles: Record<string, string> = {
@@ -168,6 +177,6 @@ function formatDate(dateStr: string): string {
     </div>
   </a>
   <div class="absolute right-2 top-2 z-10">
-    <VideoCardMenu client:load videoId={id} folderId={folderId} spaceId={spaceId} />
+    <VideoCardMenu client:load videoId={id} folderId={folderId} folders={folders} />
   </div>
 </div>

--- a/src/components/VideoCardMenu.tsx
+++ b/src/components/VideoCardMenu.tsx
@@ -3,13 +3,19 @@ import { actions } from "astro:actions";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { MoveToFolderDialog } from "./MoveToFolderDialog";
 
+interface Folder {
+  id: string;
+  name: string;
+  parentId: string | null;
+}
+
 interface VideoCardMenuProps {
   videoId: string;
   folderId?: string | null;
-  spaceId?: string | null;
+  folders: Folder[];
 }
 
-export function VideoCardMenu({ videoId, folderId = null, spaceId = null }: VideoCardMenuProps) {
+export function VideoCardMenu({ videoId, folderId = null, folders }: VideoCardMenuProps) {
   const [open, setOpen] = useState(false);
   const [moveOpen, setMoveOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -129,7 +135,7 @@ export function VideoCardMenu({ videoId, folderId = null, spaceId = null }: Vide
         entityId={videoId}
         entityType="video"
         currentFolderId={folderId}
-        spaceId={spaceId}
+        folders={folders}
         onClose={() => setMoveOpen(false)}
       />
 

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -62,6 +62,13 @@ const childFolders = allFolders.filter((folder) => {
   if (currentFolderId) return folder.parentId === currentFolderId;
   return folder.parentId === null;
 });
+// Lightweight folder list passed down to cards so the move-to-folder dialog
+// can render the destination tree without a client-side fetch.
+const folderOptions = allFolders.map((folder) => ({
+  id: folder.id,
+  name: folder.name,
+  parentId: folder.parentId,
+}));
 const childFolderIds = childFolders.map((folder) => folder.id);
 
 let folderVideoCounts: Record<string, number> = {};
@@ -231,6 +238,7 @@ const emptyDescription = currentFolderRecord
             spaceId={selectedSpaceId}
             videoCount={folderVideoCounts[folder.id] || 0}
             thumbnails={folderThumbnails[folder.id] || []}
+            folders={folderOptions}
           />
         ))}
         {userVideos.map((video) => (
@@ -250,6 +258,7 @@ const emptyDescription = currentFolderRecord
             requiredApprovals={selectedSpace.requiredApprovals}
             approvalCount={approvalCountsByVideo[video.id] || 0}
             phase={video.phase}
+            folders={folderOptions}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary

Eliminates the client-side `fetch('/api/folders?space=...')` inside `MoveToFolderDialog` by passing the folder list down as a prop from `dashboard.astro`, which already loads every folder for the selected space.

## Changes

- `MoveToFolderDialog.tsx`: replaces the `useEffect` fetch with a `folders` prop. Drops `spaceId`, `loading` state, and the loading-related disabled flags. `buildFolderOptions` still lives in the component (cycle exclusion logic preserved when moving a folder).
- `VideoCardMenu.tsx` / `FolderCardMenu.tsx`: accept and forward `folders` to the dialog. `VideoCardMenu` no longer needs `spaceId` (it was only used to build the fetch URL).
- `VideoCard.astro` / `FolderCard.astro`: accept an optional `folders` prop and forward it to their menu components.
- `dashboard.astro`: projects the existing `allFolders` query result into a lightweight `{ id, name, parentId }` shape and passes it to every `VideoCard` / `FolderCard`.

## Acceptance criteria

- [x] No client-side `fetch()` when dialog opens
- [x] Folders passed as prop from parent page
- [x] Folder tree building logic (`buildFolderOptions`) stays in component

## Verification

`pnpm build` passes locally (Astro server build completes cleanly).

Closes #65