### PR TITLE
feat(video-details): surface upload new version button in header

### DIFF
--- a/src/components/UploadVersionModal.tsx
+++ b/src/components/UploadVersionModal.tsx
@@ -135,8 +135,13 @@ export function UploadVersionModal({
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="w-full rounded-lg border border-border-default px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-tertiary sm:w-auto"
+        className="inline-flex h-9 items-center gap-2 rounded-lg border border-border-default bg-bg-secondary px-3 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary"
       >
+        <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+          <polyline points="17 8 12 3 7 8" />
+          <line x1="12" y1="3" x2="12" y2="15" />
+        </svg>
         Upload new version
       </button>
 

--- a/src/components/UploadVersionModal.tsx
+++ b/src/components/UploadVersionModal.tsx
@@ -12,6 +12,11 @@ interface UploadVersionModalProps {
   title: string;
   description: string;
   transcriptsEnabled?: boolean;
+  // When `open` is provided, the parent controls open state and is
+  // responsible for rendering its own trigger. The component's built-in
+  // trigger is hidden in this mode.
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 function formatFileSize(bytes: number): string {
@@ -25,10 +30,18 @@ export function UploadVersionModal({
   title: initialTitle,
   description: initialDescription,
   transcriptsEnabled = false,
+  open: controlledOpen,
+  onOpenChange,
 }: UploadVersionModalProps) {
   const headingId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
-  const [open, setOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = isControlled ? controlledOpen : internalOpen;
+  const setOpen = (next: boolean) => {
+    if (!isControlled) setInternalOpen(next);
+    onOpenChange?.(next);
+  };
   const [state, setState] = useState<UploadState>("idle");
   const [file, setFile] = useState<File | null>(null);
   const [title, setTitle] = useState(initialTitle);
@@ -132,18 +145,20 @@ export function UploadVersionModal({
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className="inline-flex h-9 items-center gap-2 rounded-lg border border-border-default bg-bg-secondary px-3 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary"
-      >
-        <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-          <polyline points="17 8 12 3 7 8" />
-          <line x1="12" y1="3" x2="12" y2="15" />
-        </svg>
-        Upload new version
-      </button>
+      {!isControlled && (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="inline-flex h-9 items-center gap-2 rounded-lg border border-border-default bg-bg-secondary px-3 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary"
+        >
+          <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="17 8 12 3 7 8" />
+            <line x1="12" y1="3" x2="12" y2="15" />
+          </svg>
+          Upload new version
+        </button>
+      )}
 
       <Modal
         isOpen={open}

--- a/src/components/VideoHeader.tsx
+++ b/src/components/VideoHeader.tsx
@@ -47,6 +47,7 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl, spaceId, 
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [moreMenuOpen, setMoreMenuOpen] = useState(false);
+  const [uploadVersionOpen, setUploadVersionOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const [confirmRevokeOpen, setConfirmRevokeOpen] = useState(false);
@@ -203,12 +204,28 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl, spaceId, 
         <VersionSwitcher videoId={videoId} versions={versions} />
 
         {uploadVersion && (
-          <UploadVersionModal
-            videoId={videoId}
-            title={uploadVersion.title}
-            description={uploadVersion.description}
-            transcriptsEnabled={uploadVersion.transcriptsEnabled}
-          />
+          <>
+            <button
+              type="button"
+              onClick={() => setUploadVersionOpen(true)}
+              className="hidden h-9 items-center gap-2 rounded-lg border border-border-default bg-bg-secondary px-3 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary sm:inline-flex"
+            >
+              <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                <polyline points="17 8 12 3 7 8" />
+                <line x1="12" y1="3" x2="12" y2="15" />
+              </svg>
+              Upload new version
+            </button>
+            <UploadVersionModal
+              videoId={videoId}
+              title={uploadVersion.title}
+              description={uploadVersion.description}
+              transcriptsEnabled={uploadVersion.transcriptsEnabled}
+              open={uploadVersionOpen}
+              onOpenChange={setUploadVersionOpen}
+            />
+          </>
         )}
 
         <div className="relative" ref={moreMenuRef}>
@@ -245,6 +262,24 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl, spaceId, 
                 </svg>
                 Share
               </button>
+              {uploadVersion && (
+                <button
+                  role="menuitem"
+                  type="button"
+                  onClick={() => {
+                    setMoreMenuOpen(false);
+                    setUploadVersionOpen(true);
+                  }}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-text-primary transition-colors hover:bg-bg-tertiary sm:hidden"
+                >
+                  <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                    <polyline points="17 8 12 3 7 8" />
+                    <line x1="12" y1="3" x2="12" y2="15" />
+                  </svg>
+                  Upload new version
+                </button>
+              )}
               <button
                 role="menuitem"
                 onClick={requestDeleteVideo}

--- a/src/components/VideoHeader.tsx
+++ b/src/components/VideoHeader.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { actions } from "astro:actions";
 import { ConfirmDialog } from "./ConfirmDialog";
+import { UploadVersionModal } from "./UploadVersionModal";
 import { VersionSwitcher } from "./VersionSwitcher";
 
 interface ShareLink {
@@ -21,6 +22,12 @@ interface VersionSummary {
   commentCount: number;
 }
 
+interface UploadVersionConfig {
+  title: string;
+  description: string;
+  transcriptsEnabled: boolean;
+}
+
 interface VideoHeaderProps {
   videoId: string;
   shareLink: ShareLink | null;
@@ -29,11 +36,11 @@ interface VideoHeaderProps {
   backHref: string;
   backLabel?: string;
   spaceName?: string;
-  uploadVersionHref?: string | null;
   versions: VersionSummary[];
+  uploadVersion?: UploadVersionConfig | null;
 }
 
-export function VideoHeader({ videoId, shareLink: initialLink, appUrl, spaceId, backHref, backLabel = "Back to videos", spaceName, uploadVersionHref = null, versions }: VideoHeaderProps) {
+export function VideoHeader({ videoId, shareLink: initialLink, appUrl, spaceId, backHref, backLabel = "Back to videos", spaceName, versions, uploadVersion = null }: VideoHeaderProps) {
   const [shareLink, setShareLink] = useState(initialLink);
   const [loading, setLoading] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -195,6 +202,15 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl, spaceId, 
       <div className="ml-auto flex items-center gap-2">
         <VersionSwitcher videoId={videoId} versions={versions} />
 
+        {uploadVersion && (
+          <UploadVersionModal
+            videoId={videoId}
+            title={uploadVersion.title}
+            description={uploadVersion.description}
+            transcriptsEnabled={uploadVersion.transcriptsEnabled}
+          />
+        )}
+
         <div className="relative" ref={moreMenuRef}>
           <button
             onClick={() => setMoreMenuOpen((o) => !o)}
@@ -229,20 +245,6 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl, spaceId, 
                 </svg>
                 Share
               </button>
-              {uploadVersionHref && (
-                <a
-                  role="menuitem"
-                  href={uploadVersionHref}
-                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-text-primary transition-colors hover:bg-bg-tertiary"
-                >
-                  <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                    <polyline points="17 8 12 3 7 8" />
-                    <line x1="12" y1="3" x2="12" y2="15" />
-                  </svg>
-                  Upload new version
-                </a>
-              )}
               <button
                 role="menuitem"
                 onClick={requestDeleteVideo}

--- a/src/pages/videos/[id]/index.astro
+++ b/src/pages/videos/[id]/index.astro
@@ -5,7 +5,6 @@ import { ApprovalStatusPill } from "../../../components/ApprovalStatusPill";
 import { InlineEditor } from "../../../components/InlineEditor";
 import { ScriptWorkspace } from "../../../components/ScriptWorkspace";
 import { UploadView } from "../../../components/UploadView";
-import { UploadVersionModal } from "../../../components/UploadVersionModal";
 import { VideoDetailView } from "../../../components/VideoDetailView";
 import { VideoDetailsPanel } from "../../../components/VideoDetailsPanel";
 import { VideoHeader } from "../../../components/VideoHeader";
@@ -88,6 +87,11 @@ const tabHref = (tab: "script" | "video" | "details") => {
       backHref={backHref}
       spaceName={videoSpace.name}
       versions={versions}
+      uploadVersion={hasVideo && !isPublished && isOwner ? {
+        title: video.title,
+        description: video.description || "",
+        transcriptsEnabled,
+      } : null}
     />
 
     <div class="space-y-6">
@@ -186,46 +190,33 @@ const tabHref = (tab: "script" | "video" | "details") => {
           readOnly={isPublished}
         />
       ) : hasVideo ? (
-        <div class="space-y-6">
-          <VideoDetailView
-            client:load
-            videoId={video.id}
-            streamVideoId={video.streamVideoId}
-            status={video.status}
-            duration={video.duration}
-            initialComments={commentsWithNames}
-            currentUserId={user.id}
-            currentUserName={user.name}
-            title={video.title}
-            uploadDate={video.createdAt}
-            fileName={video.fileName}
-            targetDate={video.targetDate}
-            transcriptsEnabled={transcriptsEnabled}
-            uploadedBy={video.uploadedBy}
-            initialApprovalStatus={showApprovals ? approvalStatus : null}
-            initialPhase={phase}
-            pipelineEnabled={false}
-            userRole={role}
-            spaceId={video.spaceId}
-            initialActivity={projectActivity}
-            initialTranscriptData={initialTranscriptData}
-            hook={video.hook ?? null}
-            takeaway1={video.takeaway1 ?? null}
-            takeaway2={video.takeaway2 ?? null}
-            takeaway3={video.takeaway3 ?? null}
-          />
-          {!isPublished && isOwner && (
-            <div class="flex justify-end">
-              <UploadVersionModal
-                client:load
-                videoId={video.id}
-                title={video.title}
-                description={video.description || ""}
-                transcriptsEnabled={transcriptsEnabled}
-              />
-            </div>
-          )}
-        </div>
+        <VideoDetailView
+          client:load
+          videoId={video.id}
+          streamVideoId={video.streamVideoId}
+          status={video.status}
+          duration={video.duration}
+          initialComments={commentsWithNames}
+          currentUserId={user.id}
+          currentUserName={user.name}
+          title={video.title}
+          uploadDate={video.createdAt}
+          fileName={video.fileName}
+          targetDate={video.targetDate}
+          transcriptsEnabled={transcriptsEnabled}
+          uploadedBy={video.uploadedBy}
+          initialApprovalStatus={showApprovals ? approvalStatus : null}
+          initialPhase={phase}
+          pipelineEnabled={false}
+          userRole={role}
+          spaceId={video.spaceId}
+          initialActivity={projectActivity}
+          initialTranscriptData={initialTranscriptData}
+          hook={video.hook ?? null}
+          takeaway1={video.takeaway1 ?? null}
+          takeaway2={video.takeaway2 ?? null}
+          takeaway3={video.takeaway3 ?? null}
+        />
       ) : isPublished ? (
         <div class="rounded-xl border border-border-default bg-bg-secondary p-5 text-sm text-text-secondary">
           This project was published without a video upload.


### PR DESCRIPTION
## Summary
- The **Upload new version** button used to render at the bottom of the video tab, requiring scroll to discover.
- It now lives in the top action bar in `VideoHeader`, next to the version switcher, so it's visible above the fold and styled consistently with the other primary actions.
- Removed the `uploadVersionHref` prop on `VideoHeader` and its overflow-menu item — they were dead code (never wired in).

## Changes
- `src/components/VideoHeader.tsx`: import and render `UploadVersionModal` in the action bar when an `uploadVersion` config is provided. Drop `uploadVersionHref` prop + its menu entry.
- `src/components/UploadVersionModal.tsx`: restyle the trigger button to match the header peer button (`h-9`, bordered, with upload icon) instead of the old full-width pill.
- `src/pages/videos/[id]/index.astro`: pass `uploadVersion` to `VideoHeader` (gated by the same `hasVideo && !isPublished && isOwner` rule), remove the bottom placement and the now-unused `UploadVersionModal` import.

## Testing
See the local test plan in the implementation comment.

Closes #88