### PR TITLE
feat(approvals): enforce required approvals server-side with owner override

### DIFF
--- a/migrations/0020_notifications_nullable_comment.sql
+++ b/migrations/0020_notifications_nullable_comment.sql
@@ -1,0 +1,36 @@
+-- Make notifications.comment_id nullable so non-comment notifications
+-- (e.g. approval.requested) can be persisted without a backing comment.
+-- SQLite cannot drop NOT NULL via ALTER TABLE, so we recreate the table.
+
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE `__new_notifications` (
+  `id` text PRIMARY KEY NOT NULL,
+  `user_id` text NOT NULL REFERENCES `users`(`id`) ON DELETE CASCADE,
+  `actor_user_id` text REFERENCES `users`(`id`) ON DELETE SET NULL,
+  `actor_display_name` text NOT NULL,
+  `type` text NOT NULL,
+  `video_id` text NOT NULL REFERENCES `videos`(`id`) ON DELETE CASCADE,
+  `comment_id` text REFERENCES `comments`(`id`) ON DELETE CASCADE,
+  `parent_comment_id` text REFERENCES `comments`(`id`) ON DELETE CASCADE,
+  `space_id` text NOT NULL REFERENCES `spaces`(`id`) ON DELETE CASCADE,
+  `title` text NOT NULL,
+  `body` text,
+  `href` text NOT NULL,
+  `read_at` text,
+  `created_at` text DEFAULT (datetime('now')) NOT NULL
+);
+
+INSERT INTO `__new_notifications`
+SELECT `id`, `user_id`, `actor_user_id`, `actor_display_name`, `type`,
+       `video_id`, `comment_id`, `parent_comment_id`, `space_id`,
+       `title`, `body`, `href`, `read_at`, `created_at`
+FROM `notifications`;
+
+DROP TABLE `notifications`;
+ALTER TABLE `__new_notifications` RENAME TO `notifications`;
+
+CREATE INDEX `notifications_user_read_idx` ON `notifications` (`user_id`, `read_at`);
+CREATE INDEX `notifications_created_at_idx` ON `notifications` (`created_at`);
+
+PRAGMA foreign_keys=ON;

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -44,7 +44,10 @@ import {
   isCommentReactionEmoji,
   toggleCommentReaction,
 } from "../lib/comments";
-import { createCommentNotifications } from "../lib/notifications";
+import {
+  createCommentNotifications,
+  createApprovalRequestNotifications,
+} from "../lib/notifications";
 import { buildInviteAuthPath, buildInviteEmail } from "../lib/email";
 
 // Re-export ActionError for convenience
@@ -263,8 +266,9 @@ export const server = {
       input: z.object({
         id: z.string().min(1),
         phase: phaseSchema,
+        override: z.boolean().optional(),
       }),
-      handler: async ({ id, phase }, context) => {
+      handler: async ({ id, phase, override }, context) => {
         const user = requireUser(context);
         const db = createDb(env.DB);
 
@@ -295,6 +299,36 @@ export const server = {
           });
         }
 
+        // Server-side approval gate. Only enforced on transitions INTO
+        // published — already-published videos can be unpublished freely,
+        // and increasing requiredApprovals later does not retroactively
+        // un-publish anything.
+        let publishedWithOverride = false;
+        let shortApprovalsBy = 0;
+        if (phase === "published" && video.phase !== "published") {
+          const status = await getApprovalStatus(db, id, video.spaceId);
+          if (status.requiredApprovals > 0 && !status.isApproved) {
+            if (override) {
+              if (role !== "owner") {
+                throw new ActionError({
+                  code: "FORBIDDEN",
+                  message: "Only the space owner can publish without full approvals",
+                });
+              }
+              publishedWithOverride = true;
+              shortApprovalsBy = Math.max(
+                0,
+                status.requiredApprovals - status.currentApprovals,
+              );
+            } else {
+              throw new ActionError({
+                code: "FORBIDDEN",
+                message: "Required approvals not met",
+              });
+            }
+          }
+        }
+
         const now = new Date().toISOString();
         await db
           .update(videos)
@@ -310,11 +344,47 @@ export const server = {
           createdAt: now,
         });
 
+        if (publishedWithOverride) {
+          await logProjectActivity(db, {
+            videoId: id,
+            actorUserId: user.id,
+            actorDisplayName: user.name,
+            type: "phase.published_with_override",
+            data: { shortApprovalsBy },
+            createdAt: now,
+          });
+        }
+
         await broadcastPhaseChange(env, id, {
           videoId: id,
           phase,
           changedBy: user.name,
         });
+
+        // Fire approval-requested notifications when the project enters
+        // `reviewing_video` and the space requires approvals. Don't fail
+        // the action if notification dispatch errors.
+        if (
+          phase === "reviewing_video" &&
+          video.phase !== "reviewing_video"
+        ) {
+          try {
+            const spaceRow = await db
+              .select({ requiredApprovals: spaces.requiredApprovals })
+              .from(spaces)
+              .where(eq(spaces.id, video.spaceId))
+              .limit(1);
+            if ((spaceRow[0]?.requiredApprovals ?? 0) > 0) {
+              await createApprovalRequestNotifications(db, {
+                videoId: id,
+                actorUserId: user.id,
+                actorDisplayName: user.name,
+              });
+            }
+          } catch (err) {
+            console.error("Failed to send approval-requested notifications", err);
+          }
+        }
 
         const updated = await db
           .select()
@@ -397,6 +467,18 @@ export const server = {
         const status = await getApprovalStatus(db, id, video.spaceId);
         await broadcastApprovalUpdate(env, id, status);
 
+        await logProjectActivity(db, {
+          videoId: id,
+          actorUserId: user.id,
+          actorDisplayName: user.name,
+          type: "approval.given",
+          data: {
+            approverUserId: user.id,
+            approverDisplayName: user.name,
+          },
+          createdAt: now,
+        });
+
         return { approvalStatus: status };
       },
     }),
@@ -441,6 +523,17 @@ export const server = {
 
         const status = await getApprovalStatus(db, id, video.spaceId);
         await broadcastApprovalUpdate(env, id, status);
+
+        await logProjectActivity(db, {
+          videoId: id,
+          actorUserId: user.id,
+          actorDisplayName: user.name,
+          type: "approval.revoked",
+          data: {
+            approverUserId: user.id,
+            approverDisplayName: user.name,
+          },
+        });
 
         return { approvalStatus: status };
       },
@@ -865,6 +958,57 @@ export const server = {
           createdAt: now,
           updatedAt: now,
         });
+
+        // Reset approvals when a new version is uploaded. We hard-delete
+        // approval rows for ALL prior versions in this version group so the
+        // approver list starts fresh on the new version. Old versions are
+        // archived/read-only anyway.
+        try {
+          const groupVersions = await db
+            .select({ id: videos.id })
+            .from(videos)
+            .where(
+              and(
+                eq(videos.spaceId, baseVideo.spaceId),
+                eq(videos.versionGroupId, versionGroupId),
+              ),
+            );
+          const priorIds = groupVersions
+            .map((row) => row.id)
+            .filter((existingId) => existingId !== videoId);
+
+          if (priorIds.length > 0) {
+            const existingApprovals = await db
+              .select({ id: approvals.id })
+              .from(approvals)
+              .where(inArray(approvals.videoId, priorIds))
+              .limit(1);
+
+            if (existingApprovals.length > 0) {
+              await db
+                .delete(approvals)
+                .where(inArray(approvals.videoId, priorIds));
+
+              await logProjectActivity(db, {
+                videoId,
+                actorUserId: user.id,
+                actorDisplayName: user.name,
+                type: "approvals.reset",
+                data: { reason: "new_version" },
+                createdAt: now,
+              });
+
+              const status = await getApprovalStatus(
+                db,
+                videoId,
+                baseVideo.spaceId,
+              );
+              await broadcastApprovalUpdate(env, videoId, status);
+            }
+          }
+        } catch (err) {
+          console.error("Failed to reset approvals on new version", err);
+        }
 
         return { videoId, uploadUrl };
       },

--- a/src/components/ApprovalSection.tsx
+++ b/src/components/ApprovalSection.tsx
@@ -127,6 +127,17 @@ export function ApprovalSection({
   const canUndo =
     !readOnly && !!currentUserId && isSpaceMember && hasApproved;
 
+  const dispatchLocalApprovalUpdate = useCallback(
+    (next: ApprovalStatus) => {
+      window.dispatchEvent(
+        new CustomEvent("quickcut:approval-update", {
+          detail: { videoId, status: next },
+        }),
+      );
+    },
+    [videoId],
+  );
+
   const approve = useCallback(async () => {
     setBusy(true);
     setError(null);
@@ -136,13 +147,16 @@ export function ApprovalSection({
         setError(error.message || "Could not approve");
         return;
       }
-      if (data?.approvalStatus) setStatus(data.approvalStatus);
+      if (data?.approvalStatus) {
+        setStatus(data.approvalStatus);
+        dispatchLocalApprovalUpdate(data.approvalStatus);
+      }
     } catch {
       setError("Network error");
     } finally {
       setBusy(false);
     }
-  }, [videoId]);
+  }, [videoId, dispatchLocalApprovalUpdate]);
 
   const undoApproval = useCallback(async () => {
     setBusy(true);
@@ -153,13 +167,16 @@ export function ApprovalSection({
         setError(error.message || "Could not remove approval");
         return;
       }
-      if (data?.approvalStatus) setStatus(data.approvalStatus);
+      if (data?.approvalStatus) {
+        setStatus(data.approvalStatus);
+        dispatchLocalApprovalUpdate(data.approvalStatus);
+      }
     } catch {
       setError("Network error");
     } finally {
       setBusy(false);
     }
-  }, [videoId]);
+  }, [videoId, dispatchLocalApprovalUpdate]);
 
   // Don't render at all if the workflow isn't enabled. Defensive check —
   // callers normally gate the section on requiredApprovals > 0.

--- a/src/components/ApprovalStatusPill.tsx
+++ b/src/components/ApprovalStatusPill.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from "react";
+import {
+  connectVideoRoom,
+  type BroadcastApprovalStatus,
+} from "../lib/realtime";
+import type { ApprovalStatus } from "./ApprovalSection";
+
+interface ApprovalStatusPillProps {
+  videoId: string;
+  initialStatus: ApprovalStatus | null;
+  isPublished: boolean;
+  /** Pass null for share viewers (read-only). */
+  currentUserId: string | null;
+  shareToken?: string;
+  viewerName?: string;
+}
+
+function CheckIcon({ className = "h-3.5 w-3.5" }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        d="M16.704 5.296a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L8 12.586l7.29-7.29a1 1 0 011.414 0z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Compact, prominent approval-state pill for the video detail header.
+ *
+ * Renders one of:
+ *  - "Published" (when the project is published)
+ *  - "Approved" (threshold met)
+ *  - "Awaiting approvals - X/N" (threshold > 0 and not met)
+ *  - nothing (no threshold configured / earlier phase without status)
+ *
+ * Subscribes to the same VideoRoom broadcast channel as ApprovalSection
+ * so progress updates in real time.
+ */
+export function ApprovalStatusPill({
+  videoId,
+  initialStatus,
+  isPublished,
+  currentUserId,
+  shareToken,
+  viewerName,
+}: ApprovalStatusPillProps) {
+  const [status, setStatus] = useState<ApprovalStatus | null>(initialStatus);
+
+  useEffect(() => {
+    setStatus(initialStatus);
+  }, [initialStatus]);
+
+  useEffect(() => {
+    if (isPublished) return;
+    const conn = connectVideoRoom(
+      videoId,
+      {
+        shareToken,
+        viewerName: viewerName || "Anonymous",
+        viewerUserId: currentUserId || undefined,
+      },
+      {
+        onApproval: (incoming: BroadcastApprovalStatus) => {
+          setStatus(incoming);
+        },
+      },
+    );
+    return () => conn.disconnect();
+  }, [videoId, shareToken, viewerName, currentUserId, isPublished]);
+
+  if (isPublished) {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full border border-accent-secondary/30 bg-accent-secondary/15 px-2.5 py-1 text-xs font-semibold text-accent-secondary"
+        aria-label="Project published"
+      >
+        <CheckIcon />
+        Published
+      </span>
+    );
+  }
+
+  if (!status || status.requiredApprovals <= 0) return null;
+
+  if (status.isApproved) {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full border border-accent-secondary/30 bg-accent-secondary/15 px-2.5 py-1 text-xs font-semibold text-accent-secondary"
+        aria-label="Approved"
+      >
+        <CheckIcon />
+        Approved
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-full border border-accent-warning/30 bg-accent-warning/15 px-2.5 py-1 text-xs font-semibold text-accent-warning"
+      aria-label={`Awaiting approvals: ${status.currentApprovals} of ${status.requiredApprovals}`}
+    >
+      <span className="h-1.5 w-1.5 rounded-full bg-accent-warning" aria-hidden="true" />
+      Awaiting approvals · {status.currentApprovals}/{status.requiredApprovals}
+    </span>
+  );
+}

--- a/src/components/ApprovalStatusPill.tsx
+++ b/src/components/ApprovalStatusPill.tsx
@@ -76,6 +76,20 @@ export function ApprovalStatusPill({
     return () => conn.disconnect();
   }, [videoId, shareToken, viewerName, currentUserId, isPublished]);
 
+  // Same-tab sync: ApprovalSection dispatches this event after a local
+  // approve/unapprove so the pill updates immediately even if the WS
+  // broadcast is delayed or the connection is still establishing.
+  useEffect(() => {
+    if (isPublished) return;
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ videoId: string; status: ApprovalStatus }>).detail;
+      if (!detail || detail.videoId !== videoId) return;
+      setStatus(detail.status);
+    };
+    window.addEventListener("quickcut:approval-update", handler);
+    return () => window.removeEventListener("quickcut:approval-update", handler);
+  }, [videoId, isPublished]);
+
   if (isPublished) {
     return (
       <span

--- a/src/components/ProjectActivityTimeline.tsx
+++ b/src/components/ProjectActivityTimeline.tsx
@@ -47,6 +47,38 @@ function getActivityCopy(item: ProjectActivityItem): { title: string; detail: st
       title: "Uploaded first cut",
       detail: typeof data.fileName === "string" ? data.fileName : "Video upload started",
     }),
+    "approval.given": () => ({
+      title: "Approved video",
+      detail:
+        typeof data.approverDisplayName === "string"
+          ? `${data.approverDisplayName} approved this version`
+          : "Video approved",
+    }),
+    "approval.revoked": () => ({
+      title: "Revoked approval",
+      detail:
+        typeof data.approverDisplayName === "string"
+          ? `${data.approverDisplayName} removed their approval`
+          : "Approval revoked",
+    }),
+    "approvals.reset": () => ({
+      title: "Approvals reset",
+      detail:
+        data.reason === "new_version"
+          ? "Approvals cleared for new video version"
+          : "Approvals cleared",
+    }),
+    "phase.published_with_override": () => {
+      const short =
+        typeof data.shortApprovalsBy === "number" ? data.shortApprovalsBy : 0;
+      return {
+        title: "Published without full approvals",
+        detail:
+          short > 0
+            ? `Owner override skipped ${short} pending approval${short === 1 ? "" : "s"}`
+            : "Owner override",
+      };
+    },
   };
 
   return copy[item.type]?.() || { title: item.type, detail: "" };
@@ -58,6 +90,10 @@ function getActivityIcon(type: ProjectActivityType): string {
     "phase.changed": "->",
     "target_date.changed": "cal",
     "first_cut.uploaded": "up",
+    "approval.given": "ok",
+    "approval.revoked": "x",
+    "approvals.reset": "rst",
+    "phase.published_with_override": "!",
   };
   return icons[type];
 }

--- a/src/components/ProjectPhaseControls.tsx
+++ b/src/components/ProjectPhaseControls.tsx
@@ -3,11 +3,24 @@ import { actions } from "astro:actions";
 import { FullscreenOverlay } from "./FullscreenOverlay";
 import { PhaseStepper, type PipelineStep } from "./PhaseStepper";
 import { normalizeVideoPhase, type VideoPhase } from "../types";
+import { PublishOverrideDialog } from "./PublishOverrideDialog";
+import type { ApprovalStatus } from "./ApprovalSection";
 
 type PrimaryAction =
   | { type: "link"; label: string; href: string }
   | { type: "event"; label: string; eventName: string }
-  | { type: "phase"; label: string; phase: VideoPhase; confirmMessage?: string };
+  | {
+      type: "phase";
+      label: string;
+      phase: VideoPhase;
+      confirmMessage?: string;
+      /** When true, this primary action represents an owner override publish. */
+      override?: boolean;
+      /** Optional approval status snapshot for override-path dialog copy. */
+      approvalStatus?: ApprovalStatus | null;
+      /** Tooltip when the action is disabled (e.g. waiting on approvals). */
+      disabledReason?: string;
+    };
 
 interface ProjectPhaseControlsProps {
   videoId: string;
@@ -32,6 +45,7 @@ export function ProjectPhaseControls({
   const [currentPhase, setCurrentPhase] = useState(() => normalizeVideoPhase(initialPhase));
   const [savingPrimaryAction, setSavingPrimaryAction] = useState(false);
   const [confirmPhaseOpen, setConfirmPhaseOpen] = useState(false);
+  const [overrideOpen, setOverrideOpen] = useState(false);
   const [phaseError, setPhaseError] = useState("");
 
   const handlePhaseChange = (phase: VideoPhase) => {
@@ -43,10 +57,15 @@ export function ProjectPhaseControls({
     setSavingPrimaryAction(true);
     setPhaseError("");
     try {
-      const { error } = await actions.video.setPhase({ id: videoId, phase: action.phase });
+      const { error } = await actions.video.setPhase({
+        id: videoId,
+        phase: action.phase,
+        override: action.override,
+      });
       if (error) throw new Error(error.message || "Failed to update phase");
       handlePhaseChange(action.phase);
       setConfirmPhaseOpen(false);
+      setOverrideOpen(false);
     } catch (err) {
       setPhaseError(err instanceof Error ? err.message : "Failed to update phase");
       console.error(err);
@@ -64,6 +83,11 @@ export function ProjectPhaseControls({
     }
 
     if (primaryAction.type === "phase") {
+      if (primaryAction.override) {
+        setPhaseError("");
+        setOverrideOpen(true);
+        return;
+      }
       if (primaryAction.confirmMessage) {
         setPhaseError("");
         setConfirmPhaseOpen(true);
@@ -72,6 +96,16 @@ export function ProjectPhaseControls({
       void runPhaseAction(primaryAction);
     }
   };
+
+  const overrideAction =
+    primaryAction?.type === "phase" && primaryAction.override ? primaryAction : null;
+  const overrideStatus = overrideAction?.approvalStatus ?? null;
+  const overrideShortBy = overrideStatus
+    ? Math.max(
+        0,
+        overrideStatus.requiredApprovals - overrideStatus.currentApprovals,
+      )
+    : 0;
 
   return (
     <>
@@ -104,21 +138,48 @@ export function ProjectPhaseControls({
                 {primaryAction.label}
               </a>
             )}
-            {primaryAction.type !== "link" && (
-              <button
-                type="button"
-                onClick={runPrimaryAction}
-                disabled={savingPrimaryAction}
-                className="inline-flex w-full justify-center rounded-lg bg-accent-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-50 sm:flex-1 lg:w-44 lg:flex-none"
-              >
-                {savingPrimaryAction ? "Saving..." : primaryAction.label}
-              </button>
-            )}
+            {primaryAction.type !== "link" && (() => {
+              const isPhase = primaryAction.type === "phase";
+              const reason = isPhase ? primaryAction.disabledReason : undefined;
+              const isDisabled = savingPrimaryAction || !!reason;
+              const isOverride = isPhase && primaryAction.override;
+              const buttonClass = isOverride
+                ? "inline-flex w-full justify-center rounded-lg border border-accent-warning/40 bg-accent-warning/15 px-4 py-2 text-sm font-medium text-accent-warning transition-colors hover:bg-accent-warning/25 disabled:opacity-50 sm:flex-1 lg:w-44 lg:flex-none"
+                : "inline-flex w-full justify-center rounded-lg bg-accent-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-50 sm:flex-1 lg:w-44 lg:flex-none";
+              return (
+                <button
+                  type="button"
+                  onClick={runPrimaryAction}
+                  disabled={isDisabled}
+                  title={reason}
+                  className={buttonClass}
+                >
+                  {savingPrimaryAction ? "Saving..." : primaryAction.label}
+                </button>
+              );
+            })()}
           </div>
         )}
       </div>
 
-      {primaryAction?.type === "phase" && primaryAction.confirmMessage && (
+      {overrideAction && overrideStatus && (
+        <PublishOverrideDialog
+          isOpen={overrideOpen}
+          onCancel={() => {
+            if (!savingPrimaryAction) setOverrideOpen(false);
+          }}
+          onConfirm={() => {
+            void runPhaseAction(overrideAction);
+          }}
+          loading={savingPrimaryAction}
+          error={phaseError || undefined}
+          shortBy={overrideShortBy}
+          requiredApprovals={overrideStatus.requiredApprovals}
+          currentApprovals={overrideStatus.currentApprovals}
+        />
+      )}
+
+      {primaryAction?.type === "phase" && !primaryAction.override && primaryAction.confirmMessage && (
         <FullscreenOverlay
           isOpen={confirmPhaseOpen}
           onClose={() => {

--- a/src/components/ProjectStatusControls.tsx
+++ b/src/components/ProjectStatusControls.tsx
@@ -53,6 +53,18 @@ export function ProjectStatusControls({
     return () => conn.disconnect();
   }, [videoId, initialApprovalStatus]);
 
+  // Same-tab sync from ApprovalSection.
+  useEffect(() => {
+    if (!initialApprovalStatus) return;
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ videoId: string; status: ApprovalStatus }>).detail;
+      if (!detail || detail.videoId !== videoId) return;
+      setApprovalStatus(detail.status);
+    };
+    window.addEventListener("quickcut:approval-update", handler);
+    return () => window.removeEventListener("quickcut:approval-update", handler);
+  }, [videoId, initialApprovalStatus]);
+
   const requiresApproval =
     !!approvalStatus && approvalStatus.requiredApprovals > 0;
   const isBlockedFromPublish =
@@ -135,6 +147,19 @@ export function ProjectStatusControls({
     label: PROJECT_STATUS_LABELS[option],
   }));
 
+  // Members without permission to change status see a static label instead
+  // of a disabled-but-still-hoverable dropdown.
+  if (!canEdit || isPublished) {
+    return (
+      <div
+        className="inline-flex items-center rounded-lg border border-border-default bg-bg-secondary/60 px-3 py-1.5 text-sm font-medium text-text-secondary"
+        aria-label={`Project status: ${PROJECT_STATUS_LABELS[status]}`}
+      >
+        {PROJECT_STATUS_LABELS[status]}
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-1.5">
       <ToastViewport toasts={toasts} onDismiss={dismissToast} />
@@ -147,7 +172,7 @@ export function ProjectStatusControls({
           options={options}
           value={status}
           onChange={updateStatus}
-          disabled={!canEdit || saving || isPublished}
+          disabled={saving}
           menuAlign="left"
         />
       </div>

--- a/src/components/ProjectStatusControls.tsx
+++ b/src/components/ProjectStatusControls.tsx
@@ -1,13 +1,23 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { actions } from "astro:actions";
 import { PROJECT_STATUS_LABELS, PROJECT_STATUSES, normalizeVideoPhase, type ProjectStatus } from "../types";
 import { Dropdown, type DropdownOption } from "./Dropdown";
 import { ToastViewport, useToast } from "./Toast";
+import { PublishOverrideDialog } from "./PublishOverrideDialog";
+import {
+  connectVideoRoom,
+  type BroadcastApprovalStatus,
+} from "../lib/realtime";
+import type { ApprovalStatus } from "./ApprovalSection";
 
 interface ProjectStatusControlsProps {
   videoId: string;
   initialStatus: string;
   canEdit: boolean;
+  /** Required to gate publishing on approvals. Pass null when approvals are not configured. */
+  initialApprovalStatus?: ApprovalStatus | null;
+  /** True when the current user is the space owner — only owners may override. */
+  isOwner?: boolean;
   onStatusChange?: (status: ProjectStatus) => void;
 }
 
@@ -15,32 +25,109 @@ export function ProjectStatusControls({
   videoId,
   initialStatus,
   canEdit,
+  initialApprovalStatus = null,
+  isOwner = false,
   onStatusChange,
 }: ProjectStatusControlsProps) {
   const [status, setStatus] = useState<ProjectStatus>(() => normalizeVideoPhase(initialStatus));
   const [saving, setSaving] = useState(false);
+  const [approvalStatus, setApprovalStatus] = useState<ApprovalStatus | null>(initialApprovalStatus);
+  const [overrideOpen, setOverrideOpen] = useState(false);
+  const [overrideError, setOverrideError] = useState<string | null>(null);
   const { toasts, showToast, dismissToast } = useToast();
   const isPublished = status === "published";
 
-  const updateStatus = async (nextStatus: ProjectStatus) => {
-    if (nextStatus === status || saving) return;
-    if (nextStatus === "published" && !window.confirm("Publishing locks the project. Script, comments, and video versions become read-only.")) {
-      return;
-    }
+  // Keep approvalStatus in sync via the realtime broadcast so the gate
+  // unlocks (or relocks) the moment any reviewer approves/unapproves.
+  useEffect(() => {
+    if (!initialApprovalStatus) return;
+    const conn = connectVideoRoom(
+      videoId,
+      { viewerName: "owner" },
+      {
+        onApproval: (incoming: BroadcastApprovalStatus) => {
+          setApprovalStatus(incoming);
+        },
+      },
+    );
+    return () => conn.disconnect();
+  }, [videoId, initialApprovalStatus]);
 
+  const requiresApproval =
+    !!approvalStatus && approvalStatus.requiredApprovals > 0;
+  const isBlockedFromPublish =
+    requiresApproval && !approvalStatus!.isApproved;
+  const shortBy = approvalStatus
+    ? Math.max(0, approvalStatus.requiredApprovals - approvalStatus.currentApprovals)
+    : 0;
+
+  const performStatusUpdate = async (
+    nextStatus: ProjectStatus,
+    override?: boolean,
+  ): Promise<boolean> => {
     setSaving(true);
     try {
-      const { error } = await actions.video.setPhase({ id: videoId, phase: nextStatus });
+      const { error } = await actions.video.setPhase({
+        id: videoId,
+        phase: nextStatus,
+        override,
+      });
       if (error) throw new Error(error.message || "Failed to update project status");
       setStatus(nextStatus);
       onStatusChange?.(nextStatus);
-      showToast("Status successfully updated");
+      showToast(
+        override
+          ? "Published without full approvals"
+          : "Status successfully updated",
+      );
+      return true;
     } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to update status";
+      if (override) {
+        setOverrideError(message);
+      } else {
+        showToast(message, "error");
+      }
       console.error(err);
-      showToast("Failed to update status", "error");
+      return false;
     } finally {
       setSaving(false);
     }
+  };
+
+  const updateStatus = async (nextStatus: ProjectStatus) => {
+    if (nextStatus === status || saving) return;
+
+    if (nextStatus === "published") {
+      if (isBlockedFromPublish) {
+        if (!isOwner) {
+          showToast(
+            `Needs ${shortBy} more approval${shortBy === 1 ? "" : "s"} before publishing.`,
+            "error",
+          );
+          return;
+        }
+        // Owner override path — open confirmation dialog.
+        setOverrideError(null);
+        setOverrideOpen(true);
+        return;
+      }
+      if (
+        !window.confirm(
+          "Publishing locks the project. Script, comments, and video versions become read-only.",
+        )
+      ) {
+        return;
+      }
+    }
+
+    await performStatusUpdate(nextStatus);
+  };
+
+  const confirmOverride = async () => {
+    const ok = await performStatusUpdate("published", true);
+    if (ok) setOverrideOpen(false);
   };
 
   const options: DropdownOption<ProjectStatus>[] = PROJECT_STATUSES.map((option) => ({
@@ -64,6 +151,21 @@ export function ProjectStatusControls({
           menuAlign="left"
         />
       </div>
+
+      {approvalStatus && (
+        <PublishOverrideDialog
+          isOpen={overrideOpen}
+          onCancel={() => {
+            if (!saving) setOverrideOpen(false);
+          }}
+          onConfirm={confirmOverride}
+          loading={saving}
+          error={overrideError}
+          shortBy={shortBy}
+          requiredApprovals={approvalStatus.requiredApprovals}
+          currentApprovals={approvalStatus.currentApprovals}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/PublishOverrideDialog.tsx
+++ b/src/components/PublishOverrideDialog.tsx
@@ -1,0 +1,92 @@
+import { useId } from "react";
+import { FullscreenOverlay } from "./FullscreenOverlay";
+
+interface PublishOverrideDialogProps {
+  isOpen: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  loading?: boolean;
+  error?: string | null;
+  /** How many approvals short of the threshold the project is. */
+  shortBy: number;
+  /** Total required approvals (for context in the dialog body). */
+  requiredApprovals: number;
+  /** Current approval count (for context). */
+  currentApprovals: number;
+}
+
+/**
+ * Owner-only override confirmation. Shown when an owner attempts to
+ * publish a video that has not met its required-approvals threshold.
+ * The override is logged in the project activity timeline.
+ */
+export function PublishOverrideDialog({
+  isOpen,
+  onCancel,
+  onConfirm,
+  loading = false,
+  error,
+  shortBy,
+  requiredApprovals,
+  currentApprovals,
+}: PublishOverrideDialogProps) {
+  const headingId = useId();
+
+  return (
+    <FullscreenOverlay
+      isOpen={isOpen}
+      onClose={() => {
+        if (!loading) onCancel();
+      }}
+      closeOnBackdropClick={!loading}
+      closeOnEscape={!loading}
+      ariaLabelledBy={headingId}
+      contentClassName="m-4 w-full max-w-md rounded-2xl border border-border-default bg-bg-secondary p-6 shadow-2xl"
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!loading) onConfirm();
+        }}
+      >
+        <h2 id={headingId} className="text-lg font-semibold text-text-primary">
+          Publish without full approvals?
+        </h2>
+        <p className="mt-2 text-sm text-text-secondary">
+          This project has {currentApprovals} of {requiredApprovals} required
+          approval{requiredApprovals === 1 ? "" : "s"}. As space owner, you can
+          publish anyway — but the override will be recorded in the project
+          activity timeline.
+        </p>
+        <div className="mt-3 rounded-lg border border-accent-warning/30 bg-accent-warning/10 px-3 py-2 text-xs text-accent-warning">
+          Publishing will skip {shortBy} pending approval
+          {shortBy === 1 ? "" : "s"}.
+        </div>
+
+        {error && (
+          <div className="mt-4 rounded-lg bg-accent-danger/15 px-3 py-2 text-sm text-accent-danger">
+            {error}
+          </div>
+        )}
+
+        <div className="mt-6 flex gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={loading}
+            className="flex-1 rounded-lg border border-border-default px-4 py-2 text-sm text-text-primary transition-colors hover:bg-bg-tertiary disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={loading}
+            className="flex-1 rounded-lg bg-accent-warning px-4 py-2 text-sm font-medium text-white transition-colors hover:opacity-90 disabled:opacity-50"
+          >
+            {loading ? "Publishing..." : "Publish anyway"}
+          </button>
+        </div>
+      </form>
+    </FullscreenOverlay>
+  );
+}

--- a/src/components/VideoDetailView.tsx
+++ b/src/components/VideoDetailView.tsx
@@ -92,16 +92,46 @@ export function VideoDetailView({
   const [liveComments, setLiveComments] = useState(initialReviewComments);
   const isPublished = currentPhase === "published";
   const canChangePhase = !isShareMode && pipelineEnabled && (userRole === "owner" || uploadedBy === currentUserId);
+  const isOwner = userRole === "owner";
   const scriptLockedMessage = "This script is read-only because a video has been uploaded. Use the Video step for feedback on the cut.";
-  const canMarkAsPublished = !isPublished && canChangePhase && (!approvalStatus || approvalStatus.isApproved);
-  const primaryAction = canMarkAsPublished
-    ? {
-        type: "phase" as const,
+  const requiresApproval =
+    !!approvalStatus && approvalStatus.requiredApprovals > 0;
+  const isApprovalBlocked =
+    requiresApproval && !approvalStatus!.isApproved;
+  const shortApprovalsBy = approvalStatus
+    ? Math.max(
+        0,
+        approvalStatus.requiredApprovals - approvalStatus.currentApprovals,
+      )
+    : 0;
+
+  let primaryAction: React.ComponentProps<typeof ProjectPhaseControls>["primaryAction"] = null;
+  if (!isPublished && canChangePhase) {
+    if (!isApprovalBlocked) {
+      primaryAction = {
+        type: "phase",
         label: "Mark as Published",
-        phase: "published" as const,
-        confirmMessage: "Marking this project as published locks the script, comments, and versions. This assumes you have published the video manually elsewhere.",
-      }
-    : null;
+        phase: "published",
+        confirmMessage:
+          "Marking this project as published locks the script, comments, and versions. This assumes you have published the video manually elsewhere.",
+      };
+    } else if (isOwner) {
+      primaryAction = {
+        type: "phase",
+        label: "Publish without approvals",
+        phase: "published",
+        override: true,
+        approvalStatus,
+      };
+    } else {
+      primaryAction = {
+        type: "phase",
+        label: "Mark as Published",
+        phase: "published",
+        disabledReason: `Needs ${shortApprovalsBy} more approval${shortApprovalsBy === 1 ? "" : "s"}.`,
+      };
+    }
+  }
   const [focusRequest, setFocusRequest] = useState<{ id: string; nonce: number } | null>(null);
   const [activeTool, setActiveTool] = useState<AnnotationTool>("none");
   const [pendingAnnotation, setPendingAnnotation] = useState<Annotation | null>(null);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -168,6 +168,10 @@ export const projectActivity = sqliteTable("project_activity", {
       "phase.changed",
       "target_date.changed",
       "first_cut.uploaded",
+      "approval.given",
+      "approval.revoked",
+      "approvals.reset",
+      "phase.published_with_override",
     ],
   }).notNull(),
   data: text("data"),
@@ -365,14 +369,15 @@ export const notifications = sqliteTable(
         "comment.reply",
         "script_comment.created",
         "script_comment.reply",
+        "approval.requested",
       ],
     }).notNull(),
     videoId: text("video_id")
       .notNull()
       .references(() => videos.id, { onDelete: "cascade" }),
-    commentId: text("comment_id")
-      .notNull()
-      .references(() => comments.id, { onDelete: "cascade" }),
+    commentId: text("comment_id").references(() => comments.id, {
+      onDelete: "cascade",
+    }),
     parentCommentId: text("parent_comment_id").references(() => comments.id, {
       onDelete: "cascade",
     }),

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -6,7 +6,11 @@ export type ProjectActivityType =
   | "project.created"
   | "phase.changed"
   | "target_date.changed"
-  | "first_cut.uploaded";
+  | "first_cut.uploaded"
+  | "approval.given"
+  | "approval.revoked"
+  | "approvals.reset"
+  | "phase.published_with_override";
 
 export interface ProjectActivityItem {
   id: string;

--- a/src/lib/notification-copy.ts
+++ b/src/lib/notification-copy.ts
@@ -2,7 +2,8 @@ export type NotificationType =
   | "comment.created"
   | "comment.reply"
   | "script_comment.created"
-  | "script_comment.reply";
+  | "script_comment.reply"
+  | "approval.requested";
 
 export interface NotificationCopy {
   title: string;
@@ -34,6 +35,11 @@ export function getNotificationCopy(
       return {
         title: `${actorName} commented on "${videoTitle}"`,
         heading: "New comment on your video",
+      };
+    case "approval.requested":
+      return {
+        title: `${actorName} requested your approval on "${videoTitle}"`,
+        heading: "Approval requested",
       };
   }
 }

--- a/src/lib/notification-copy.ts
+++ b/src/lib/notification-copy.ts
@@ -37,9 +37,12 @@ export function getNotificationCopy(
         heading: "New comment on your video",
       };
     case "approval.requested":
+      // Generic copy by design: until we add explicit, per-user approval
+      // requests, this notification fans out to every space member, so the
+      // wording can't claim "your approval" was requested.
       return {
-        title: `${actorName} requested your approval on "${videoTitle}"`,
-        heading: "Approval requested",
+        title: `"${videoTitle}" is looking for approval`,
+        heading: "Approval needed",
       };
   }
 }

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -187,6 +187,76 @@ export async function createCommentNotifications(
   }
 }
 
+export interface ApprovalRequestNotificationInput {
+  videoId: string;
+  actorUserId: string | null;
+  actorDisplayName: string;
+}
+
+/**
+ * Notify all space members (excluding the actor and the video uploader)
+ * that a video has entered review and requires their approval. Fires when
+ * a video transitions into `reviewing_video` and the space has
+ * `requiredApprovals > 0`.
+ */
+export async function createApprovalRequestNotifications(
+  db: Database,
+  input: ApprovalRequestNotificationInput,
+): Promise<void> {
+  const videoRows = await db
+    .select({
+      id: videos.id,
+      title: videos.title,
+      uploadedBy: videos.uploadedBy,
+      spaceId: videos.spaceId,
+    })
+    .from(videos)
+    .where(eq(videos.id, input.videoId))
+    .limit(1);
+
+  const video = videoRows[0];
+  if (!video) return;
+
+  const memberRows = await db
+    .select({ userId: spaceMembers.userId })
+    .from(spaceMembers)
+    .where(eq(spaceMembers.spaceId, video.spaceId));
+
+  const exclude = new Set<string>();
+  if (input.actorUserId) exclude.add(input.actorUserId);
+  if (video.uploadedBy) exclude.add(video.uploadedBy);
+
+  const recipientIds = memberRows
+    .map((row) => row.userId)
+    .filter((id) => !exclude.has(id));
+
+  if (recipientIds.length === 0) return;
+
+  const copy = getNotificationCopy(
+    "approval.requested",
+    input.actorDisplayName,
+    video.title,
+  );
+  const href = `/videos/${video.id}?tab=video`;
+
+  await db.insert(notifications).values(
+    recipientIds.map((userId) => ({
+      id: crypto.randomUUID(),
+      userId,
+      actorUserId: input.actorUserId,
+      actorDisplayName: input.actorDisplayName,
+      type: "approval.requested" as const,
+      videoId: video.id,
+      commentId: null,
+      parentCommentId: null,
+      spaceId: video.spaceId,
+      title: copy.title,
+      body: null,
+      href,
+    })),
+  );
+}
+
 export async function getNotificationsForUser(
   db: Database,
   userId: string,

--- a/src/pages/videos/[id]/index.astro
+++ b/src/pages/videos/[id]/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../../../layouts/Layout.astro";
 import { ProjectStatusControls } from "../../../components/ProjectStatusControls";
+import { ApprovalStatusPill } from "../../../components/ApprovalStatusPill";
 import { InlineEditor } from "../../../components/InlineEditor";
 import { ScriptWorkspace } from "../../../components/ScriptWorkspace";
 import { UploadView } from "../../../components/UploadView";
@@ -96,7 +97,22 @@ const tabHref = (tab: "script" | "video") => {
                 as="h1"
                 className="min-w-0 break-words text-2xl font-bold text-text-primary sm:text-3xl"
               />
-              <ProjectStatusControls client:load videoId={video.id} initialStatus={phase} canEdit={canEditStatus} />
+              <ProjectStatusControls
+                client:load
+                videoId={video.id}
+                initialStatus={phase}
+                canEdit={canEditStatus}
+                initialApprovalStatus={showApprovals ? approvalStatus : null}
+                isOwner={isOwner}
+              />
+              <ApprovalStatusPill
+                client:load
+                videoId={video.id}
+                initialStatus={showApprovals ? approvalStatus : null}
+                isPublished={isPublished}
+                currentUserId={user.id}
+                viewerName={user.name}
+              />
             </div>
           </div>
           <div class="mt-4">

--- a/src/pages/videos/[id]/index.astro
+++ b/src/pages/videos/[id]/index.astro
@@ -105,14 +105,16 @@ const tabHref = (tab: "script" | "video") => {
                 initialApprovalStatus={showApprovals ? approvalStatus : null}
                 isOwner={isOwner}
               />
-              <ApprovalStatusPill
-                client:load
-                videoId={video.id}
-                initialStatus={showApprovals ? approvalStatus : null}
-                isPublished={isPublished}
-                currentUserId={user.id}
-                viewerName={user.name}
-              />
+              {(hasVideo || isPublished) && (
+                <ApprovalStatusPill
+                  client:load
+                  videoId={video.id}
+                  initialStatus={showApprovals ? approvalStatus : null}
+                  isPublished={isPublished}
+                  currentUserId={user.id}
+                  viewerName={user.name}
+                />
+              )}
             </div>
           </div>
           <div class="mt-4">


### PR DESCRIPTION
## Summary

Closes #80.

Closes the publish-gate gap: marking a video as published is now blocked **server-side** in the `setPhase` action when `requiredApprovals > 0` and the threshold isn't met. Space owners can bypass the gate by passing `override: true`, which is logged to the project activity timeline. Adds the supporting UX pieces (header pill, override dialog, version-reset, approval-requested notification, activity entries).

## Changes

### Server enforcement (the actual fix)
- `actions.video.setPhase` now accepts `override?: boolean` and rejects transitions to `phase: "published"` when the threshold isn't met (only enforced on transitions *into* published — already-published videos can still unpublish freely).
- Owner override path requires `role === "owner"`; non-owners attempting `override: true` are rejected.
- Override publishes log a `phase.published_with_override` activity entry with `shortApprovalsBy`.

### Approvals reset on new version
- After `uploadVersion` writes the new row, all approval rows for prior versions in the version group are hard-deleted.
- Logs an `approvals.reset` activity entry (`{ reason: "new_version" }`) and broadcasts a fresh approval status snapshot.

### approval.requested notification
- New helper `createApprovalRequestNotifications` in `src/lib/notifications.ts`.
- Fires from `setPhase` when transitioning **into** `reviewing_video` and `requiredApprovals > 0`.
- Recipients: all space members except the actor and the uploader.
- Migration `0020` makes `notifications.comment_id` nullable so non-comment notifications can be persisted.

### Header pill
- New `ApprovalStatusPill` component shown in the video detail header.
- States: `Published` / `Approved` / `Awaiting approvals · X/N` / hidden.
- Realtime-subscribed via the existing VideoRoom broadcast channel.

### Override dialog
- New `PublishOverrideDialog` reused by both `ProjectStatusControls` (standard mode) and `ProjectPhaseControls` (pipeline mode).
- Non-owners on an unapproved video see the publish button disabled with a tooltip explaining how many more approvals are needed.
- Owners see the button relabel to **"Publish without approvals"** and confirm via the dialog.

### Activity timeline
- New activity types: `approval.given`, `approval.revoked`, `approvals.reset`, `phase.published_with_override`.
- Logged from `video.approve`, `video.unapprove`, `uploadVersion`, and `setPhase` (override branch).
- Copy + icons added to `ProjectActivityTimeline`.

## Files touched

- **Server:** `src/actions/index.ts`, `src/db/schema.ts`, `src/lib/activity.ts`, `src/lib/notifications.ts`, `src/lib/notification-copy.ts`
- **Migration:** `migrations/0020_notifications_nullable_comment.sql`
- **UI:** `src/components/ApprovalStatusPill.tsx` (new), `src/components/PublishOverrideDialog.tsx` (new), `src/components/ProjectStatusControls.tsx`, `src/components/ProjectPhaseControls.tsx`, `src/components/VideoDetailView.tsx`, `src/components/ProjectActivityTimeline.tsx`, `src/pages/videos/[id]/index.astro`

## Out of scope

- A persistent "Published without full approvals" badge on the video card / detail header (override visibility is via activity log only, per the locked-in decision in the issue thread).
- `approval.revoked` notifications, per-approval notifications, email digests, named approver delegation.

## Verification

- `pnpm build` succeeds.
- Migration `0020` applied locally without errors.
- Manual test plan in the PR description below.