### PR TITLE
chore(docs): switch branch naming convention to dash prefix

### DIFF
--- a/.opencode/skills/implement-gh-issue/SKILL.md
+++ b/.opencode/skills/implement-gh-issue/SKILL.md
@@ -50,7 +50,7 @@ wastes a worktree and a PR.
 
 ### 2. Pick the branch name
 
-Branch convention: `<prefix>/issue-<num>-<slug>`
+Branch convention: `<prefix>-issue-<num>-<slug>`
 
 Pick the prefix from the issue's labels:
 
@@ -64,7 +64,7 @@ Pick the prefix from the issue's labels:
 `<slug>` is a short kebab-case version of the issue title — 3-6 words,
 lowercase, no punctuation. Example: issue #42 "Add CSV export to clip
 library" with label `enhancement` →
-`feature/issue-42-add-csv-export`.
+`feature-issue-42-add-csv-export`.
 
 ### 3. Create the worktree and run setup
 
@@ -244,7 +244,7 @@ You: I'm using the implement-gh-issue skill to work issue #42 in a fresh worktre
 
 [gh issue view 42 → "Add CSV export to clip library", label: enhancement]
 [Surface acceptance criteria back to the user]
-[Create .worktrees/feature/issue-42-add-csv-export from origin/main]
+[Create .worktrees/feature-issue-42-add-csv-export from origin/main]
 [Run pnpm install]
 [Run worktree-setup: copy .dev.vars + .wrangler/state, run migrations]
 [Implement: add /api/clips/export.csv route + UI button]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,8 @@ If a worktree was created without step 3, symptoms include:
 
 ## Pull requests
 
-- Branch naming used in this repo: `feature/<topic>`, `fix/<topic>`,
-  `chore/<topic>`, `feature/issue-<n>-<topic>` for issue-driven work.
+- Branch naming used in this repo: `feature-<topic>`, `fix-<topic>`,
+  `chore-<topic>`, `feature-issue-<n>-<topic>` for issue-driven work.
 - Conventional commit messages (e.g. `feat(actions): ...`, `fix(...)`,
   `chore(...)`, `docs(...)`).
 - Reference issues with `Closes #<n>` in the PR body when applicable.


### PR DESCRIPTION
## Summary

Updates branch naming convention from `<prefix>/<topic>` to `<prefix>-<topic>` so worktrees live at a single flat directory under `.worktrees/` instead of being nested into subdirectories.

## Why

Slash-prefixed branches like `feature/issue-42-foo` create nested worktree paths (`.worktrees/feature/issue-42-foo/`) which:
- Add an empty `feature/`, `fix/`, or `chore/` directory at the root of `.worktrees/`
- Make `cd` and tab-completion clunkier
- Don't match how most local-only worktree workflows are expected to lay out

Dash prefixes give us `.worktrees/feature-issue-42-foo/` — flat, predictable, easier to clean up.

## Changes

- `AGENTS.md`: branch naming examples updated to dash form
- `.opencode/skills/implement-gh-issue/SKILL.md`: convention rule + example branch name + example worktree path updated to dash form

## Notes

- Existing branches with slash prefixes (e.g. `feature/video-metadata-fields` from PR #97) are unaffected. They still work; only new branches will follow the new convention.
- This is a docs-only change. No code or runtime impact.