### PR TITLE
refactor(version-switcher): load versions server-side

### DIFF
--- a/src/components/VersionSwitcher.tsx
+++ b/src/components/VersionSwitcher.tsx
@@ -13,6 +13,7 @@ interface VersionSummary {
 
 interface VersionSwitcherProps {
   videoId: string;
+  versions: VersionSummary[];
 }
 
 function formatDate(dateStr: string): string {
@@ -23,25 +24,9 @@ function formatDate(dateStr: string): string {
   });
 }
 
-export function VersionSwitcher({ videoId }: VersionSwitcherProps) {
-  const [versions, setVersions] = useState<VersionSummary[]>([]);
+export function VersionSwitcher({ videoId, versions }: VersionSwitcherProps) {
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    fetch(`/api/videos/${videoId}/versions`)
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data: { versions?: VersionSummary[] } | null) => {
-        if (!cancelled && data?.versions) setVersions(data.versions);
-      })
-      .catch(() => {});
-
-    return () => {
-      cancelled = true;
-    };
-  }, [videoId]);
 
   useEffect(() => {
     if (!open) return;

--- a/src/components/VideoHeader.tsx
+++ b/src/components/VideoHeader.tsx
@@ -10,6 +10,17 @@ interface ShareLink {
   viewCount: number;
 }
 
+interface VersionSummary {
+  id: string;
+  title: string;
+  status: string;
+  thumbnailUrl: string | null;
+  versionNumber: number;
+  isCurrentVersion: boolean;
+  createdAt: string;
+  commentCount: number;
+}
+
 interface VideoHeaderProps {
   videoId: string;
   shareLink: ShareLink | null;
@@ -19,9 +30,10 @@ interface VideoHeaderProps {
   backLabel?: string;
   spaceName?: string;
   uploadVersionHref?: string | null;
+  versions: VersionSummary[];
 }
 
-export function VideoHeader({ videoId, shareLink: initialLink, appUrl, spaceId, backHref, backLabel = "Back to videos", spaceName, uploadVersionHref = null }: VideoHeaderProps) {
+export function VideoHeader({ videoId, shareLink: initialLink, appUrl, spaceId, backHref, backLabel = "Back to videos", spaceName, uploadVersionHref = null, versions }: VideoHeaderProps) {
   const [shareLink, setShareLink] = useState(initialLink);
   const [loading, setLoading] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -181,7 +193,7 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl, spaceId, 
       </div>
 
       <div className="ml-auto flex items-center gap-2">
-        <VersionSwitcher videoId={videoId} />
+        <VersionSwitcher videoId={videoId} versions={versions} />
 
         <div className="relative" ref={moreMenuRef}>
           <button

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1,0 +1,71 @@
+import { and, count, desc, eq, sql } from "drizzle-orm";
+import type { Database } from "../db";
+import { comments, videos } from "../db/schema";
+
+export interface VersionSummary {
+  id: string;
+  title: string;
+  status: string;
+  thumbnailUrl: string | null;
+  duration: number | null;
+  versionNumber: number;
+  isCurrentVersion: boolean;
+  createdAt: string;
+  commentCount: number;
+}
+
+interface VersionContext {
+  id: string;
+  spaceId: string;
+  versionGroupId: string | null;
+}
+
+export async function getVideoVersions(
+  db: Database,
+  video: VersionContext,
+): Promise<VersionSummary[]> {
+  const versionGroupId = video.versionGroupId || video.id;
+
+  const versionRows = await db
+    .select()
+    .from(videos)
+    .where(
+      and(
+        eq(videos.spaceId, video.spaceId),
+        eq(videos.versionGroupId, versionGroupId),
+      ),
+    )
+    .orderBy(desc(videos.versionNumber));
+
+  const versionIds = versionRows.map((version) => version.id);
+  let commentCounts: Record<string, number> = {};
+
+  if (versionIds.length > 0) {
+    const counts = await db
+      .select({ videoId: comments.videoId, count: count() })
+      .from(comments)
+      .where(
+        sql`${comments.videoId} IN (${sql.join(
+          versionIds.map((versionId) => sql`${versionId}`),
+          sql`, `,
+        )})`,
+      )
+      .groupBy(comments.videoId);
+
+    commentCounts = Object.fromEntries(
+      counts.map((row) => [row.videoId, row.count]),
+    );
+  }
+
+  return versionRows.map((version) => ({
+    id: version.id,
+    title: version.title,
+    status: version.status,
+    thumbnailUrl: version.thumbnailUrl,
+    duration: version.duration,
+    versionNumber: version.versionNumber,
+    isCurrentVersion: version.isCurrentVersion,
+    createdAt: version.createdAt,
+    commentCount: commentCounts[version.id] || 0,
+  }));
+}

--- a/src/pages/api/videos/[id]/versions.ts
+++ b/src/pages/api/videos/[id]/versions.ts
@@ -1,12 +1,13 @@
 import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
-import { and, count, desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { createDb } from "../../../../db";
-import { comments, videos } from "../../../../db/schema";
+import { videos } from "../../../../db/schema";
 import { createDirectUpload } from "../../../../lib/stream";
 import { uploadSchema } from "../../../../lib/validation";
 import { isTranscriptGenerationEnabled } from "../../../../lib/flags";
 import { verifySpaceAccess } from "../../../../lib/spaces";
+import { getVideoVersions } from "../../../../lib/versions";
 
 const ALLOWED_EXTENSIONS = ["mp4", "mov", "webm", "avi", "mkv"];
 const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024;
@@ -33,39 +34,9 @@ export const GET: APIRoute = async ({ params, locals }) => {
   const getRole = await verifySpaceAccess(db, locals.user.id, video.spaceId);
   if (!getRole) return json({ error: "Forbidden" }, 403);
 
-  const versionGroupId = video.versionGroupId || video.id;
-  const versionRows = await db
-    .select()
-    .from(videos)
-    .where(and(eq(videos.spaceId, video.spaceId), eq(videos.versionGroupId, versionGroupId)))
-    .orderBy(desc(videos.versionNumber));
+  const versions = await getVideoVersions(db, video);
 
-  const versionIds = versionRows.map((version) => version.id);
-  let commentCounts: Record<string, number> = {};
-
-  if (versionIds.length > 0) {
-    const counts = await db
-      .select({ videoId: comments.videoId, count: count() })
-      .from(comments)
-      .where(sql`${comments.videoId} IN (${sql.join(versionIds.map((versionId) => sql`${versionId}`), sql`, `)})`)
-      .groupBy(comments.videoId);
-
-    commentCounts = Object.fromEntries(counts.map((row) => [row.videoId, row.count]));
-  }
-
-  return json({
-    versions: versionRows.map((version) => ({
-      id: version.id,
-      title: version.title,
-      status: version.status,
-      thumbnailUrl: version.thumbnailUrl,
-      duration: version.duration,
-      versionNumber: version.versionNumber,
-      isCurrentVersion: version.isCurrentVersion,
-      createdAt: version.createdAt,
-      commentCount: commentCounts[version.id] || 0,
-    })),
-  });
+  return json({ versions });
 };
 
 export const POST: APIRoute = async ({ params, locals, request }) => {

--- a/src/pages/videos/[id]/index.astro
+++ b/src/pages/videos/[id]/index.astro
@@ -16,6 +16,7 @@ import { getCommentsWithNames } from "../../../lib/comments";
 import { isTranscriptGenerationEnabled } from "../../../lib/flags";
 import { getProjectActivity } from "../../../lib/activity";
 import { verifySpaceAccess } from "../../../lib/spaces";
+import { getVideoVersions } from "../../../lib/versions";
 import { normalizeVideoPhase } from "../../../types";
 
 const user = Astro.locals.user;
@@ -50,6 +51,7 @@ const commentsWithNames = await getCommentsWithNames(db, id, {
   name: user.name,
 });
 const transcriptsEnabled = await isTranscriptGenerationEnabled(env, user);
+const versions = await getVideoVersions(db, video);
 const backHref = `/dashboard?space=${video.spaceId}${video.folderId ? `&folderId=${video.folderId}` : ""}`;
 const phase = normalizeVideoPhase(video.phase);
 const isPublished = phase === "published";
@@ -76,6 +78,7 @@ const tabHref = (tab: "script" | "video") => {
       spaceId={video.spaceId}
       backHref={backHref}
       spaceName={videoSpace.name}
+      versions={versions}
     />
 
     <div class="space-y-6">


### PR DESCRIPTION
## Summary

- Removes the client-side `useEffect` + `fetch('/api/videos/{id}/versions')` from `VersionSwitcher.tsx`.
- The Astro video page (`src/pages/videos/[id]/index.astro`) now loads versions server-side via a new shared helper `getVideoVersions(db, video)` in `src/lib/versions.ts` and passes the result down through `VideoHeader` to `VersionSwitcher`.
- The existing `GET /api/videos/[id]/versions` endpoint is preserved and refactored to use the same helper, so behavior stays consistent.

## Why

Issue #64: the version dropdown's data was being fetched on mount, causing a brief empty state and an avoidable round trip. The parent page already queries the video, so we have the cheaper path available — render with the data on first paint.

## Acceptance criteria

- [x] No client-side `fetch()` on mount in `VersionSwitcher`
- [x] Versions load immediately with server-rendered HTML
- [x] Component still works when navigating between versions (Astro re-renders the page, prop is fresh)

Closes #64