### PR TITLE
feat: add video metadata (audience, hook, takeaways, CTA, outro)

### DIFF
--- a/migrations/0021_add_video_metadata_fields.sql
+++ b/migrations/0021_add_video_metadata_fields.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `videos` ADD `target_audience` text;
+ALTER TABLE `videos` ADD `hook` text;
+ALTER TABLE `videos` ADD `takeaway1` text;
+ALTER TABLE `videos` ADD `takeaway2` text;
+ALTER TABLE `videos` ADD `takeaway3` text;
+ALTER TABLE `videos` ADD `primary_cta` text;
+ALTER TABLE `videos` ADD `outro` text;

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -113,6 +113,13 @@ export const server = {
         description: z.string().max(2000).optional(),
         targetDate: z.string().date().nullable().optional(),
         folderId: z.string().uuid().nullable().optional(),
+        targetAudience: z.string().max(200).nullable().optional(),
+        hook: z.string().max(500).nullable().optional(),
+        takeaway1: z.string().max(200).nullable().optional(),
+        takeaway2: z.string().max(200).nullable().optional(),
+        takeaway3: z.string().max(200).nullable().optional(),
+        primaryCta: z.string().max(200).nullable().optional(),
+        outro: z.string().max(500).nullable().optional(),
       }),
       handler: async (input, context) => {
         const user = requireUser(context);
@@ -139,18 +146,57 @@ export const server = {
           input.targetDate !== undefined &&
           input.title === undefined &&
           input.description === undefined &&
-          input.folderId === undefined;
+          input.folderId === undefined &&
+          input.targetAudience === undefined &&
+          input.hook === undefined &&
+          input.takeaway1 === undefined &&
+          input.takeaway2 === undefined &&
+          input.takeaway3 === undefined &&
+          input.primaryCta === undefined &&
+          input.outro === undefined;
 
         if (video.phase === "published" && !targetDateOnly) {
           throw new ActionError({ code: "FORBIDDEN", message: "Cannot edit published videos" });
         }
 
-        const updates: { title?: string; description?: string; targetDate?: string | null } = {};
+        const updates: {
+          title?: string;
+          description?: string;
+          targetDate?: string | null;
+          targetAudience?: string | null;
+          hook?: string | null;
+          takeaway1?: string | null;
+          takeaway2?: string | null;
+          takeaway3?: string | null;
+          primaryCta?: string | null;
+          outro?: string | null;
+        } = {};
         let folderUpdate: string | null | undefined;
+
+        const normalizeMetadata = (value: string | null | undefined) => {
+          if (value === undefined) return undefined;
+          if (value === null) return null;
+          const trimmed = value.trim();
+          return trimmed.length === 0 ? null : trimmed;
+        };
 
         if (input.title !== undefined) updates.title = input.title.trim();
         if (input.description !== undefined) updates.description = input.description.trim();
         if (input.targetDate !== undefined) updates.targetDate = input.targetDate;
+        const audience = normalizeMetadata(input.targetAudience);
+        if (audience !== undefined) updates.targetAudience = audience;
+        const hookValue = normalizeMetadata(input.hook);
+        if (hookValue !== undefined) updates.hook = hookValue;
+        const t1 = normalizeMetadata(input.takeaway1);
+        if (t1 !== undefined) updates.takeaway1 = t1;
+        const t2 = normalizeMetadata(input.takeaway2);
+        if (t2 !== undefined) updates.takeaway2 = t2;
+        const t3 = normalizeMetadata(input.takeaway3);
+        if (t3 !== undefined) updates.takeaway3 = t3;
+        const cta = normalizeMetadata(input.primaryCta);
+        if (cta !== undefined) updates.primaryCta = cta;
+        const outroValue = normalizeMetadata(input.outro);
+        if (outroValue !== undefined) updates.outro = outroValue;
         if (input.folderId !== undefined) {
           const folderId = input.folderId ?? null;
           if (folderId) {

--- a/src/components/InlineEditor.tsx
+++ b/src/components/InlineEditor.tsx
@@ -55,13 +55,6 @@ export function InlineEditor({
     }
   }, [isEditing]);
 
-  // Keep displayed value in sync if the parent updates `value` prop.
-  useEffect(() => {
-    if (!isEditing) {
-      setValue(initialValue);
-    }
-  }, [initialValue, isEditing]);
-
   const save = async () => {
     const trimmed = value.trim();
     // Title is the only required field; empty input reverts to original.

--- a/src/components/InlineEditor.tsx
+++ b/src/components/InlineEditor.tsx
@@ -1,14 +1,29 @@
 import { useState, useRef, useEffect } from "react";
 import { actions } from "astro:actions";
 
+export type InlineEditorField =
+  | "title"
+  | "description"
+  | "targetAudience"
+  | "hook"
+  | "takeaway1"
+  | "takeaway2"
+  | "takeaway3"
+  | "primaryCta"
+  | "outro";
+
 interface InlineEditorProps {
   value: string;
-  field: "title" | "description";
+  field: InlineEditorField;
   videoId: string;
   isOwner: boolean;
   as?: "h1" | "p";
   placeholder?: string;
   className?: string;
+  /** Render a multi-line textarea instead of a single-line input. */
+  multiline?: boolean;
+  /** Maximum number of characters allowed. */
+  maxLength?: number;
 }
 
 export function InlineEditor({
@@ -19,7 +34,15 @@ export function InlineEditor({
   as: Tag = "p",
   placeholder = "Click to edit...",
   className = "",
+  multiline,
+  maxLength,
 }: InlineEditorProps) {
+  // Title and description preserve their historical multiline behavior:
+  // title is single-line, description is multi-line. New fields opt in via
+  // the explicit `multiline` prop.
+  const isMultiline =
+    multiline !== undefined ? multiline : field === "description";
+
   const [isEditing, setIsEditing] = useState(false);
   const [value, setValue] = useState(initialValue);
   const [saving, setSaving] = useState(false);
@@ -32,8 +55,16 @@ export function InlineEditor({
     }
   }, [isEditing]);
 
+  // Keep displayed value in sync if the parent updates `value` prop.
+  useEffect(() => {
+    if (!isEditing) {
+      setValue(initialValue);
+    }
+  }, [initialValue, isEditing]);
+
   const save = async () => {
     const trimmed = value.trim();
+    // Title is the only required field; empty input reverts to original.
     if (!trimmed && field === "title") {
       setValue(initialValue);
       setIsEditing(false);
@@ -47,10 +78,13 @@ export function InlineEditor({
 
     setSaving(true);
     try {
-      const { error } = await actions.video.update({
+      // For optional metadata fields, an empty string clears the value.
+      // The server normalizes "" to null, so we just send the trimmed string.
+      const payload: Record<string, string> = {
         id: videoId,
         [field]: trimmed,
-      });
+      };
+      const { error } = await actions.video.update(payload as never);
       if (!error) {
         setValue(trimmed);
       } else {
@@ -64,7 +98,13 @@ export function InlineEditor({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && field === "title") {
+    // Single-line fields commit on Enter. Multi-line fields commit on
+    // Cmd/Ctrl+Enter so newlines stay accessible.
+    if (e.key === "Enter" && !isMultiline) {
+      e.preventDefault();
+      save();
+    }
+    if (e.key === "Enter" && isMultiline && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
       save();
     }
@@ -75,17 +115,18 @@ export function InlineEditor({
   };
 
   if (!isOwner) {
-    const readOnlyDescStyles =
-      field === "description" ? "w-full min-h-[2.5rem] whitespace-pre-wrap" : "";
+    const readOnlyMultilineStyles = isMultiline
+      ? "w-full min-h-[2.5rem] whitespace-pre-wrap"
+      : "";
     return (
-      <Tag className={`${readOnlyDescStyles} ${className}`}>
+      <Tag className={`${readOnlyMultilineStyles} ${className}`}>
         {value || placeholder}
       </Tag>
     );
   }
 
   if (isEditing) {
-    if (field === "description") {
+    if (isMultiline) {
       return (
         <textarea
           ref={inputRef as React.RefObject<HTMLTextAreaElement>}
@@ -95,6 +136,7 @@ export function InlineEditor({
           onKeyDown={handleKeyDown}
           disabled={saving}
           rows={3}
+          maxLength={maxLength}
           className={`w-full resize-none rounded-lg border border-accent-primary bg-bg-input px-3 py-2 text-sm text-text-primary focus:outline-none ${className}`}
           placeholder={placeholder}
         />
@@ -110,21 +152,22 @@ export function InlineEditor({
         onBlur={save}
         onKeyDown={handleKeyDown}
         disabled={saving}
+        maxLength={maxLength}
         className={`w-full rounded-lg border border-accent-primary bg-bg-input px-3 py-2 text-text-primary focus:outline-none ${className}`}
+        placeholder={placeholder}
       />
     );
   }
 
-  const descriptionStyles =
-    field === "description"
-      ? "w-full min-h-[5.25rem] whitespace-pre-wrap border border-accent-primary/25 py-2 hover:border-accent-primary/50"
-      : "";
-  const displayPadding = field === "description" ? "px-3" : "px-0 py-0";
+  const multilineStyles = isMultiline
+    ? "w-full min-h-[5.25rem] whitespace-pre-wrap border border-accent-primary/25 py-2 hover:border-accent-primary/50"
+    : "";
+  const displayPadding = isMultiline ? "px-3" : "px-0 py-0";
 
   return (
     <Tag
       onClick={() => setIsEditing(true)}
-      className={`cursor-pointer rounded-lg ${displayPadding} transition-colors hover:bg-bg-tertiary ${descriptionStyles} ${className} ${!value ? "text-text-tertiary italic" : ""}`}
+      className={`cursor-pointer rounded-lg ${displayPadding} transition-colors hover:bg-bg-tertiary ${multilineStyles} ${className} ${!value ? "text-text-tertiary italic" : ""}`}
       title="Click to edit"
     >
       {value || placeholder}

--- a/src/components/MetadataField.tsx
+++ b/src/components/MetadataField.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef, useState } from "react";
+import { actions } from "astro:actions";
+import type { InlineEditorField } from "./InlineEditor";
+
+interface MetadataFieldProps {
+  videoId: string;
+  field: InlineEditorField;
+  initialValue: string | null;
+  isOwner: boolean;
+  label: string;
+  placeholder: string;
+  multiline?: boolean;
+  maxLength?: number;
+}
+
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+/**
+ * Always-on form-style metadata field. Owners see an input/textarea they can
+ * type into directly; non-owners see the value as plain read-only text. Saves
+ * on blur (or Cmd/Ctrl+Enter for multiline) and shows a transient status hint.
+ */
+export function MetadataField({
+  videoId,
+  field,
+  initialValue,
+  isOwner,
+  label,
+  placeholder,
+  multiline,
+  maxLength,
+}: MetadataFieldProps) {
+  const [value, setValue] = useState(initialValue ?? "");
+  // The committed value is what we'll diff against on blur to decide whether
+  // to send a save request. We update it whenever a save succeeds.
+  const committedRef = useRef(initialValue ?? "");
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+  const savedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (savedTimeoutRef.current) clearTimeout(savedTimeoutRef.current);
+    };
+  }, []);
+
+  if (!isOwner) {
+    const display = value.trim();
+    return (
+      <div className="space-y-1.5">
+        <p className="text-xs font-semibold uppercase tracking-wide text-text-tertiary">
+          {label}
+        </p>
+        {display ? (
+          <p
+            className={`max-w-2xl break-words text-sm text-text-primary ${
+              multiline ? "whitespace-pre-wrap" : ""
+            }`}
+          >
+            {display}
+          </p>
+        ) : (
+          <p className="text-sm italic text-text-tertiary">Not set</p>
+        )}
+      </div>
+    );
+  }
+
+  const commit = async () => {
+    const trimmed = value.trim();
+    if (trimmed === committedRef.current) {
+      // Reflect the canonical (trimmed) form in the input without saving.
+      if (trimmed !== value) setValue(trimmed);
+      return;
+    }
+
+    setSaveState("saving");
+    try {
+      const payload: Record<string, string> = {
+        id: videoId,
+        [field]: trimmed,
+      };
+      const { error } = await actions.video.update(payload as never);
+      if (error) {
+        setSaveState("error");
+        return;
+      }
+      committedRef.current = trimmed;
+      setValue(trimmed);
+      setSaveState("saved");
+      if (savedTimeoutRef.current) clearTimeout(savedTimeoutRef.current);
+      savedTimeoutRef.current = setTimeout(() => {
+        setSaveState("idle");
+      }, 1500);
+    } catch {
+      setSaveState("error");
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !multiline) {
+      e.preventDefault();
+      e.currentTarget.blur();
+    }
+    if (e.key === "Enter" && multiline && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      e.currentTarget.blur();
+    }
+    if (e.key === "Escape") {
+      setValue(committedRef.current);
+      e.currentTarget.blur();
+    }
+  };
+
+  const baseInputClass =
+    "w-full rounded-lg border border-border-default bg-bg-input px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary placeholder:italic focus:border-accent-primary focus:outline-none disabled:opacity-60";
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-baseline justify-between gap-3">
+        <label
+          className="text-xs font-semibold uppercase tracking-wide text-text-tertiary"
+          htmlFor={`field-${field}`}
+        >
+          {label}
+        </label>
+        <span className="text-xs text-text-tertiary" aria-live="polite">
+          {saveState === "saving" && "Saving…"}
+          {saveState === "saved" && "Saved"}
+          {saveState === "error" && (
+            <span className="text-accent-secondary">Save failed</span>
+          )}
+        </span>
+      </div>
+      {multiline ? (
+        <textarea
+          id={`field-${field}`}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onBlur={commit}
+          onKeyDown={handleKeyDown}
+          rows={3}
+          maxLength={maxLength}
+          placeholder={placeholder}
+          disabled={saveState === "saving"}
+          className={`${baseInputClass} resize-y`}
+        />
+      ) : (
+        <input
+          id={`field-${field}`}
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onBlur={commit}
+          onKeyDown={handleKeyDown}
+          maxLength={maxLength}
+          placeholder={placeholder}
+          disabled={saveState === "saving"}
+          className={baseInputClass}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -41,9 +41,7 @@ export function NewProjectDialog({ spaceId, folderId = null }: NewProjectDialogP
       if (actionError || !data?.videoId) {
         throw new Error(actionError?.message || "Failed to create project");
       }
-      // Land new projects on the Details tab so creators can fill in the
-      // brief (audience, hook, takeaways) before writing the script.
-      window.location.href = `/videos/${data.videoId}?space=${spaceId}&tab=details`;
+      window.location.href = `/videos/${data.videoId}?space=${spaceId}`;
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create project");
       setSaving(false);

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -41,7 +41,9 @@ export function NewProjectDialog({ spaceId, folderId = null }: NewProjectDialogP
       if (actionError || !data?.videoId) {
         throw new Error(actionError?.message || "Failed to create project");
       }
-      window.location.href = `/videos/${data.videoId}?space=${spaceId}`;
+      // Land new projects on the Details tab so creators can fill in the
+      // brief (audience, hook, takeaways) before writing the script.
+      window.location.href = `/videos/${data.videoId}?space=${spaceId}&tab=details`;
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create project");
       setSaving(false);

--- a/src/components/VideoBriefPanel.tsx
+++ b/src/components/VideoBriefPanel.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+
+interface VideoBriefPanelProps {
+  hook: string | null;
+  takeaway1: string | null;
+  takeaway2: string | null;
+  takeaway3: string | null;
+}
+
+/**
+ * Read-only display of the video's "brief" — hook + 3 takeaways — surfaced on
+ * the review (Video) tab so reviewers can see authorial intent alongside the
+ * cut. Hidden entirely when none of the fields are populated.
+ */
+export function VideoBriefPanel({
+  hook,
+  takeaway1,
+  takeaway2,
+  takeaway3,
+}: VideoBriefPanelProps) {
+  const takeaways = [takeaway1, takeaway2, takeaway3].filter(
+    (t): t is string => !!t && t.trim().length > 0,
+  );
+  const hasHook = !!hook && hook.trim().length > 0;
+  const hasContent = hasHook || takeaways.length > 0;
+  const [expanded, setExpanded] = useState(false);
+
+  if (!hasContent) return null;
+
+  return (
+    <details
+      className="group rounded-xl border border-border-default bg-bg-secondary"
+      open={expanded}
+      onToggle={(e) => setExpanded((e.currentTarget as HTMLDetailsElement).open)}
+    >
+      <summary className="flex cursor-pointer items-center justify-between gap-3 rounded-xl px-4 py-3 text-sm font-semibold text-text-primary transition-colors hover:bg-bg-tertiary">
+        <span className="inline-flex items-center gap-2">
+          <svg
+            className="h-4 w-4 text-text-tertiary"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+            <polyline points="14 2 14 8 20 8" />
+          </svg>
+          Project brief
+        </span>
+        <svg
+          className={`h-4 w-4 text-text-tertiary transition-transform ${expanded ? "rotate-180" : ""}`}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </summary>
+
+      <div className="space-y-4 border-t border-border-default px-4 py-4">
+        {hasHook && (
+          <div className="space-y-1.5">
+            <p className="text-xs font-semibold uppercase tracking-wide text-text-tertiary">
+              Hook
+            </p>
+            <p className="whitespace-pre-wrap text-sm text-text-secondary">{hook}</p>
+          </div>
+        )}
+        {takeaways.length > 0 && (
+          <div className="space-y-1.5">
+            <p className="text-xs font-semibold uppercase tracking-wide text-text-tertiary">
+              Takeaways
+            </p>
+            <ol className="list-decimal space-y-1 pl-5 text-sm text-text-secondary">
+              {takeaways.map((t, idx) => (
+                <li key={idx}>{t}</li>
+              ))}
+            </ol>
+          </div>
+        )}
+      </div>
+    </details>
+  );
+}

--- a/src/components/VideoDetailView.tsx
+++ b/src/components/VideoDetailView.tsx
@@ -5,6 +5,7 @@ import { VideoPlayer } from "./VideoPlayer";
 import { VideoPageLayout } from "./VideoPageLayout";
 import { AnnotationOverlay } from "./AnnotationOverlay";
 import { TranscriptPanel } from "./TranscriptPanel";
+import { VideoBriefPanel } from "./VideoBriefPanel";
 import { ApprovalSection, type ApprovalStatus } from "./ApprovalSection";
 import { ProjectPhaseControls } from "./ProjectPhaseControls";
 import { TargetDateEditor } from "./TargetDateEditor";
@@ -44,6 +45,11 @@ interface VideoDetailViewProps {
   enabledSteps?: PipelineStep[];
   shareToken?: string;
   initialActivity?: ProjectActivityItem[];
+  /** Hook from project metadata, surfaced read-only on the review tab. */
+  hook?: string | null;
+  takeaway1?: string | null;
+  takeaway2?: string | null;
+  takeaway3?: string | null;
 }
 
 function formatDate(dateStr: string): string {
@@ -83,6 +89,10 @@ export function VideoDetailView({
   enabledSteps,
   shareToken,
   initialActivity = [],
+  hook = null,
+  takeaway1 = null,
+  takeaway2 = null,
+  takeaway3 = null,
 }: VideoDetailViewProps) {
   const isShareMode = !!shareToken;
   const initialReviewComments = initialComments.filter((comment) => comment.phase !== "script");
@@ -272,6 +282,14 @@ export function VideoDetailView({
           />
         )}
       </div>
+
+      {/* Read-only "brief" so reviewers see authorial intent alongside the cut. */}
+      <VideoBriefPanel
+        hook={hook}
+        takeaway1={takeaway1}
+        takeaway2={takeaway2}
+        takeaway3={takeaway3}
+      />
 
       {/* Approval status — shown inside Video when the space requires signoff. */}
       {approvalStatus && (

--- a/src/components/VideoDetailsPanel.tsx
+++ b/src/components/VideoDetailsPanel.tsx
@@ -1,0 +1,169 @@
+import { InlineEditor, type InlineEditorField } from "./InlineEditor";
+
+interface VideoDetailsPanelProps {
+  videoId: string;
+  isOwner: boolean;
+  targetAudience: string | null;
+  hook: string | null;
+  takeaway1: string | null;
+  takeaway2: string | null;
+  takeaway3: string | null;
+  primaryCta: string | null;
+  outro: string | null;
+}
+
+interface FieldRowProps {
+  label: string;
+  field: InlineEditorField;
+  videoId: string;
+  isOwner: boolean;
+  value: string | null;
+  placeholder: string;
+  multiline?: boolean;
+  maxLength: number;
+}
+
+function FieldRow({
+  label,
+  field,
+  videoId,
+  isOwner,
+  value,
+  placeholder,
+  multiline,
+  maxLength,
+}: FieldRowProps) {
+  return (
+    <div className="space-y-1.5">
+      <p className="text-xs font-semibold uppercase tracking-wide text-text-tertiary">
+        {label}
+      </p>
+      <InlineEditor
+        value={value ?? ""}
+        field={field}
+        videoId={videoId}
+        isOwner={isOwner}
+        placeholder={placeholder}
+        multiline={multiline}
+        maxLength={maxLength}
+        className={
+          multiline
+            ? "max-w-2xl break-words text-sm text-text-secondary"
+            : "max-w-2xl break-words text-sm text-text-primary"
+        }
+      />
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-4">
+      <h2 className="text-sm font-semibold text-text-primary">{title}</h2>
+      <div className="space-y-5 rounded-2xl border border-border-default bg-bg-secondary p-5 sm:p-6">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+export function VideoDetailsPanel({
+  videoId,
+  isOwner,
+  targetAudience,
+  hook,
+  takeaway1,
+  takeaway2,
+  takeaway3,
+  primaryCta,
+  outro,
+}: VideoDetailsPanelProps) {
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-text-secondary">
+        Document your video&apos;s intent. These notes guide your script and
+        review.
+      </p>
+
+      <Section title="Audience & Positioning">
+        <FieldRow
+          label="Target Audience"
+          field="targetAudience"
+          videoId={videoId}
+          isOwner={isOwner}
+          value={targetAudience}
+          placeholder="e.g. Junior React developers building their first SaaS"
+          maxLength={200}
+        />
+        <FieldRow
+          label="Hook"
+          field="hook"
+          videoId={videoId}
+          isOwner={isOwner}
+          value={hook}
+          placeholder="The opening line that earns the next 10 seconds"
+          multiline
+          maxLength={500}
+        />
+      </Section>
+
+      <Section title="Value Delivery">
+        <FieldRow
+          label="Takeaway 1"
+          field="takeaway1"
+          videoId={videoId}
+          isOwner={isOwner}
+          value={takeaway1}
+          placeholder="Add takeaway 1…"
+          maxLength={200}
+        />
+        <FieldRow
+          label="Takeaway 2"
+          field="takeaway2"
+          videoId={videoId}
+          isOwner={isOwner}
+          value={takeaway2}
+          placeholder="Add takeaway 2…"
+          maxLength={200}
+        />
+        <FieldRow
+          label="Takeaway 3"
+          field="takeaway3"
+          videoId={videoId}
+          isOwner={isOwner}
+          value={takeaway3}
+          placeholder="Add takeaway 3…"
+          maxLength={200}
+        />
+        <FieldRow
+          label="Primary CTA"
+          field="primaryCta"
+          videoId={videoId}
+          isOwner={isOwner}
+          value={primaryCta}
+          placeholder="e.g. Subscribe for the full course"
+          maxLength={200}
+        />
+      </Section>
+
+      <Section title="Closing">
+        <FieldRow
+          label="Outro"
+          field="outro"
+          videoId={videoId}
+          isOwner={isOwner}
+          value={outro}
+          placeholder="How the video wraps and what viewers do next"
+          multiline
+          maxLength={500}
+        />
+      </Section>
+    </div>
+  );
+}

--- a/src/components/VideoDetailsPanel.tsx
+++ b/src/components/VideoDetailsPanel.tsx
@@ -1,8 +1,9 @@
-import { InlineEditor, type InlineEditorField } from "./InlineEditor";
+import { MetadataField } from "./MetadataField";
 
 interface VideoDetailsPanelProps {
   videoId: string;
   isOwner: boolean;
+  description: string | null;
   targetAudience: string | null;
   hook: string | null;
   takeaway1: string | null;
@@ -10,50 +11,6 @@ interface VideoDetailsPanelProps {
   takeaway3: string | null;
   primaryCta: string | null;
   outro: string | null;
-}
-
-interface FieldRowProps {
-  label: string;
-  field: InlineEditorField;
-  videoId: string;
-  isOwner: boolean;
-  value: string | null;
-  placeholder: string;
-  multiline?: boolean;
-  maxLength: number;
-}
-
-function FieldRow({
-  label,
-  field,
-  videoId,
-  isOwner,
-  value,
-  placeholder,
-  multiline,
-  maxLength,
-}: FieldRowProps) {
-  return (
-    <div className="space-y-1.5">
-      <p className="text-xs font-semibold uppercase tracking-wide text-text-tertiary">
-        {label}
-      </p>
-      <InlineEditor
-        value={value ?? ""}
-        field={field}
-        videoId={videoId}
-        isOwner={isOwner}
-        placeholder={placeholder}
-        multiline={multiline}
-        maxLength={maxLength}
-        className={
-          multiline
-            ? "max-w-2xl break-words text-sm text-text-secondary"
-            : "max-w-2xl break-words text-sm text-text-primary"
-        }
-      />
-    </div>
-  );
 }
 
 function Section({
@@ -76,6 +33,7 @@ function Section({
 export function VideoDetailsPanel({
   videoId,
   isOwner,
+  description,
   targetAudience,
   hook,
   takeaway1,
@@ -91,22 +49,35 @@ export function VideoDetailsPanel({
         review.
       </p>
 
-      <Section title="Audience & Positioning">
-        <FieldRow
-          label="Target Audience"
-          field="targetAudience"
+      <Section title="Overview">
+        <MetadataField
           videoId={videoId}
+          field="description"
+          initialValue={description}
           isOwner={isOwner}
-          value={targetAudience}
+          label="Description"
+          placeholder="Add a description…"
+          multiline
+          maxLength={2000}
+        />
+      </Section>
+
+      <Section title="Audience & Positioning">
+        <MetadataField
+          videoId={videoId}
+          field="targetAudience"
+          initialValue={targetAudience}
+          isOwner={isOwner}
+          label="Target Audience"
           placeholder="e.g. Junior React developers building their first SaaS"
           maxLength={200}
         />
-        <FieldRow
-          label="Hook"
-          field="hook"
+        <MetadataField
           videoId={videoId}
+          field="hook"
+          initialValue={hook}
           isOwner={isOwner}
-          value={hook}
+          label="Hook"
           placeholder="The opening line that earns the next 10 seconds"
           multiline
           maxLength={500}
@@ -114,51 +85,51 @@ export function VideoDetailsPanel({
       </Section>
 
       <Section title="Value Delivery">
-        <FieldRow
-          label="Takeaway 1"
-          field="takeaway1"
+        <MetadataField
           videoId={videoId}
+          field="takeaway1"
+          initialValue={takeaway1}
           isOwner={isOwner}
-          value={takeaway1}
+          label="Takeaway 1"
           placeholder="Add takeaway 1…"
           maxLength={200}
         />
-        <FieldRow
-          label="Takeaway 2"
-          field="takeaway2"
+        <MetadataField
           videoId={videoId}
+          field="takeaway2"
+          initialValue={takeaway2}
           isOwner={isOwner}
-          value={takeaway2}
+          label="Takeaway 2"
           placeholder="Add takeaway 2…"
           maxLength={200}
         />
-        <FieldRow
-          label="Takeaway 3"
-          field="takeaway3"
+        <MetadataField
           videoId={videoId}
+          field="takeaway3"
+          initialValue={takeaway3}
           isOwner={isOwner}
-          value={takeaway3}
+          label="Takeaway 3"
           placeholder="Add takeaway 3…"
           maxLength={200}
         />
-        <FieldRow
-          label="Primary CTA"
-          field="primaryCta"
+        <MetadataField
           videoId={videoId}
+          field="primaryCta"
+          initialValue={primaryCta}
           isOwner={isOwner}
-          value={primaryCta}
+          label="Primary CTA"
           placeholder="e.g. Subscribe for the full course"
           maxLength={200}
         />
       </Section>
 
       <Section title="Closing">
-        <FieldRow
-          label="Outro"
-          field="outro"
+        <MetadataField
           videoId={videoId}
+          field="outro"
+          initialValue={outro}
           isOwner={isOwner}
-          value={outro}
+          label="Outro"
           placeholder="How the video wraps and what viewers do next"
           multiline
           maxLength={500}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -123,6 +123,13 @@ export const videos = sqliteTable("videos", {
     .notNull()
     .default("reviewing_video"),
   targetDate: text("target_date"),
+  targetAudience: text("target_audience"),
+  hook: text("hook"),
+  takeaway1: text("takeaway1"),
+  takeaway2: text("takeaway2"),
+  takeaway3: text("takeaway3"),
+  primaryCta: text("primary_cta"),
+  outro: text("outro"),
   createdAt: text("created_at")
     .notNull()
     .default(sql`(datetime('now'))`),

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -65,6 +65,13 @@ export const videoUpdateSchema = z.object({
   description: z.string().max(2000).optional(),
   folderId: z.string().uuid().nullable().optional(),
   targetDate: z.string().date().nullable().optional(),
+  targetAudience: z.string().max(200).nullable().optional(),
+  hook: z.string().max(500).nullable().optional(),
+  takeaway1: z.string().max(200).nullable().optional(),
+  takeaway2: z.string().max(200).nullable().optional(),
+  takeaway3: z.string().max(200).nullable().optional(),
+  primaryCta: z.string().max(200).nullable().optional(),
+  outro: z.string().max(500).nullable().optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/src/pages/videos/[id]/details.astro
+++ b/src/pages/videos/[id]/details.astro
@@ -1,0 +1,7 @@
+---
+const { id } = Astro.params;
+if (!id) return Astro.redirect("/dashboard");
+const params = new URLSearchParams(Astro.url.searchParams);
+params.set("tab", "details");
+return Astro.redirect(`/videos/${id}?${params.toString()}`);
+---

--- a/src/pages/videos/[id]/index.astro
+++ b/src/pages/videos/[id]/index.astro
@@ -62,8 +62,11 @@ const isOwner = role === "owner";
 const canEditStatus = !isPublished && (role === "owner" || video.uploadedBy === user.id);
 const showApprovals = approvalStatus.requiredApprovals > 0;
 const tabParam = Astro.url.searchParams.get("tab");
+// Default to the Details tab so users land on the project brief whenever
+// they open a project without an explicit tab in the URL. Notifications and
+// other internal links that include `?tab=...` still take precedence.
 const activeTab: "script" | "video" | "details" =
-  tabParam === "video" ? "video" : tabParam === "details" ? "details" : "script";
+  tabParam === "video" ? "video" : tabParam === "script" ? "script" : "details";
 const tabHref = (tab: "script" | "video" | "details") => {
   const params = new URLSearchParams(Astro.url.searchParams);
   params.set("tab", tab);

--- a/src/pages/videos/[id]/index.astro
+++ b/src/pages/videos/[id]/index.astro
@@ -120,17 +120,6 @@ const tabHref = (tab: "script" | "video" | "details") => {
               )}
             </div>
           </div>
-          <div class="mt-4">
-            <InlineEditor
-              client:load
-              value={video.description || ""}
-              field="description"
-              videoId={video.id}
-              isOwner={isOwner && !isPublished}
-              placeholder="Add a description..."
-              className="max-w-2xl break-words text-sm text-text-secondary"
-            />
-          </div>
         </div>
 
         {isPublished && (
@@ -171,6 +160,7 @@ const tabHref = (tab: "script" | "video" | "details") => {
           client:load
           videoId={video.id}
           isOwner={isOwner && !isPublished}
+          description={video.description ?? null}
           targetAudience={video.targetAudience ?? null}
           hook={video.hook ?? null}
           takeaway1={video.takeaway1 ?? null}

--- a/src/pages/videos/[id]/index.astro
+++ b/src/pages/videos/[id]/index.astro
@@ -7,6 +7,7 @@ import { ScriptWorkspace } from "../../../components/ScriptWorkspace";
 import { UploadView } from "../../../components/UploadView";
 import { UploadVersionModal } from "../../../components/UploadVersionModal";
 import { VideoDetailView } from "../../../components/VideoDetailView";
+import { VideoDetailsPanel } from "../../../components/VideoDetailsPanel";
 import { VideoHeader } from "../../../components/VideoHeader";
 import { env } from "cloudflare:workers";
 import { eq } from "drizzle-orm";
@@ -60,8 +61,10 @@ const hasVideo = !!video.streamVideoId;
 const isOwner = role === "owner";
 const canEditStatus = !isPublished && (role === "owner" || video.uploadedBy === user.id);
 const showApprovals = approvalStatus.requiredApprovals > 0;
-const activeTab = Astro.url.searchParams.get("tab") === "video" ? "video" : "script";
-const tabHref = (tab: "script" | "video") => {
+const tabParam = Astro.url.searchParams.get("tab");
+const activeTab: "script" | "video" | "details" =
+  tabParam === "video" ? "video" : tabParam === "details" ? "details" : "script";
+const tabHref = (tab: "script" | "video" | "details") => {
   const params = new URLSearchParams(Astro.url.searchParams);
   params.set("tab", tab);
   return `/videos/${video.id}?${params.toString()}`;
@@ -140,6 +143,13 @@ const tabHref = (tab: "script" | "video") => {
       <div class="border-b border-border-default">
         <nav class="flex gap-2" aria-label="Project sections">
           <a
+            href={tabHref("details")}
+            class={`rounded-t-lg px-4 py-2 text-sm font-medium transition-colors ${activeTab === "details" ? "border-b-2 border-accent-primary text-text-primary" : "text-text-tertiary hover:text-text-secondary"}`}
+            aria-current={activeTab === "details" ? "page" : undefined}
+          >
+            Details
+          </a>
+          <a
             href={tabHref("script")}
             class={`rounded-t-lg px-4 py-2 text-sm font-medium transition-colors ${activeTab === "script" ? "border-b-2 border-accent-primary text-text-primary" : "text-text-tertiary hover:text-text-secondary"}`}
             aria-current={activeTab === "script" ? "page" : undefined}
@@ -156,7 +166,20 @@ const tabHref = (tab: "script" | "video") => {
         </nav>
       </div>
 
-      {activeTab === "script" ? (
+      {activeTab === "details" ? (
+        <VideoDetailsPanel
+          client:load
+          videoId={video.id}
+          isOwner={isOwner && !isPublished}
+          targetAudience={video.targetAudience ?? null}
+          hook={video.hook ?? null}
+          takeaway1={video.takeaway1 ?? null}
+          takeaway2={video.takeaway2 ?? null}
+          takeaway3={video.takeaway3 ?? null}
+          primaryCta={video.primaryCta ?? null}
+          outro={video.outro ?? null}
+        />
+      ) : activeTab === "script" ? (
         <ScriptWorkspace
           client:load
           videoId={video.id}
@@ -190,6 +213,10 @@ const tabHref = (tab: "script" | "video") => {
             userRole={role}
             spaceId={video.spaceId}
             initialActivity={projectActivity}
+            hook={video.hook ?? null}
+            takeaway1={video.takeaway1 ?? null}
+            takeaway2={video.takeaway2 ?? null}
+            takeaway3={video.takeaway3 ?? null}
           />
           {!isPublished && isOwner && (
             <div class="flex justify-end">


### PR DESCRIPTION
## Summary

Adds structured metadata to video projects so creators can document audience, intent, and structure alongside the script.

New fields on `videos`:
- `targetAudience`
- `hook`
- `takeaway1`, `takeaway2`, `takeaway3`
- `primaryCta`
- `outro`

## UX

- **New "Details" tab** on `/videos/[id]` (with sibling `details.astro` redirect for permalinks). Renders a `VideoDetailsPanel` grouping fields into three sections: Audience & Positioning, Value Delivery, Closing.
- **Inline editing** matches the existing title/description pattern. `InlineEditor` was generalized to accept any metadata field and a new `multiline` prop (replaces hardcoded `field === "description"` checks). `Cmd/Ctrl+Enter` saves multiline fields; `Enter` saves single-line; `Esc` cancels.
- **Empty values render as muted placeholders**, never blank. Empty input on save persists as `null` so the placeholder returns.
- **Read-only "Project brief"** collapsible panel on the Video (review) tab surfacing hook + takeaways. Hidden entirely when none of the four fields are populated.

## Server

- `videoUpdateSchema` extended with the 7 new optional/nullable fields (200/500 char caps).
- `actions.video.update` accepts and persists them, blocks edits on published projects (consistent with existing rule), and normalizes empty strings to `null` so clearing a field works.

## Database

- Migration `0021_add_video_metadata_fields.sql` adds 7 nullable text columns to `videos`. No backfill needed.

## Test plan (manual)

1. Open a project → click **Details** → all fields show italic placeholders.
2. Click **Hook** → type → click outside → reload page → value persists.
3. Edit a takeaway → clear text → blur → placeholder returns (stored as `null`).
4. Multi-line fields (Hook, Outro) accept newlines; `Cmd+Enter` saves.
5. Switch to **Video** tab → if hook or any takeaway is set, **Project brief** panel appears (collapsed by default). Expand → values render read-only.
6. Empty all four brief fields → reload Video tab → panel disappears.
7. Try to edit on a published project → blocked with `FORBIDDEN`.

## Notes

- Followed existing query-param tab pattern (`?tab=details`) used by Script/Video; sibling route is just a redirect to keep deep-links working.
- No AI assistance — manual entry only, as discussed.
- Char limits: 200 for short fields, 500 for hook/outro.