### PR TITLE
feat(notifications): real-time badge updates in header

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -39,6 +39,7 @@ import {
   broadcastApprovalUpdate,
   broadcastNewComment,
   broadcastCommentReactions,
+  broadcastNotification,
 } from "../lib/broadcast";
 import {
   isCommentReactionEmoji,
@@ -421,11 +422,15 @@ export const server = {
               .where(eq(spaces.id, video.spaceId))
               .limit(1);
             if ((spaceRow[0]?.requiredApprovals ?? 0) > 0) {
-              await createApprovalRequestNotifications(db, {
-                videoId: id,
-                actorUserId: user.id,
-                actorDisplayName: user.name,
-              });
+              await createApprovalRequestNotifications(
+                db,
+                {
+                  videoId: id,
+                  actorUserId: user.id,
+                  actorDisplayName: user.name,
+                },
+                env,
+              );
             }
           } catch (err) {
             console.error("Failed to send approval-requested notifications", err);
@@ -1157,6 +1162,7 @@ export const server = {
               from: env.OTP_EMAIL_FROM,
               baseUrl: new URL(context.request.url).origin,
             },
+            env,
           );
         } catch (err) {
           console.error("Failed to create comment notification", err);
@@ -1368,6 +1374,7 @@ export const server = {
               from: env.OTP_EMAIL_FROM,
               baseUrl: new URL(context.request.url).origin,
             },
+            env,
           );
         } catch (err) {
           console.error("Failed to create reply notification", err);
@@ -1692,6 +1699,19 @@ export const server = {
           throw new ActionError({
             code: "INTERNAL_SERVER_ERROR",
             message: "Failed to send invite email",
+          });
+        }
+
+        // If the invitee already has an account, push a real-time signal to
+        // their open tabs so the header badge increments — pending invites
+        // count toward the unread badge (see Layout.astro).
+        if (existingUser.length > 0) {
+          await broadcastNotification(env, existingUser[0].id, {
+            kind: "invite",
+            id: invite.id,
+            title: `${user.name} invited you to ${space[0].name}`,
+            href: "/notifications",
+            createdAt: new Date().toISOString(),
           });
         }
 

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { connectUserNotifications } from "../lib/notifications-realtime";
 
 interface UserMenuProps {
   name: string;
@@ -33,6 +34,41 @@ export function UserMenu({ name, email, notificationCount = 0 }: UserMenuProps) 
     return () => {
       window.removeEventListener("quickcut:invite-accepted", handler);
       window.removeEventListener("quickcut:notification-read", handler);
+    };
+  }, []);
+
+  // Real-time badge increments. The header SSRs the initial count on every
+  // navigation, so this only needs to handle notifications that arrive while
+  // the page is open. Other parts of the app can listen for the same event
+  // (e.g. to show toasts or live-update the /notifications page) without
+  // opening their own socket.
+  useEffect(() => {
+    const onNotification = (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+      if (detail && typeof detail === "object" && detail.kind === "invite") {
+        // Defer to the SSR'd source of truth on next navigation; for now
+        // any invite/notification simply increments the badge.
+      }
+      setCount((current) => current + 1);
+    };
+    window.addEventListener("quickcut:notification-received", onNotification);
+
+    const conn = connectUserNotifications({
+      onNotification: (notification) => {
+        window.dispatchEvent(
+          new CustomEvent("quickcut:notification-received", {
+            detail: notification,
+          }),
+        );
+      },
+    });
+
+    return () => {
+      window.removeEventListener(
+        "quickcut:notification-received",
+        onNotification,
+      );
+      conn.disconnect();
     };
   }, []);
 

--- a/src/durable-objects/UserNotifications.ts
+++ b/src/durable-objects/UserNotifications.ts
@@ -1,0 +1,111 @@
+import { DurableObject } from "cloudflare:workers";
+
+/**
+ * Lightweight payload broadcast to the user's connected clients when a
+ * new notification (comment, approval request, or pending space invite)
+ * is created. The header badge only needs a signal to increment, but we
+ * include identifying fields so future consumers (toasts, the
+ * /notifications page) can react without an extra fetch.
+ */
+export interface BroadcastUserNotification {
+	/** Distinguishes a regular notification row from a pending space invite. */
+	kind: "notification" | "invite";
+	/** notifications.id for kind="notification", spaceInvites.id for kind="invite". */
+	id: string;
+	/** Notification type (e.g. comment.created, approval.requested) when kind="notification". */
+	type?: string;
+	title: string;
+	href: string;
+	createdAt: string;
+}
+
+type ServerMessage = {
+	type: "notification.new";
+	notification: BroadcastUserNotification;
+};
+
+/**
+ * UserNotifications coordinates real-time delivery of badge-count signals
+ * to a single user's open browser tabs.
+ *
+ * One Durable Object instance per userId (deterministic via getByName).
+ * Uses hibernatable WebSockets so an idle user costs nothing while their
+ * tabs are open but quiet.
+ *
+ * D1 remains the source of truth; this DO exists purely so the API write
+ * paths can fan out to currently-connected tabs after a successful insert.
+ * If broadcasts fail or the channel is severed, the next page load picks
+ * up the correct count from the SSR'd value.
+ */
+export class UserNotifications extends DurableObject<Env> {
+	/**
+	 * Handle the WebSocket upgrade. The route handler authenticates the
+	 * user, then forwards the upgrade Request to this DO, which accepts
+	 * the socket and registers it for hibernation.
+	 */
+	async fetch(request: Request): Promise<Response> {
+		const upgradeHeader = request.headers.get("Upgrade");
+		if (upgradeHeader?.toLowerCase() !== "websocket") {
+			return new Response("Expected WebSocket upgrade", { status: 426 });
+		}
+
+		const pair = new WebSocketPair();
+		const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
+
+		// Hibernatable acceptance: the runtime stores the socket and only wakes
+		// the DO on incoming messages or when we call broadcast.
+		this.ctx.acceptWebSocket(server);
+
+		return new Response(null, {
+			status: 101,
+			webSocket: client,
+		});
+	}
+
+	/**
+	 * RPC method called by API routes after a notification (or pending
+	 * space invite) has been persisted for this user. Pushes a
+	 * notification.new message to every currently connected tab.
+	 */
+	async broadcastNotification(
+		notification: BroadcastUserNotification,
+	): Promise<void> {
+		const message: ServerMessage = { type: "notification.new", notification };
+		const payload = JSON.stringify(message);
+
+		for (const ws of this.ctx.getWebSockets()) {
+			try {
+				ws.send(payload);
+			} catch {
+				// Socket may have been closed between the snapshot and the send.
+				// Ignore — the runtime will clean it up.
+			}
+		}
+	}
+
+	// No client -> server messages needed. Drop anything we receive.
+	async webSocketMessage(_ws: WebSocket, _message: ArrayBuffer | string): Promise<void> {
+		// no-op
+	}
+
+	async webSocketClose(
+		ws: WebSocket,
+		code: number,
+		_reason: string,
+		_wasClean: boolean,
+	): Promise<void> {
+		try {
+			ws.close(code, "client closed");
+		} catch {
+			// ignore
+		}
+	}
+
+	async webSocketError(ws: WebSocket, _error: unknown): Promise<void> {
+		try {
+			ws.close(1011, "internal error");
+		} catch {
+			// ignore
+		}
+	}
+}

--- a/src/lib/broadcast.ts
+++ b/src/lib/broadcast.ts
@@ -4,6 +4,7 @@ import type {
 	BroadcastCommentReactions,
 	BroadcastPhaseChange,
 } from "../durable-objects/VideoRoom";
+import type { BroadcastUserNotification } from "../durable-objects/UserNotifications";
 
 /**
  * Best-effort fan-out of a freshly persisted comment to every viewer
@@ -69,5 +70,24 @@ export async function broadcastPhaseChange(
 		await stub.broadcastPhaseChange(phaseChange);
 	} catch (err) {
 		console.error("VideoRoom phase broadcast failed", { videoId, err });
+	}
+}
+
+/**
+ * Best-effort fan-out of a freshly persisted notification (or pending
+ * space invite) to every tab the recipient has open. Failures are
+ * swallowed: D1 already has the row, so the next page load will pick
+ * up the correct badge count via SSR.
+ */
+export async function broadcastNotification(
+	env: Env,
+	userId: string,
+	notification: BroadcastUserNotification,
+): Promise<void> {
+	try {
+		const stub = env.USER_NOTIFICATIONS.getByName(userId);
+		await stub.broadcastNotification(notification);
+	} catch (err) {
+		console.error("UserNotifications broadcast failed", { userId, err });
 	}
 }

--- a/src/lib/notifications-realtime.ts
+++ b/src/lib/notifications-realtime.ts
@@ -1,0 +1,105 @@
+import type { BroadcastUserNotification } from "../durable-objects/UserNotifications";
+
+export type { BroadcastUserNotification } from "../durable-objects/UserNotifications";
+
+type ServerMessage = {
+	type: "notification.new";
+	notification: BroadcastUserNotification;
+};
+
+export interface UserNotificationHandlers {
+	onNotification?: (notification: BroadcastUserNotification) => void;
+}
+
+export interface UserNotificationConnection {
+	disconnect: () => void;
+}
+
+/**
+ * Open a hibernation-aware WebSocket to the per-user UserNotifications
+ * Durable Object. Reconnects with capped exponential backoff so a flaky
+ * network or Wrangler reload eventually recovers without a page refresh.
+ *
+ * If the channel is permanently unavailable, the header badge still
+ * reflects the SSR'd count from the most recent page load — graceful
+ * degradation is intentional.
+ */
+export function connectUserNotifications(
+	handlers: UserNotificationHandlers,
+): UserNotificationConnection {
+	let socket: WebSocket | null = null;
+	let cancelled = false;
+	let retry = 0;
+	let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+	const buildUrl = () => {
+		const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+		return `${proto}//${window.location.host}/api/notifications/live`;
+	};
+
+	const open = () => {
+		if (cancelled) return;
+		try {
+			socket = new WebSocket(buildUrl());
+		} catch {
+			scheduleReconnect();
+			return;
+		}
+
+		socket.addEventListener("open", () => {
+			retry = 0;
+		});
+
+		socket.addEventListener("message", (event) => {
+			if (typeof event.data !== "string") return;
+			let parsed: ServerMessage | null = null;
+			try {
+				parsed = JSON.parse(event.data) as ServerMessage;
+			} catch {
+				return;
+			}
+			if (parsed.type === "notification.new") {
+				handlers.onNotification?.(parsed.notification);
+			}
+		});
+
+		socket.addEventListener("close", () => {
+			if (!cancelled) scheduleReconnect();
+		});
+
+		socket.addEventListener("error", () => {
+			// Let close handler drive reconnection.
+			try {
+				socket?.close();
+			} catch {
+				// ignore
+			}
+		});
+	};
+
+	const scheduleReconnect = () => {
+		if (cancelled) return;
+		const delay = Math.min(1000 * 2 ** retry, 15_000);
+		retry += 1;
+		reconnectTimer = setTimeout(open, delay);
+	};
+
+	open();
+
+	return {
+		disconnect() {
+			cancelled = true;
+			if (reconnectTimer) {
+				clearTimeout(reconnectTimer);
+				reconnectTimer = null;
+			}
+			if (socket) {
+				try {
+					socket.close();
+				} catch {
+					// ignore
+				}
+			}
+		},
+	};
+}

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { Database } from "../db";
 import { comments, notifications, spaceMembers, spaces, users, videos } from "../db/schema";
+import { broadcastNotification } from "./broadcast";
 import { buildCommentNotificationEmail } from "./email";
 import { getNotificationCopy, type NotificationType } from "./notification-copy";
 
@@ -77,6 +78,7 @@ export async function createCommentNotifications(
   db: Database,
   input: CommentNotificationInput,
   emailConfig?: EmailConfig,
+  realtimeEnv?: Env,
 ): Promise<void> {
   const videoRows = await db
     .select({
@@ -122,22 +124,40 @@ export async function createCommentNotifications(
   const copy = getNotificationCopy(type, input.actorDisplayName, video.title);
   const body = snippet(input.text);
 
-  await db.insert(notifications).values(
-    recipientIds.map((userId) => ({
-      id: crypto.randomUUID(),
-      userId,
-      actorUserId: input.actorUserId,
-      actorDisplayName: input.actorDisplayName,
-      type,
-      videoId: video.id,
-      commentId: input.commentId,
-      parentCommentId: input.parentCommentId,
-      spaceId: video.spaceId,
-      title: copy.title,
-      body,
-      href,
-    })),
-  );
+  const rows = recipientIds.map((userId) => ({
+    id: crypto.randomUUID(),
+    userId,
+    actorUserId: input.actorUserId,
+    actorDisplayName: input.actorDisplayName,
+    type,
+    videoId: video.id,
+    commentId: input.commentId,
+    parentCommentId: input.parentCommentId,
+    spaceId: video.spaceId,
+    title: copy.title,
+    body,
+    href,
+  }));
+
+  await db.insert(notifications).values(rows);
+
+  // Real-time fan-out to each recipient's open tabs. Best-effort; failures
+  // are logged inside broadcastNotification and do not block email delivery.
+  if (realtimeEnv) {
+    const createdAt = new Date().toISOString();
+    await Promise.all(
+      rows.map((row) =>
+        broadcastNotification(realtimeEnv, row.userId, {
+          kind: "notification",
+          id: row.id,
+          type: row.type,
+          title: row.title,
+          href: row.href,
+          createdAt,
+        }),
+      ),
+    );
+  }
 
   if (!emailConfig) return;
 
@@ -202,6 +222,7 @@ export interface ApprovalRequestNotificationInput {
 export async function createApprovalRequestNotifications(
   db: Database,
   input: ApprovalRequestNotificationInput,
+  realtimeEnv?: Env,
 ): Promise<void> {
   const videoRows = await db
     .select({
@@ -239,22 +260,38 @@ export async function createApprovalRequestNotifications(
   );
   const href = `/videos/${video.id}?tab=video`;
 
-  await db.insert(notifications).values(
-    recipientIds.map((userId) => ({
-      id: crypto.randomUUID(),
-      userId,
-      actorUserId: input.actorUserId,
-      actorDisplayName: input.actorDisplayName,
-      type: "approval.requested" as const,
-      videoId: video.id,
-      commentId: null,
-      parentCommentId: null,
-      spaceId: video.spaceId,
-      title: copy.title,
-      body: null,
-      href,
-    })),
-  );
+  const rows = recipientIds.map((userId) => ({
+    id: crypto.randomUUID(),
+    userId,
+    actorUserId: input.actorUserId,
+    actorDisplayName: input.actorDisplayName,
+    type: "approval.requested" as const,
+    videoId: video.id,
+    commentId: null,
+    parentCommentId: null,
+    spaceId: video.spaceId,
+    title: copy.title,
+    body: null,
+    href,
+  }));
+
+  await db.insert(notifications).values(rows);
+
+  if (realtimeEnv) {
+    const createdAt = new Date().toISOString();
+    await Promise.all(
+      rows.map((row) =>
+        broadcastNotification(realtimeEnv, row.userId, {
+          kind: "notification",
+          id: row.id,
+          type: row.type,
+          title: row.title,
+          href: row.href,
+          createdAt,
+        }),
+      ),
+    );
+  }
 }
 
 export async function getNotificationsForUser(

--- a/src/pages/api/notifications/live.ts
+++ b/src/pages/api/notifications/live.ts
@@ -1,0 +1,22 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+
+/**
+ * Authenticated WebSocket upgrade endpoint for the per-user notification
+ * channel. The session cookie is verified by middleware, which populates
+ * locals.user before this handler runs. We then forward the upgrade to
+ * the user's UserNotifications Durable Object instance.
+ */
+export const GET: APIRoute = async ({ request, locals }) => {
+	const upgradeHeader = request.headers.get("Upgrade");
+	if (upgradeHeader?.toLowerCase() !== "websocket") {
+		return new Response("Expected WebSocket upgrade", { status: 426 });
+	}
+
+	if (!locals.user) {
+		return new Response("Unauthorized", { status: 401 });
+	}
+
+	const stub = env.USER_NOTIFICATIONS.getByName(locals.user.id);
+	return stub.fetch(request);
+};

--- a/src/pages/api/share/[token]/comments.ts
+++ b/src/pages/api/share/[token]/comments.ts
@@ -212,7 +212,7 @@ export const POST: APIRoute = async ({ params, request }) => {
       send: (msg) => env.EMAIL.send(msg),
       from: env.OTP_EMAIL_FROM,
       baseUrl: new URL(request.url).origin,
-    });
+    }, env);
   } catch (err) {
     console.error("Failed to create share comment notification", err);
   }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2,6 +2,7 @@ import { handle } from "@astrojs/cloudflare/handler";
 
 // Re-export Durable Object classes so Wrangler can register them.
 export { VideoRoom } from "./durable-objects/VideoRoom";
+export { UserNotifications } from "./durable-objects/UserNotifications";
 export { TranscriptWorkflow } from "./workflows/TranscriptWorkflow";
 
 export default {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -46,12 +46,20 @@
         "name": "VIDEO_ROOM",
         "class_name": "VideoRoom",
       },
+      {
+        "name": "USER_NOTIFICATIONS",
+        "class_name": "UserNotifications",
+      },
     ],
   },
   "migrations": [
     {
       "tag": "v1",
       "new_sqlite_classes": ["VideoRoom"],
+    },
+    {
+      "tag": "v2",
+      "new_sqlite_classes": ["UserNotifications"],
     },
   ],
   "vars": {


### PR DESCRIPTION
## Summary
- New per-user `UserNotifications` Durable Object (hibernatable WebSocket) so the header badge increments within ~1s when a notification arrives — no page refresh required.
- Comment, approval-request, and pending space-invite write paths now fan out to the recipient's connected tabs after the D1 insert. D1 remains authoritative; broadcast failures are swallowed and the SSR'd badge count keeps working as graceful fallback.
- `UserMenu` opens the channel on mount and dispatches `quickcut:notification-received`, leaving the door open for future consumers (toasts, live `/notifications` page) without each opening its own socket.

## Changes
- `src/durable-objects/UserNotifications.ts`: new DO mirroring `VideoRoom` (acceptWebSocket + RPC `broadcastNotification`)
- `wrangler.jsonc` / `src/worker.ts`: register `USER_NOTIFICATIONS` binding + v2 SQLite migration
- `src/pages/api/notifications/live.ts`: auth'd WS upgrade endpoint (uses `locals.user.id` from middleware)
- `src/lib/broadcast.ts`: `broadcastNotification(env, userId, payload)` helper
- `src/lib/notifications.ts`: both `createCommentNotifications` and `createApprovalRequestNotifications` now accept an optional `env` and broadcast after insert
- `src/actions/index.ts` / `src/pages/api/share/[token]/comments.ts`: pass `env` through; `createInvite` broadcasts to invitee's existing account if any
- `src/lib/notifications-realtime.ts`: client connector with reconnect/backoff (mirrors `realtime.ts`)
- `src/components/UserMenu.tsx`: subscribe on mount, increment count on event, close on unmount

## Testing
See test plan in the comment that follows.

Closes #99