### PR TITLE
feat(share): expose Details tab to guests

### DIFF
--- a/src/components/ShareView.tsx
+++ b/src/components/ShareView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { NamePromptModal } from "./NamePromptModal";
 import { ScriptWorkspace } from "./ScriptWorkspace";
+import { VideoDetailsPanel } from "./VideoDetailsPanel";
 import { VideoDetailView } from "./VideoDetailView";
 import type { ApprovalStatus } from "./ApprovalSection";
 import type { TranscriptResponse } from "./TranscriptPanel";
@@ -19,10 +20,18 @@ interface Video {
   uploadedBy: string | null;
   createdAt: string;
   phase: string;
+  description: string | null;
+  targetAudience: string | null;
+  hook: string | null;
+  takeaway1: string | null;
+  takeaway2: string | null;
+  takeaway3: string | null;
+  primaryCta: string | null;
+  outro: string | null;
 }
 
 interface ShareViewProps {
-  activeTab: "script" | "video";
+  activeTab: "details" | "script" | "video";
   video: Video;
   initialScriptContent: string;
   initialComments: Comment[];
@@ -70,6 +79,23 @@ export function ShareView({
         dismissable={false}
         title="Welcome"
         description="Enter your name to view this project and leave comments."
+      />
+    );
+  }
+
+  if (activeTab === "details") {
+    return (
+      <VideoDetailsPanel
+        videoId={video.id}
+        isOwner={false}
+        description={video.description}
+        targetAudience={video.targetAudience}
+        hook={video.hook}
+        takeaway1={video.takeaway1}
+        takeaway2={video.takeaway2}
+        takeaway3={video.takeaway3}
+        primaryCta={video.primaryCta}
+        outro={video.outro}
       />
     );
   }

--- a/src/pages/s/[token].astro
+++ b/src/pages/s/[token].astro
@@ -85,8 +85,12 @@ if (!isRevoked) {
 }
 
 const hasVideo = !!video?.streamVideoId;
-const activeTab = Astro.url.searchParams.get("tab") === "video" ? "video" : "script";
-const tabHref = (tab: "script" | "video") => {
+const tabParam = Astro.url.searchParams.get("tab");
+// Default to Details so guests land on the project brief, matching the
+// signed-in project view behavior.
+const activeTab: "details" | "script" | "video" =
+  tabParam === "video" ? "video" : tabParam === "script" ? "script" : "details";
+const tabHref = (tab: "details" | "script" | "video") => {
   const params = new URLSearchParams(Astro.url.searchParams);
   params.set("tab", tab);
   return `/s/${token}?${params.toString()}`;
@@ -138,6 +142,13 @@ const isPublished = phase === "published";
         <div class="border-b border-border-default">
           <nav class="flex gap-2" aria-label="Project sections">
             <a
+              href={tabHref("details")}
+              class={`rounded-t-lg px-4 py-2 text-sm font-medium transition-colors ${activeTab === "details" ? "border-b-2 border-accent-primary text-text-primary" : "text-text-tertiary hover:text-text-secondary"}`}
+              aria-current={activeTab === "details" ? "page" : undefined}
+            >
+              Details
+            </a>
+            <a
               href={tabHref("script")}
               class={`rounded-t-lg px-4 py-2 text-sm font-medium transition-colors ${activeTab === "script" ? "border-b-2 border-accent-primary text-text-primary" : "text-text-tertiary hover:text-text-secondary"}`}
               aria-current={activeTab === "script" ? "page" : undefined}
@@ -154,8 +165,13 @@ const isPublished = phase === "published";
           </nav>
         </div>
 
-        <!-- Tab content -->
-        {activeTab === "script" || hasVideo ? (
+        <!-- Tab content. Details and Script don't require an uploaded cut, so
+             only the Video tab is gated on `hasVideo`. -->
+        {activeTab === "video" && !hasVideo ? (
+          <div class="rounded-xl border border-border-default bg-bg-secondary p-5 text-sm text-text-secondary">
+            No video has been uploaded yet for this project.
+          </div>
+        ) : (
           <ShareView
             client:load
             activeTab={activeTab}
@@ -168,10 +184,6 @@ const isPublished = phase === "published";
             pipelineEnabled={videoSpace?.pipelineEnabled || false}
             initialTranscriptData={initialTranscriptData}
           />
-        ) : (
-          <div class="rounded-xl border border-border-default bg-bg-secondary p-5 text-sm text-text-secondary">
-            No video has been uploaded yet for this project.
-          </div>
         )}
 
         <!-- Approvals summary at bottom -->


### PR DESCRIPTION
## Summary

- Add a **Details** tab to the guest share view (`/s/[token]`) alongside Script and Video so reviewers can see the project brief that the script was written against.
- Reuse `VideoDetailsPanel` with `isOwner={false}` so all fields render read-only via the existing path in `MetadataField` — no new components, no new endpoints.
- Default the share view to Details, matching the signed-in project view.

## Changes

- `src/components/ShareView.tsx` — widen `activeTab` to `"details" | "script" | "video"`, accept the brief fields on the `Video` prop, render `VideoDetailsPanel` for the details case.
- `src/pages/s/[token].astro` — parse `?tab=details` and default to it; add the Details `<a>` to the tab nav; gate only the Video tab on `hasVideo` so Details and Script remain reachable for projects that haven't uploaded a cut yet.

## Testing

See test plan in chat. Highlights:

- Bare share link → lands on Details with the brief read-only.
- Switching tabs preserves the share token.
- No inputs, save buttons, or metadata network requests for guests.
- Revoked share link still shows "Link Unavailable" for every tab variant.

Closes #104