### PR TITLE
feat(approvals): targeted approval requests with email notifications

### DIFF
--- a/migrations/0022_create_approval_requests.sql
+++ b/migrations/0022_create_approval_requests.sql
@@ -1,14 +1,6 @@
--- Targeted approval requests (issue #93).
---
--- Replaces the previous "fan-out to every space member" model. An owner
--- or uploader can now explicitly request approval from specific space
--- members. Each row is the source of truth for one (video, requester,
--- requestedUser) request and tracks its lifecycle: pending → resolved
--- when the requested user approves the video, or cancelled if the
--- requester withdraws it.
---
--- Notifications and emails are still the delivery mechanism, but they
--- are now per-user and personalized off these rows.
+-- Targeted approval requests (issue #93). One row per
+-- (video, requester, requested_user) tracks lifecycle:
+-- pending -> resolved when the requested user approves, or cancelled.
 
 CREATE TABLE IF NOT EXISTS `approval_requests` (
   `id` text PRIMARY KEY NOT NULL,
@@ -22,8 +14,8 @@ CREATE TABLE IF NOT EXISTS `approval_requests` (
   `resolved_at` text
 );
 
--- One pending request per (video, requested_user). Resolved/cancelled
--- rows are kept for audit but don't prevent re-requesting.
+-- Partial unique: only one pending row per (video, requested_user);
+-- resolved/cancelled rows are preserved for audit.
 CREATE UNIQUE INDEX IF NOT EXISTS `approval_requests_video_user_pending_unique`
   ON `approval_requests` (`video_id`, `requested_user_id`)
   WHERE `status` = 'pending';

--- a/migrations/0022_create_approval_requests.sql
+++ b/migrations/0022_create_approval_requests.sql
@@ -1,0 +1,35 @@
+-- Targeted approval requests (issue #93).
+--
+-- Replaces the previous "fan-out to every space member" model. An owner
+-- or uploader can now explicitly request approval from specific space
+-- members. Each row is the source of truth for one (video, requester,
+-- requestedUser) request and tracks its lifecycle: pending → resolved
+-- when the requested user approves the video, or cancelled if the
+-- requester withdraws it.
+--
+-- Notifications and emails are still the delivery mechanism, but they
+-- are now per-user and personalized off these rows.
+
+CREATE TABLE IF NOT EXISTS `approval_requests` (
+  `id` text PRIMARY KEY NOT NULL,
+  `video_id` text NOT NULL REFERENCES `videos`(`id`) ON DELETE CASCADE,
+  `space_id` text NOT NULL REFERENCES `spaces`(`id`) ON DELETE CASCADE,
+  `requester_user_id` text REFERENCES `users`(`id`) ON DELETE SET NULL,
+  `requester_display_name` text NOT NULL,
+  `requested_user_id` text NOT NULL REFERENCES `users`(`id`) ON DELETE CASCADE,
+  `status` text NOT NULL DEFAULT 'pending',
+  `created_at` text DEFAULT (datetime('now')) NOT NULL,
+  `resolved_at` text
+);
+
+-- One pending request per (video, requested_user). Resolved/cancelled
+-- rows are kept for audit but don't prevent re-requesting.
+CREATE UNIQUE INDEX IF NOT EXISTS `approval_requests_video_user_pending_unique`
+  ON `approval_requests` (`video_id`, `requested_user_id`)
+  WHERE `status` = 'pending';
+
+CREATE INDEX IF NOT EXISTS `approval_requests_requested_user_pending_idx`
+  ON `approval_requests` (`requested_user_id`, `status`);
+
+CREATE INDEX IF NOT EXISTS `approval_requests_video_idx`
+  ON `approval_requests` (`video_id`);

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -492,8 +492,6 @@ export const server = {
           throw new ActionError({ code: "CONFLICT", message: "Could not record approval" });
         }
 
-        // Resolve any pending targeted approval requests for this approver,
-        // so the "Pending for me" bucket clears once they approve. Best-effort.
         try {
           await resolveApprovalRequestsForApprover(db, id, user.id);
         } catch (err) {
@@ -601,8 +599,6 @@ export const server = {
           throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
         }
 
-        // Only the uploader or a space owner can request approvals on a
-        // video. Member-reviewers shouldn't be able to ping each other.
         if (role !== "owner" && video.uploadedBy !== user.id) {
           throw new ActionError({
             code: "FORBIDDEN",
@@ -623,9 +619,7 @@ export const server = {
           });
         }
 
-        // Validate that every requested user is a member of the same space.
-        // Silently drops the actor and the uploader — neither can approve,
-        // so requesting approval from them is meaningless.
+        // Drop the actor and uploader — neither can approve.
         const uniqueIds = [...new Set(userIds)].filter(
           (uid) => uid !== user.id && uid !== video.uploadedBy,
         );
@@ -654,9 +648,8 @@ export const server = {
           });
         }
 
-        // Skip users who already have a pending request for this video.
-        // Approving a video does not delete the row (status flips to
-        // "resolved"), so we only filter on status = pending.
+        // Resolved/cancelled rows are kept for audit, so only block
+        // re-requesting against rows that are still pending.
         const existing = await db
           .select({ requestedUserId: approvalRequests.requestedUserId })
           .from(approvalRequests)
@@ -692,8 +685,6 @@ export const server = {
 
         await db.insert(approvalRequests).values(newRows);
 
-        // Per-user notification + email. Best-effort: dispatch failures
-        // don't roll back the request rows.
         try {
           await createTargetedApprovalRequestNotifications(
             db,

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -12,6 +12,7 @@ import {
   spaceMembers,
   spaceInvites,
   approvals,
+  approvalRequests,
   comments,
   scripts,
   transcripts,
@@ -47,7 +48,8 @@ import {
 } from "../lib/comments";
 import {
   createCommentNotifications,
-  createApprovalRequestNotifications,
+  createTargetedApprovalRequestNotifications,
+  resolveApprovalRequestsForApprover,
 } from "../lib/notifications";
 import { buildInviteAuthPath, buildInviteEmail } from "../lib/email";
 
@@ -408,34 +410,9 @@ export const server = {
           changedBy: user.name,
         });
 
-        // Fire approval-requested notifications when the project enters
-        // `reviewing_video` and the space requires approvals. Don't fail
-        // the action if notification dispatch errors.
-        if (
-          phase === "reviewing_video" &&
-          video.phase !== "reviewing_video"
-        ) {
-          try {
-            const spaceRow = await db
-              .select({ requiredApprovals: spaces.requiredApprovals })
-              .from(spaces)
-              .where(eq(spaces.id, video.spaceId))
-              .limit(1);
-            if ((spaceRow[0]?.requiredApprovals ?? 0) > 0) {
-              await createApprovalRequestNotifications(
-                db,
-                {
-                  videoId: id,
-                  actorUserId: user.id,
-                  actorDisplayName: user.name,
-                },
-                env,
-              );
-            }
-          } catch (err) {
-            console.error("Failed to send approval-requested notifications", err);
-          }
-        }
+        // NOTE: per issue #93 the generic fan-out of approval.requested
+        // notifications to every space member has been removed. Approvals
+        // are now requested explicitly via `video.requestApprovals`.
 
         const updated = await db
           .select()
@@ -515,6 +492,14 @@ export const server = {
           throw new ActionError({ code: "CONFLICT", message: "Could not record approval" });
         }
 
+        // Resolve any pending targeted approval requests for this approver,
+        // so the "Pending for me" bucket clears once they approve. Best-effort.
+        try {
+          await resolveApprovalRequestsForApprover(db, id, user.id);
+        } catch (err) {
+          console.error("Failed to resolve approval requests on approve", err);
+        }
+
         const status = await getApprovalStatus(db, id, video.spaceId);
         await broadcastApprovalUpdate(env, id, status);
 
@@ -587,6 +572,152 @@ export const server = {
         });
 
         return { approvalStatus: status };
+      },
+    }),
+
+    requestApprovals: defineAction({
+      input: z.object({
+        id: z.string().min(1),
+        userIds: z.array(z.string().min(1)).min(1).max(50),
+      }),
+      handler: async ({ id, userIds }, context) => {
+        const user = requireUser(context);
+        const db = createDb(env.DB);
+
+        const videoResult = await db
+          .select()
+          .from(videos)
+          .where(eq(videos.id, id))
+          .limit(1);
+
+        if (videoResult.length === 0) {
+          throw new ActionError({ code: "NOT_FOUND", message: "Video not found" });
+        }
+
+        const video = videoResult[0];
+
+        const role = await verifySpaceAccess(db, user.id, video.spaceId);
+        if (!role) {
+          throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
+        }
+
+        // Only the uploader or a space owner can request approvals on a
+        // video. Member-reviewers shouldn't be able to ping each other.
+        if (role !== "owner" && video.uploadedBy !== user.id) {
+          throw new ActionError({
+            code: "FORBIDDEN",
+            message: "Only the uploader or a space owner can request approvals",
+          });
+        }
+
+        const spaceRow = await db
+          .select({ requiredApprovals: spaces.requiredApprovals })
+          .from(spaces)
+          .where(eq(spaces.id, video.spaceId))
+          .limit(1);
+
+        if (!spaceRow[0] || spaceRow[0].requiredApprovals <= 0) {
+          throw new ActionError({
+            code: "FORBIDDEN",
+            message: "Approval workflow is not enabled for this space",
+          });
+        }
+
+        // Validate that every requested user is a member of the same space.
+        // Silently drops the actor and the uploader — neither can approve,
+        // so requesting approval from them is meaningless.
+        const uniqueIds = [...new Set(userIds)].filter(
+          (uid) => uid !== user.id && uid !== video.uploadedBy,
+        );
+
+        if (uniqueIds.length === 0) {
+          throw new ActionError({
+            code: "BAD_REQUEST",
+            message: "No valid approvers selected",
+          });
+        }
+
+        const memberRows = await db
+          .select({ userId: spaceMembers.userId })
+          .from(spaceMembers)
+          .where(
+            and(
+              eq(spaceMembers.spaceId, video.spaceId),
+              inArray(spaceMembers.userId, uniqueIds),
+            ),
+          );
+        const validMemberIds = memberRows.map((row) => row.userId);
+        if (validMemberIds.length !== uniqueIds.length) {
+          throw new ActionError({
+            code: "BAD_REQUEST",
+            message: "One or more selected users are not members of this space",
+          });
+        }
+
+        // Skip users who already have a pending request for this video.
+        // Approving a video does not delete the row (status flips to
+        // "resolved"), so we only filter on status = pending.
+        const existing = await db
+          .select({ requestedUserId: approvalRequests.requestedUserId })
+          .from(approvalRequests)
+          .where(
+            and(
+              eq(approvalRequests.videoId, id),
+              eq(approvalRequests.status, "pending"),
+              inArray(approvalRequests.requestedUserId, validMemberIds),
+            ),
+          );
+        const alreadyPending = new Set(existing.map((r) => r.requestedUserId));
+        const toCreate = validMemberIds.filter((uid) => !alreadyPending.has(uid));
+
+        if (toCreate.length === 0) {
+          return {
+            created: 0,
+            alreadyPending: validMemberIds.length,
+          };
+        }
+
+        const now = new Date().toISOString();
+        const newRows = toCreate.map((requestedUserId) => ({
+          id: nanoid(),
+          videoId: id,
+          spaceId: video.spaceId,
+          requesterUserId: user.id,
+          requesterDisplayName: user.name,
+          requestedUserId,
+          status: "pending" as const,
+          createdAt: now,
+          resolvedAt: null,
+        }));
+
+        await db.insert(approvalRequests).values(newRows);
+
+        // Per-user notification + email. Best-effort: dispatch failures
+        // don't roll back the request rows.
+        try {
+          await createTargetedApprovalRequestNotifications(
+            db,
+            {
+              videoId: id,
+              requestedUserIds: toCreate,
+              actorUserId: user.id,
+              actorDisplayName: user.name,
+            },
+            {
+              send: (msg) => env.EMAIL.send(msg),
+              from: env.OTP_EMAIL_FROM,
+              baseUrl: new URL(context.request.url).origin,
+            },
+            env,
+          );
+        } catch (err) {
+          console.error("Failed to dispatch targeted approval-request notifications", err);
+        }
+
+        return {
+          created: toCreate.length,
+          alreadyPending: alreadyPending.size,
+        };
       },
     }),
 

--- a/src/components/ApprovalSection.tsx
+++ b/src/components/ApprovalSection.tsx
@@ -136,8 +136,6 @@ export function ApprovalSection({
     !readOnly && !!currentUserId && isSpaceMember && !isUploader && !hasApproved;
   const canUndo =
     !readOnly && !!currentUserId && isSpaceMember && hasApproved;
-  // Only the uploader or a space owner can fan out targeted approval
-  // requests. Other space members can approve, but not request.
   const canRequestApprovals =
     !readOnly &&
     !!currentUserId &&

--- a/src/components/ApprovalSection.tsx
+++ b/src/components/ApprovalSection.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
 import { actions } from "astro:actions";
 import { connectVideoRoom, type BroadcastApprovalStatus } from "../lib/realtime";
+import { RequestApprovalDialog } from "./RequestApprovalDialog";
+import { ToastViewport, useToast } from "./Toast";
 
 export interface ApprovalRecord {
   id: string;
@@ -34,6 +36,10 @@ interface ApprovalSectionProps {
   shareToken?: string;
   /** Notifies parent UI when approval status changes. */
   onStatusChange?: (status: ApprovalStatus) => void;
+  /** Space the video belongs to. Required to enable the request-approval picker. */
+  spaceId?: string;
+  /** Current user's role in the space. Owners can always request approvals. */
+  userRole?: "owner" | "member";
 }
 
 function formatTimeAgo(iso: string): string {
@@ -91,10 +97,14 @@ export function ApprovalSection({
   viewerName,
   shareToken,
   onStatusChange,
+  spaceId,
+  userRole,
 }: ApprovalSectionProps) {
   const [status, setStatus] = useState<ApprovalStatus>(initialStatus);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [requestOpen, setRequestOpen] = useState(false);
+  const { toasts, showToast, dismissToast } = useToast();
 
   useEffect(() => {
     onStatusChange?.(status);
@@ -126,6 +136,14 @@ export function ApprovalSection({
     !readOnly && !!currentUserId && isSpaceMember && !isUploader && !hasApproved;
   const canUndo =
     !readOnly && !!currentUserId && isSpaceMember && hasApproved;
+  // Only the uploader or a space owner can fan out targeted approval
+  // requests. Other space members can approve, but not request.
+  const canRequestApprovals =
+    !readOnly &&
+    !!currentUserId &&
+    !!spaceId &&
+    isSpaceMember &&
+    (isUploader || userRole === "owner");
 
   const dispatchLocalApprovalUpdate = useCallback(
     (next: ApprovalStatus) => {
@@ -208,27 +226,39 @@ export function ApprovalSection({
           </p>
         </div>
 
-        {canApprove && (
-          <button
-            type="button"
-            onClick={approve}
-            disabled={busy}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-accent-primary px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-60"
-          >
-            <CheckIcon className="h-4 w-4" />
-            Approve
-          </button>
-        )}
-        {canUndo && (
-          <button
-            type="button"
-            onClick={undoApproval}
-            disabled={busy}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border-default bg-bg-tertiary px-3 py-1.5 text-sm font-medium text-text-primary transition-colors hover:border-border-hover hover:bg-bg-secondary disabled:opacity-60"
-          >
-            Undo Approval
-          </button>
-        )}
+        <div className="flex flex-wrap items-center gap-2">
+          {canRequestApprovals && (
+            <button
+              type="button"
+              onClick={() => setRequestOpen(true)}
+              disabled={busy}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-border-default bg-bg-tertiary px-3 py-1.5 text-sm font-medium text-text-primary transition-colors hover:border-border-hover hover:bg-bg-secondary disabled:opacity-60"
+            >
+              Request approval…
+            </button>
+          )}
+          {canApprove && (
+            <button
+              type="button"
+              onClick={approve}
+              disabled={busy}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-accent-primary px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-60"
+            >
+              <CheckIcon className="h-4 w-4" />
+              Approve
+            </button>
+          )}
+          {canUndo && (
+            <button
+              type="button"
+              onClick={undoApproval}
+              disabled={busy}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-border-default bg-bg-tertiary px-3 py-1.5 text-sm font-medium text-text-primary transition-colors hover:border-border-hover hover:bg-bg-secondary disabled:opacity-60"
+            >
+              Undo Approval
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Progress bar */}
@@ -286,6 +316,28 @@ export function ApprovalSection({
           {error}
         </p>
       )}
+
+      {canRequestApprovals && spaceId && currentUserId && (
+        <RequestApprovalDialog
+          open={requestOpen}
+          onClose={() => setRequestOpen(false)}
+          videoId={videoId}
+          spaceId={spaceId}
+          currentUserId={currentUserId}
+          uploadedBy={uploadedBy}
+          onRequested={(count) => {
+            if (count > 0) {
+              showToast(
+                `Requested approval from ${count} ${count === 1 ? "person" : "people"}`,
+              );
+            } else {
+              showToast("Those people already have a pending request");
+            }
+          }}
+        />
+      )}
+
+      <ToastViewport toasts={toasts} onDismiss={dismissToast} />
     </section>
   );
 }

--- a/src/components/NotificationCenter.tsx
+++ b/src/components/NotificationCenter.tsx
@@ -1,11 +1,15 @@
 import { useState } from "react";
 import type { PendingInviteForUser } from "../lib/invites";
-import type { UserNotification } from "../lib/notifications";
+import type {
+  PendingApprovalRequestForUser,
+  UserNotification,
+} from "../lib/notifications";
 import { ToastViewport, useToast } from "./Toast";
 
 interface NotificationCenterProps {
   invites: PendingInviteForUser[];
   notifications: UserNotification[];
+  pendingApprovals?: PendingApprovalRequestForUser[];
 }
 
 interface AcceptInviteResponse {
@@ -29,12 +33,17 @@ function formatDate(value: string): string {
 }
 
 function getNotificationLabel(type: UserNotification["type"]): string {
+  if (type === "approval.requested") return "Approval requested";
   if (type.startsWith("script_comment")) return "Script feedback";
   if (type.endsWith("reply")) return "Reply";
   return "Video comment";
 }
 
-export function NotificationCenter({ invites, notifications }: NotificationCenterProps) {
+export function NotificationCenter({
+  invites,
+  notifications,
+  pendingApprovals = [],
+}: NotificationCenterProps) {
   const [pendingInvites, setPendingInvites] = useState(invites);
   const [commentNotifications, setCommentNotifications] = useState(notifications);
   const [loadingToken, setLoadingToken] = useState<string | null>(null);
@@ -104,7 +113,10 @@ export function NotificationCenter({ invites, notifications }: NotificationCente
     }
   };
 
-  const hasAnyNotifications = pendingInvites.length > 0 || commentNotifications.length > 0;
+  const hasAnyNotifications =
+    pendingInvites.length > 0 ||
+    commentNotifications.length > 0 ||
+    pendingApprovals.length > 0;
 
   return (
     <>
@@ -137,7 +149,7 @@ export function NotificationCenter({ invites, notifications }: NotificationCente
           </div>
           <h2 className="text-lg font-semibold text-text-primary">No pending notifications</h2>
           <p className="mt-2 text-sm text-text-secondary">
-            Space invites, comment activity, and replies will appear here.
+            Space invites, approval requests, and comment activity will appear here.
           </p>
         </div>
       ) : (
@@ -183,6 +195,50 @@ export function NotificationCenter({ invites, notifications }: NotificationCente
                     </li>
                   );
                 })}
+              </ul>
+            </section>
+          )}
+
+          {pendingApprovals.length > 0 && (
+            <section>
+              <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-text-tertiary">
+                Pending approval requests
+              </h2>
+              <ul className="space-y-3">
+                {pendingApprovals.map((request) => (
+                  <li
+                    key={request.id}
+                    className="rounded-2xl border border-accent-primary/40 bg-accent-primary/10 p-5"
+                  >
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="rounded-full bg-bg-tertiary px-2 py-0.5 text-xs font-medium text-text-secondary">
+                            Approval requested
+                          </span>
+                          <span className="text-xs text-text-tertiary">
+                            {formatDate(request.createdAt)}
+                          </span>
+                        </div>
+                        <p className="mt-2 text-sm font-semibold text-text-primary">
+                          {request.requesterDisplayName} requested your approval on &ldquo;
+                          {request.videoTitle}&rdquo;
+                        </p>
+                        <p className="mt-1 text-xs text-text-tertiary">
+                          In {request.spaceName}
+                        </p>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <a
+                          href={`/videos/${request.videoId}?tab=video`}
+                          className="rounded-lg bg-accent-primary px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover"
+                        >
+                          Review video
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                ))}
               </ul>
             </section>
           )}

--- a/src/components/RequestApprovalDialog.tsx
+++ b/src/components/RequestApprovalDialog.tsx
@@ -44,7 +44,6 @@ export function RequestApprovalDialog({
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  // Reset transient state every time the dialog opens.
   useEffect(() => {
     if (!open) return;
     setSelected(new Set());
@@ -52,8 +51,6 @@ export function RequestApprovalDialog({
     setSubmitError(null);
   }, [open]);
 
-  // Lazy-load members the first time the dialog opens. Re-fetches if the
-  // dialog is reopened against a different space.
   useEffect(() => {
     if (!open) return;
     const controller = new AbortController();

--- a/src/components/RequestApprovalDialog.tsx
+++ b/src/components/RequestApprovalDialog.tsx
@@ -52,28 +52,30 @@ export function RequestApprovalDialog({
     setSubmitError(null);
   }, [open]);
 
-  // Lazy-load members the first time the dialog opens.
+  // Lazy-load members the first time the dialog opens. Re-fetches if the
+  // dialog is reopened against a different space.
   useEffect(() => {
-    if (!open || members !== null || loading) return;
-    let cancelled = false;
+    if (!open) return;
+    const controller = new AbortController();
     setLoading(true);
     setFetchError(null);
-    fetch(`/api/spaces/${spaceId}/members`)
+    fetch(`/api/spaces/${spaceId}/members`, { signal: controller.signal })
       .then(async (res) => {
-        if (!res.ok) throw new Error("Failed to load space members");
+        if (!res.ok) throw new Error(`Failed to load space members (${res.status})`);
         const data = (await res.json()) as { members: SpaceMemberOption[] };
-        if (!cancelled) setMembers(data.members);
+        setMembers(data.members);
       })
       .catch((err) => {
-        if (!cancelled) setFetchError(err instanceof Error ? err.message : "Failed to load");
+        if ((err as Error).name === "AbortError") return;
+        setFetchError(err instanceof Error ? err.message : "Failed to load");
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (!controller.signal.aborted) setLoading(false);
       });
     return () => {
-      cancelled = true;
+      controller.abort();
     };
-  }, [open, spaceId, members, loading]);
+  }, [open, spaceId]);
 
   const eligibleMembers = useMemo(() => {
     if (!members) return [];

--- a/src/components/RequestApprovalDialog.tsx
+++ b/src/components/RequestApprovalDialog.tsx
@@ -1,0 +1,254 @@
+import { useEffect, useMemo, useState } from "react";
+import { actions } from "astro:actions";
+import { Modal } from "./Modal";
+
+interface SpaceMemberOption {
+  userId: string;
+  name: string;
+  email: string;
+  role: "owner" | "member";
+}
+
+interface RequestApprovalDialogProps {
+  open: boolean;
+  onClose: () => void;
+  videoId: string;
+  spaceId: string;
+  /** Currently signed-in user; excluded from the list. */
+  currentUserId: string;
+  /** Video uploader; excluded because uploaders cannot approve their own video. */
+  uploadedBy: string | null;
+  /** Notify caller of a successful request so it can show a toast. */
+  onRequested?: (count: number) => void;
+}
+
+/**
+ * Modal that fetches space members and lets the uploader/owner pick a subset
+ * to ping for approval. Filters by name/email, supports keyboard interaction
+ * via standard form controls, and submits via `actions.video.requestApprovals`.
+ */
+export function RequestApprovalDialog({
+  open,
+  onClose,
+  videoId,
+  spaceId,
+  currentUserId,
+  uploadedBy,
+  onRequested,
+}: RequestApprovalDialogProps) {
+  const [loading, setLoading] = useState(false);
+  const [members, setMembers] = useState<SpaceMemberOption[] | null>(null);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [filter, setFilter] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Reset transient state every time the dialog opens.
+  useEffect(() => {
+    if (!open) return;
+    setSelected(new Set());
+    setFilter("");
+    setSubmitError(null);
+  }, [open]);
+
+  // Lazy-load members the first time the dialog opens.
+  useEffect(() => {
+    if (!open || members !== null || loading) return;
+    let cancelled = false;
+    setLoading(true);
+    setFetchError(null);
+    fetch(`/api/spaces/${spaceId}/members`)
+      .then(async (res) => {
+        if (!res.ok) throw new Error("Failed to load space members");
+        const data = (await res.json()) as { members: SpaceMemberOption[] };
+        if (!cancelled) setMembers(data.members);
+      })
+      .catch((err) => {
+        if (!cancelled) setFetchError(err instanceof Error ? err.message : "Failed to load");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, spaceId, members, loading]);
+
+  const eligibleMembers = useMemo(() => {
+    if (!members) return [];
+    return members.filter(
+      (m) => m.userId !== currentUserId && m.userId !== uploadedBy,
+    );
+  }, [members, currentUserId, uploadedBy]);
+
+  const filteredMembers = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return eligibleMembers;
+    return eligibleMembers.filter(
+      (m) =>
+        m.name.toLowerCase().includes(q) ||
+        m.email.toLowerCase().includes(q),
+    );
+  }, [eligibleMembers, filter]);
+
+  const toggle = (userId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(userId)) next.delete(userId);
+      else next.add(userId);
+      return next;
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (selected.size === 0 || submitting) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const { data, error } = await actions.video.requestApprovals({
+        id: videoId,
+        userIds: Array.from(selected),
+      });
+      if (error) {
+        setSubmitError(error.message || "Could not send requests");
+        return;
+      }
+      onRequested?.(data?.created ?? 0);
+      onClose();
+    } catch {
+      setSubmitError("Network error");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={open}
+      onClose={onClose}
+      size="md"
+      ariaLabelledBy="request-approval-heading"
+    >
+      <div>
+        <h2
+          id="request-approval-heading"
+          className="text-lg font-semibold text-text-primary"
+        >
+          Request approval
+        </h2>
+        <p className="mt-1 text-sm text-text-secondary">
+          Pick the people you want to review this cut. They will get an in-app
+          notification and an email if they have email notifications enabled.
+        </p>
+
+        <div className="mt-4">
+          <label
+            htmlFor="request-approval-filter"
+            className="sr-only"
+          >
+            Filter members
+          </label>
+          <input
+            id="request-approval-filter"
+            type="text"
+            value={filter}
+            onChange={(event) => setFilter(event.target.value)}
+            placeholder="Filter by name or email"
+            className="w-full rounded-lg border border-border-default bg-bg-tertiary px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent-primary focus:outline-none"
+          />
+        </div>
+
+        <div className="mt-3 max-h-64 overflow-y-auto rounded-lg border border-border-default bg-bg-primary">
+          {loading && (
+            <p className="p-4 text-center text-sm text-text-tertiary">
+              Loading members…
+            </p>
+          )}
+          {!loading && fetchError && (
+            <p className="p-4 text-center text-sm text-accent-danger" role="alert">
+              {fetchError}
+            </p>
+          )}
+          {!loading && !fetchError && eligibleMembers.length === 0 && (
+            <p className="p-4 text-center text-sm text-text-tertiary">
+              No other space members are available to review.
+            </p>
+          )}
+          {!loading &&
+            !fetchError &&
+            eligibleMembers.length > 0 &&
+            filteredMembers.length === 0 && (
+              <p className="p-4 text-center text-sm text-text-tertiary">
+                No members match &ldquo;{filter}&rdquo;.
+              </p>
+            )}
+          {!loading && filteredMembers.length > 0 && (
+            <ul className="divide-y divide-border-default">
+              {filteredMembers.map((member) => {
+                const isSelected = selected.has(member.userId);
+                return (
+                  <li key={member.userId}>
+                    <label className="flex cursor-pointer items-center gap-3 px-3 py-2 transition-colors hover:bg-bg-tertiary">
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={() => toggle(member.userId)}
+                        className="h-4 w-4 shrink-0 accent-accent-primary"
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-sm font-medium text-text-primary">
+                          {member.name}
+                          {member.role === "owner" && (
+                            <span className="ml-2 rounded-full bg-bg-tertiary px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-text-tertiary">
+                              Owner
+                            </span>
+                          )}
+                        </span>
+                        <span className="block truncate text-xs text-text-tertiary">
+                          {member.email}
+                        </span>
+                      </span>
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        {submitError && (
+          <p
+            className="mt-3 text-sm text-accent-danger"
+            role="alert"
+          >
+            {submitError}
+          </p>
+        )}
+
+        <div className="mt-5 flex flex-wrap items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="rounded-lg border border-border-default px-3 py-2 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={selected.size === 0 || submitting}
+            className="rounded-lg bg-accent-primary px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-50"
+          >
+            {submitting
+              ? "Sending…"
+              : selected.size === 0
+                ? "Request approval"
+                : `Request from ${selected.size} ${selected.size === 1 ? "person" : "people"}`}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/VideoDetailView.tsx
+++ b/src/components/VideoDetailView.tsx
@@ -306,6 +306,8 @@ export function VideoDetailView({
           readOnly={isShareMode || isPublished}
           shareToken={shareToken}
           onStatusChange={setApprovalStatus}
+          spaceId={spaceId}
+          userRole={userRole === "owner" ? "owner" : "member"}
         />
       )}
     </>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -321,6 +321,40 @@ export const approvals = sqliteTable("approvals", {
     .default(sql`(datetime('now'))`),
 });
 
+export const approvalRequests = sqliteTable(
+  "approval_requests",
+  {
+    id: text("id").primaryKey(),
+    videoId: text("video_id")
+      .notNull()
+      .references(() => videos.id, { onDelete: "cascade" }),
+    spaceId: text("space_id")
+      .notNull()
+      .references(() => spaces.id, { onDelete: "cascade" }),
+    requesterUserId: text("requester_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    requesterDisplayName: text("requester_display_name").notNull(),
+    requestedUserId: text("requested_user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    status: text("status", { enum: ["pending", "resolved", "cancelled"] })
+      .notNull()
+      .default("pending"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    resolvedAt: text("resolved_at"),
+  },
+  (table) => [
+    index("approval_requests_requested_user_pending_idx").on(
+      table.requestedUserId,
+      table.status,
+    ),
+    index("approval_requests_video_idx").on(table.videoId),
+  ],
+);
+
 export const comments = sqliteTable("comments", {
   id: text("id").primaryKey(),
   videoId: text("video_id")

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -21,6 +21,13 @@ export interface CommentNotificationEmailParams {
   baseUrl: string;
 }
 
+export interface ApprovalRequestEmailParams {
+  actorDisplayName: string;
+  videoTitle: string;
+  href: string;
+  baseUrl: string;
+}
+
 function escapeHtml(value: string): string {
   return value
     .replaceAll("&", "&amp;")
@@ -63,6 +70,51 @@ export function buildInviteEmail({ inviteUrl, inviterName, spaceName }: InviteEm
           <a href="${safeInviteUrl}" style="color: #6c5ce7; word-break: break-all;">${safeInviteUrl}</a>
         </p>
         <p style="margin: 24px 0 0; color: #9ca3af; font-size: 12px;">If you were not expecting this invite, you can ignore this email.</p>
+      </div>
+    </div>
+  `;
+
+  return { subject, text, html };
+}
+
+export function buildApprovalRequestEmail({
+  actorDisplayName,
+  videoTitle,
+  href,
+  baseUrl,
+}: ApprovalRequestEmailParams) {
+  const safeActor = escapeHtml(actorDisplayName);
+  const safeTitle = escapeHtml(videoTitle);
+  const fullUrl = `${baseUrl}${href}`;
+  const safeFullUrl = escapeHtml(fullUrl);
+  const subject = sanitizeSubjectPart(
+    `${actorDisplayName} requested your approval on "${videoTitle}"`,
+  );
+
+  const text = [
+    `${actorDisplayName} requested your approval on "${videoTitle}".`,
+    "",
+    `Review the video and approve or leave feedback: ${fullUrl}`,
+    "",
+    "You're receiving this because you have email notifications enabled on Quick Cuts. You can turn them off in your account menu.",
+  ].join("\n");
+
+  const html = `
+    <div style="font-family: Inter, Arial, sans-serif; color: #111827; line-height: 1.5; background: #f9fafb; padding: 32px;">
+      <div style="max-width: 520px; margin: 0 auto; background: #ffffff; border: 1px solid #e5e7eb; border-radius: 18px; padding: 32px;">
+        <p style="margin: 0 0 8px; color: #6c5ce7; font-size: 14px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;">Quick Cuts</p>
+        <h1 style="font-size: 24px; line-height: 1.25; margin: 0 0 16px; color: #111827;">Approval requested</h1>
+        <p style="margin: 0 0 24px; color: #4b5563; font-size: 16px;">
+          <strong style="color: #111827;">${safeActor}</strong> requested your approval on <strong style="color: #111827;">${safeTitle}</strong>.
+        </p>
+        <a href="${safeFullUrl}" style="display: inline-block; background: #6c5ce7; color: #ffffff; text-decoration: none; font-weight: 700; border-radius: 10px; padding: 12px 18px;">Review video</a>
+        <p style="margin: 24px 0 0; color: #6b7280; font-size: 13px;">
+          If the button does not work, copy and paste this link into your browser:<br />
+          <a href="${safeFullUrl}" style="color: #6c5ce7; word-break: break-all;">${safeFullUrl}</a>
+        </p>
+        <p style="margin: 24px 0 0; color: #9ca3af; font-size: 12px;">
+          You&rsquo;re receiving this because you have email notifications enabled. You can turn them off from the account menu in Quick Cuts.
+        </p>
       </div>
     </div>
   `;

--- a/src/lib/notification-copy.ts
+++ b/src/lib/notification-copy.ts
@@ -37,9 +37,6 @@ export function getNotificationCopy(
         heading: "New comment on your video",
       };
     case "approval.requested":
-      // Per-user copy: targeted approval requests (issue #93) generate one
-      // notification row per requested reviewer, so the wording can claim
-      // "your approval" was requested.
       return {
         title: `${actorName} requested your approval on "${videoTitle}"`,
         heading: "Approval requested",

--- a/src/lib/notification-copy.ts
+++ b/src/lib/notification-copy.ts
@@ -37,12 +37,12 @@ export function getNotificationCopy(
         heading: "New comment on your video",
       };
     case "approval.requested":
-      // Generic copy by design: until we add explicit, per-user approval
-      // requests, this notification fans out to every space member, so the
-      // wording can't claim "your approval" was requested.
+      // Per-user copy: targeted approval requests (issue #93) generate one
+      // notification row per requested reviewer, so the wording can claim
+      // "your approval" was requested.
       return {
-        title: `"${videoTitle}" is looking for approval`,
-        heading: "Approval needed",
+        title: `${actorName} requested your approval on "${videoTitle}"`,
+        heading: "Approval requested",
       };
   }
 }

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,8 +1,16 @@
 import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { Database } from "../db";
-import { comments, notifications, spaceMembers, spaces, users, videos } from "../db/schema";
+import {
+  approvalRequests,
+  comments,
+  notifications,
+  spaceMembers,
+  spaces,
+  users,
+  videos,
+} from "../db/schema";
 import { broadcastNotification } from "./broadcast";
-import { buildCommentNotificationEmail } from "./email";
+import { buildApprovalRequestEmail, buildCommentNotificationEmail } from "./email";
 import { getNotificationCopy, type NotificationType } from "./notification-copy";
 
 export type { NotificationType, NotificationCopy } from "./notification-copy";
@@ -207,28 +215,35 @@ export async function createCommentNotifications(
   }
 }
 
-export interface ApprovalRequestNotificationInput {
+export interface TargetedApprovalRequestInput {
   videoId: string;
+  /** User ids the approval is being requested from. Already validated as space members. */
+  requestedUserIds: string[];
   actorUserId: string | null;
   actorDisplayName: string;
 }
 
 /**
- * Notify all space members (excluding the actor and the video uploader)
- * that a video has entered review and requires their approval. Fires when
- * a video transitions into `reviewing_video` and the space has
- * `requiredApprovals > 0`.
+ * Notify the specific users an uploader/owner has requested approval from
+ * (issue #93). One notification row per recipient, personalized copy
+ * ("X requested your approval on \"…\""), and an email when the recipient
+ * has `users.emailNotificationsEnabled = true`.
+ *
+ * Replaces the previous fan-out helper that pinged every space member
+ * regardless of whether they had been asked.
  */
-export async function createApprovalRequestNotifications(
+export async function createTargetedApprovalRequestNotifications(
   db: Database,
-  input: ApprovalRequestNotificationInput,
+  input: TargetedApprovalRequestInput,
+  emailConfig?: EmailConfig,
   realtimeEnv?: Env,
 ): Promise<void> {
+  if (input.requestedUserIds.length === 0) return;
+
   const videoRows = await db
     .select({
       id: videos.id,
       title: videos.title,
-      uploadedBy: videos.uploadedBy,
       spaceId: videos.spaceId,
     })
     .from(videos)
@@ -238,19 +253,7 @@ export async function createApprovalRequestNotifications(
   const video = videoRows[0];
   if (!video) return;
 
-  const memberRows = await db
-    .select({ userId: spaceMembers.userId })
-    .from(spaceMembers)
-    .where(eq(spaceMembers.spaceId, video.spaceId));
-
-  const exclude = new Set<string>();
-  if (input.actorUserId) exclude.add(input.actorUserId);
-  if (video.uploadedBy) exclude.add(video.uploadedBy);
-
-  const recipientIds = memberRows
-    .map((row) => row.userId)
-    .filter((id) => !exclude.has(id));
-
+  const recipientIds = [...new Set(input.requestedUserIds.filter(Boolean))];
   if (recipientIds.length === 0) return;
 
   const copy = getNotificationCopy(
@@ -292,6 +295,117 @@ export async function createApprovalRequestNotifications(
       ),
     );
   }
+
+  if (!emailConfig) return;
+
+  try {
+    const emailRecipients = await db
+      .select({ id: users.id, email: users.email })
+      .from(users)
+      .where(
+        and(
+          inArray(users.id, recipientIds),
+          eq(users.emailNotificationsEnabled, true),
+        ),
+      );
+
+    if (emailRecipients.length === 0) return;
+
+    const emailContent = buildApprovalRequestEmail({
+      actorDisplayName: input.actorDisplayName,
+      videoTitle: video.title,
+      href,
+      baseUrl: emailConfig.baseUrl,
+    });
+
+    const results = await Promise.allSettled(
+      emailRecipients.map((recipient) =>
+        emailConfig.send({
+          to: recipient.email,
+          from: emailConfig.from,
+          subject: emailContent.subject,
+          text: emailContent.text,
+          html: emailContent.html,
+        }),
+      ),
+    );
+
+    const failures = results.filter(
+      (r): r is PromiseRejectedResult => r.status === "rejected",
+    );
+    if (failures.length > 0) {
+      console.error(
+        `${failures.length}/${results.length} approval-request emails failed`,
+        failures.map((f) => f.reason),
+      );
+    }
+  } catch (error) {
+    console.error("Failed to send approval-request emails", error);
+  }
+}
+
+export interface PendingApprovalRequestForUser {
+  id: string;
+  videoId: string;
+  videoTitle: string;
+  spaceId: string;
+  spaceName: string;
+  requesterDisplayName: string;
+  createdAt: string;
+}
+
+/**
+ * Returns approval requests where this user is the requested approver and
+ * the request is still pending. Used to surface a dedicated "Pending for me"
+ * bucket in the notification center.
+ */
+export async function getPendingApprovalRequestsForUser(
+  db: Database,
+  userId: string,
+): Promise<PendingApprovalRequestForUser[]> {
+  return db
+    .select({
+      id: approvalRequests.id,
+      videoId: approvalRequests.videoId,
+      videoTitle: videos.title,
+      spaceId: approvalRequests.spaceId,
+      spaceName: spaces.name,
+      requesterDisplayName: approvalRequests.requesterDisplayName,
+      createdAt: approvalRequests.createdAt,
+    })
+    .from(approvalRequests)
+    .innerJoin(videos, eq(approvalRequests.videoId, videos.id))
+    .innerJoin(spaces, eq(approvalRequests.spaceId, spaces.id))
+    .where(
+      and(
+        eq(approvalRequests.requestedUserId, userId),
+        eq(approvalRequests.status, "pending"),
+      ),
+    )
+    .orderBy(desc(approvalRequests.createdAt));
+}
+
+/**
+ * Mark every pending approval_request from `userId` on `videoId` as resolved.
+ * Called from the approve action once an approval row is recorded so the
+ * "pending for me" bucket clears for the approver, while the row is kept for
+ * audit purposes.
+ */
+export async function resolveApprovalRequestsForApprover(
+  db: Database,
+  videoId: string,
+  userId: string,
+): Promise<void> {
+  await db
+    .update(approvalRequests)
+    .set({ status: "resolved", resolvedAt: new Date().toISOString() })
+    .where(
+      and(
+        eq(approvalRequests.videoId, videoId),
+        eq(approvalRequests.requestedUserId, userId),
+        eq(approvalRequests.status, "pending"),
+      ),
+    );
 }
 
 export async function getNotificationsForUser(

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -224,13 +224,9 @@ export interface TargetedApprovalRequestInput {
 }
 
 /**
- * Notify the specific users an uploader/owner has requested approval from
- * (issue #93). One notification row per recipient, personalized copy
- * ("X requested your approval on \"…\""), and an email when the recipient
- * has `users.emailNotificationsEnabled = true`.
- *
- * Replaces the previous fan-out helper that pinged every space member
- * regardless of whether they had been asked.
+ * Notify the specific users an uploader/owner has requested approval from.
+ * One notification row per recipient with personalized copy, and an email
+ * to recipients who have `users.emailNotificationsEnabled = true`.
  */
 export async function createTargetedApprovalRequestNotifications(
   db: Database,
@@ -354,11 +350,7 @@ export interface PendingApprovalRequestForUser {
   createdAt: string;
 }
 
-/**
- * Returns approval requests where this user is the requested approver and
- * the request is still pending. Used to surface a dedicated "Pending for me"
- * bucket in the notification center.
- */
+/** Approval requests still pending for the given user (the requested approver). */
 export async function getPendingApprovalRequestsForUser(
   db: Database,
   userId: string,
@@ -385,12 +377,7 @@ export async function getPendingApprovalRequestsForUser(
     .orderBy(desc(approvalRequests.createdAt));
 }
 
-/**
- * Mark every pending approval_request from `userId` on `videoId` as resolved.
- * Called from the approve action once an approval row is recorded so the
- * "pending for me" bucket clears for the approver, while the row is kept for
- * audit purposes.
- */
+/** Flip every pending approval_request from this user on this video to resolved. */
 export async function resolveApprovalRequestsForApprover(
   db: Database,
   videoId: string,

--- a/src/lib/spaces.ts
+++ b/src/lib/spaces.ts
@@ -1,5 +1,5 @@
 import { eq, and, asc } from "drizzle-orm";
-import { spaces, spaceMembers } from "../db/schema";
+import { spaces, spaceMembers, users } from "../db/schema";
 import type { Database } from "../db";
 
 export type SpaceRole = "owner" | "member";
@@ -58,6 +58,37 @@ export async function verifySpaceAccess(
 
   if (row.length === 0) return null;
   return row[0].role as SpaceRole;
+}
+
+export interface SpaceMember {
+  id: string;
+  userId: string;
+  role: SpaceRole;
+  name: string;
+  email: string;
+  createdAt: string;
+}
+
+/** Return every member of a space joined with their user info. */
+export async function getSpaceMembers(
+  db: Database,
+  spaceId: string,
+): Promise<SpaceMember[]> {
+  const rows = await db
+    .select({
+      id: spaceMembers.id,
+      userId: spaceMembers.userId,
+      role: spaceMembers.role,
+      createdAt: spaceMembers.createdAt,
+      name: users.name,
+      email: users.email,
+    })
+    .from(spaceMembers)
+    .innerJoin(users, eq(spaceMembers.userId, users.id))
+    .where(eq(spaceMembers.spaceId, spaceId))
+    .orderBy(asc(spaceMembers.createdAt));
+
+  return rows as SpaceMember[];
 }
 
 /**

--- a/src/pages/notifications.astro
+++ b/src/pages/notifications.astro
@@ -3,7 +3,10 @@ import Layout from "../layouts/Layout.astro";
 import { NotificationCenter } from "../components/NotificationCenter";
 import { createDb } from "../db";
 import { getPendingInvitesForUser } from "../lib/invites";
-import { getNotificationsForUser } from "../lib/notifications";
+import {
+  getNotificationsForUser,
+  getPendingApprovalRequestsForUser,
+} from "../lib/notifications";
 import { env } from "cloudflare:workers";
 
 const user = Astro.locals.user;
@@ -12,6 +15,7 @@ if (!user) return Astro.redirect("/login");
 const db = createDb(env.DB);
 const pendingInvites = await getPendingInvitesForUser(db, user.email);
 const notifications = await getNotificationsForUser(db, user.id);
+const pendingApprovals = await getPendingApprovalRequestsForUser(db, user.id);
 ---
 
 <Layout title="Notifications" user={user}>
@@ -19,10 +23,15 @@ const notifications = await getNotificationsForUser(db, user.id);
     <div class="mb-8">
       <h1 class="text-2xl font-bold text-text-primary">Notifications</h1>
       <p class="mt-1 text-sm text-text-secondary">
-        Review pending invites and recent comment activity.
+        Review pending invites, approval requests, and recent comment activity.
       </p>
     </div>
 
-    <NotificationCenter client:load invites={pendingInvites} notifications={notifications} />
+    <NotificationCenter
+      client:load
+      invites={pendingInvites}
+      notifications={notifications}
+      pendingApprovals={pendingApprovals}
+    />
   </div>
 </Layout>


### PR DESCRIPTION
## Summary
- Replace the noisy "fan-out to every space member" approval notification with explicit, per-user approval requests targeted by the uploader or space owner.
- Persist requests in a new `approval_requests` table (source of truth, audit trail), with status flipping `pending → resolved` when the requested user approves the video.
- Send a personalized in-app notification AND an email (when the recipient has `users.emailNotificationsEnabled = true`) for every targeted request.
- Surface a dedicated **Pending approval requests** section in the notification center for requests where the current user is the requested approver.

## Changes

**Schema**
- `migrations/0022_create_approval_requests.sql` — new `approval_requests` table with one-pending-per-(video,user) unique constraint and supporting indexes.
- `src/db/schema.ts` — drizzle definition for `approvalRequests`.

**Server actions**
- `src/actions/index.ts`:
  - New `video.requestApprovals({ id, userIds[] })`. Restricted to uploader or space owner. Validates space membership, drops the actor and uploader, skips users who already have a pending request, and inserts the rows + dispatches notifications.
  - `video.approve` now resolves the approver's pending `approval_requests` so the "Pending for me" bucket clears (audit-friendly: rows are kept, status flips to `resolved`).
  - Removed the generic fan-out from `video.setPhase` when entering `reviewing_video`.

**Notifications + email**
- `src/lib/notifications.ts`:
  - New `createTargetedApprovalRequestNotifications` helper — per-user notification, real-time broadcast, and email send (gated on `emailNotificationsEnabled`).
  - New `getPendingApprovalRequestsForUser` and `resolveApprovalRequestsForApprover` helpers.
  - Removed the old fan-out helper.
- `src/lib/notification-copy.ts` — `approval.requested` copy is now per-user: `"<actor> requested your approval on \"<title>\""`.
- `src/lib/email.ts` — new `buildApprovalRequestEmail` (plain HTML, matches existing invite/comment email style).

**UI**
- `src/components/RequestApprovalDialog.tsx` — new modal that loads space members, supports text filtering, multi-select via checkboxes, excludes the actor and uploader, and submits via the new action.
- `src/components/ApprovalSection.tsx` — adds a **Request approval…** button visible only to the uploader or space owner; mounts the dialog and shows a toast on success.
- `src/components/NotificationCenter.tsx` — new **Pending approval requests** section above the comment activity list, with a deep link to the video review tab.
- `src/pages/notifications.astro` — fetches pending approval requests server-side and passes them through.
- `src/lib/spaces.ts` — adds a reusable `getSpaceMembers` helper (groundwork; the dialog still hits `/api/spaces/[id]/members` to keep the change scoped).

## Decisions worth flagging

- **Persistence model:** new dedicated `approval_requests` table, not a flag on `notifications`. Keeps audit + "pending for me" queries clean and leaves room for external reviewers.
- **Generic fan-out:** removed entirely. Reviewers now opt-in via explicit requests; this matches the goal of the issue.
- **Resolve-on-approve:** `status = "resolved"` (not deleted) so the row remains for audit + future reporting.
- **External reviewers:** out of scope for this PR; tracked separately. (See the open follow-up issue mentioned in #93.)

## Testing
See the local test plan in the PR comment / chat.

Closes #93