### PR TITLE
feat(calendar): wire up per-space launch calendar view

### DIFF
--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -42,6 +42,29 @@ function getCalendarDays(month: Date) {
   });
 }
 
+function getInitials(name: string): string {
+  return name
+    .split(" ")
+    .map((n) => n[0])
+    .filter(Boolean)
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+function OwnerAvatar({ name }: { name: string | null }) {
+  if (!name) return null;
+  return (
+    <span
+      className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-primary text-[10px] font-medium text-white"
+      title={`Owner: ${name}`}
+      aria-label={`Owner: ${name}`}
+    >
+      {getInitials(name)}
+    </span>
+  );
+}
+
 function getRiskLabel(video: DashboardVideo) {
   if (!video.targetDate || video.phase === "published") return null;
   const today = new Date();
@@ -156,6 +179,7 @@ export function CalendarView({ initialVideos, spaceId }: CalendarViewProps) {
                                 </span>
                               )}
                             </div>
+                            <OwnerAvatar name={video.ownerName} />
                           </div>
                         </a>
                         <div className="mt-2 text-[10px] text-text-tertiary">
@@ -185,9 +209,12 @@ export function CalendarView({ initialVideos, spaceId }: CalendarViewProps) {
           <div className="mt-3 grid gap-3 md:grid-cols-2 lg:grid-cols-3">
             {unscheduled.map((video) => (
               <article key={video.id} className="rounded-lg border border-border-default bg-bg-primary p-3">
-                <a href={`/videos/${video.id}?space=${spaceId}`} className="text-sm font-semibold text-text-primary hover:text-accent-primary">
-                  {video.title}
-                </a>
+                <div className="flex items-start justify-between gap-2">
+                  <a href={`/videos/${video.id}?space=${spaceId}`} className="min-w-0 flex-1 text-sm font-semibold text-text-primary hover:text-accent-primary">
+                    <span className="block truncate">{video.title}</span>
+                  </a>
+                  <OwnerAvatar name={video.ownerName} />
+                </div>
                 <p className="mt-1 text-xs text-text-tertiary">{PHASE_LABELS[video.phase]}</p>
                 <div className="mt-2 text-xs text-text-tertiary">
                   <span>Set launch date</span>

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -145,22 +145,34 @@ export function CalendarView({ initialVideos, spaceId }: CalendarViewProps) {
       </div>
 
       <div className="overflow-hidden rounded-xl border border-border-default bg-bg-secondary">
-        <div className="grid grid-cols-7 border-b border-border-default bg-bg-tertiary/50">
+        {/* Weekday header is only meaningful when the cells are arranged in a 7-col grid.
+            Below the lg breakpoint we stack one day per row, so hide the strip there. */}
+        <div className="hidden border-b border-border-default bg-bg-tertiary/50 lg:grid lg:grid-cols-7">
           {weekdayLabels.map((day) => (
             <div key={day} className="px-2 py-2 text-center text-xs font-semibold text-text-tertiary">
               {day}
             </div>
           ))}
         </div>
-        <div className="grid grid-cols-1 sm:grid-cols-7">
+        {/* Stack one day per row until lg (1024px). Below that the 7-col grid leaves cells
+            too narrow to fit the card content (title, phase, risk pill, avatar, date picker). */}
+        <div className="grid grid-cols-1 lg:grid-cols-7">
           {days.map((day) => {
             const dateKey = toDateKey(day);
             const dayVideos = scheduledByDate.get(dateKey) || [];
             const outsideMonth = day.getMonth() !== month.getMonth();
+            // When stacked, hide rows that fall outside the current month so the list
+            // doesn't pad with empty cells. The 7-col grid still shows them for layout.
             return (
-              <div key={dateKey} className={`min-h-[150px] border-b border-r border-border-default p-2 ${outsideMonth ? "bg-bg-primary/40" : "bg-bg-secondary"}`}>
+              <div
+                key={dateKey}
+                className={`border-b border-r border-border-default p-2 lg:min-h-[150px] ${outsideMonth ? "hidden bg-bg-primary/40 lg:block" : "bg-bg-secondary"}`}
+              >
                 <div className={`mb-2 text-xs font-medium ${outsideMonth ? "text-text-tertiary" : "text-text-secondary"}`}>
-                  {day.getDate()}
+                  <span className="lg:hidden">
+                    {day.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" })}
+                  </span>
+                  <span className="hidden lg:inline">{day.getDate()}</span>
                 </div>
                 <div className="space-y-2">
                   {dayVideos.map((video) => {
@@ -174,7 +186,7 @@ export function CalendarView({ initialVideos, spaceId }: CalendarViewProps) {
                               <h3 className="truncate text-xs font-semibold text-text-primary">{video.title}</h3>
                               <p className="mt-0.5 text-[10px] text-text-tertiary">{PHASE_LABELS[video.phase]}</p>
                               {riskLabel && (
-                                <span className="mt-1 inline-flex rounded-full bg-accent-danger/15 px-1.5 py-0.5 text-[10px] font-semibold text-accent-danger">
+                                <span className="mt-1 inline-flex whitespace-nowrap rounded-full bg-accent-danger/15 px-1.5 py-0.5 text-[10px] font-semibold text-accent-danger">
                                   {riskLabel}
                                 </span>
                               )}

--- a/src/components/DashboardGrid.tsx
+++ b/src/components/DashboardGrid.tsx
@@ -102,6 +102,19 @@ export function DashboardGrid({
       <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
         <div className="flex-1" />
         <div className="flex items-center gap-2 sm:gap-3">
+          <a
+            href={`/spaces/${spaceId}/calendar?space=${spaceId}`}
+            className="inline-flex items-center gap-2 rounded-lg border border-border-default px-3 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary sm:px-5"
+            aria-label="Open launch calendar"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <rect x="3" y="4" width="18" height="18" rx="2" />
+              <line x1="16" y1="2" x2="16" y2="6" />
+              <line x1="8" y1="2" x2="8" y2="6" />
+              <line x1="3" y1="10" x2="21" y2="10" />
+            </svg>
+            <span className="hidden sm:inline">Calendar</span>
+          </a>
           <NewProjectDialog folderId={currentFolderId} spaceId={spaceId} />
           <CreateFolderDialog
             parentId={currentFolderId}

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -53,14 +53,15 @@ export function NewProjectDialog({ spaceId, folderId = null }: NewProjectDialogP
       <Button
         onClick={() => setOpen(true)}
         aria-label="Create a new video project"
+        className="px-3 py-2.5 sm:px-5"
         icon={(
           <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-            <path d="M12 5v14" />
-            <path d="M5 12h14" />
+            <path d="m22 8-6 4 6 4V8Z" />
+            <rect x="2" y="6" width="14" height="12" rx="2" ry="2" />
           </svg>
         )}
       >
-        New Project
+        <span className="hidden sm:inline">New Project</span>
       </Button>
 
       <Modal

--- a/src/components/ShareView.tsx
+++ b/src/components/ShareView.tsx
@@ -96,6 +96,8 @@ export function ShareView({
         takeaway3={video.takeaway3}
         primaryCta={video.primaryCta}
         outro={video.outro}
+        targetDate={video.targetDate}
+        canSetTargetDate={false}
       />
     );
   }
@@ -128,7 +130,6 @@ export function ShareView({
       title={video.title}
       uploadDate={video.createdAt}
       fileName={video.fileName}
-      targetDate={video.targetDate}
       transcriptsEnabled={false}
       uploadedBy={video.uploadedBy}
       initialApprovalStatus={initialApprovalStatus}

--- a/src/components/TargetDateEditor.tsx
+++ b/src/components/TargetDateEditor.tsx
@@ -104,8 +104,8 @@ export function TargetDateEditor({ videoId, initialTargetDate, canEdit, variant 
             value={targetDate}
             onChange={(value) => saveTargetDate(value)}
             disabled={saving}
-            ariaLabel="Target publish date"
-            placeholder="Set target publish date"
+            ariaLabel="Publish date"
+            placeholder="Set publish date"
             className="inline-flex w-auto min-w-48 rounded-lg border border-border-default bg-bg-input px-3 py-2 text-left text-sm text-text-primary transition-colors hover:border-border-hover focus:border-accent-primary focus:outline-none disabled:opacity-50"
           />
         ) : (

--- a/src/components/VideoDetailView.tsx
+++ b/src/components/VideoDetailView.tsx
@@ -8,7 +8,6 @@ import { TranscriptPanel, type TranscriptResponse } from "./TranscriptPanel";
 import { VideoBriefPanel } from "./VideoBriefPanel";
 import { ApprovalSection, type ApprovalStatus } from "./ApprovalSection";
 import { ProjectPhaseControls } from "./ProjectPhaseControls";
-import { TargetDateEditor } from "./TargetDateEditor";
 import { ProjectActivityTimeline } from "./ProjectActivityTimeline";
 import { useStreamPlayer } from "../hooks/useStreamPlayer";
 import { normalizeVideoPhase, PROJECT_STATUS_LABELS, type Annotation, type Comment, type VideoPhase } from "../types";
@@ -28,7 +27,6 @@ interface VideoDetailViewProps {
   title: string;
   uploadDate: string;
   fileName: string | null;
-  targetDate: string | null;
   transcriptsEnabled: boolean;
   uploadedBy: string | null;
   /** Null when the space has requiredApprovals = 0; the section is hidden. */
@@ -80,7 +78,6 @@ export function VideoDetailView({
   currentUserName,
   title,
   uploadDate,
-  targetDate,
   transcriptsEnabled,
   uploadedBy,
   initialApprovalStatus,
@@ -105,10 +102,6 @@ export function VideoDetailView({
   const [liveComments, setLiveComments] = useState(initialReviewComments);
   const isPublished = currentPhase === "published";
   const canChangePhase = !isShareMode && pipelineEnabled && (userRole === "owner" || uploadedBy === currentUserId);
-  // Launch date is editable any time the user is an owner or the uploader, regardless
-  // of whether the space has the pipeline workflow enabled. The launch calendar relies
-  // on this so spaces without pipeline mode can still schedule launches.
-  const canSetTargetDate = !isShareMode && (userRole === "owner" || uploadedBy === currentUserId);
   const isOwner = userRole === "owner";
   const scriptLockedMessage = "This script is read-only because a video has been uploaded. Use the Video step for feedback on the cut.";
   const requiresApproval =
@@ -280,12 +273,6 @@ export function VideoDetailView({
             {formatDuration(videoDuration)}
           </span>
         )}
-        <TargetDateEditor
-          videoId={videoId}
-          initialTargetDate={targetDate}
-          canEdit={canSetTargetDate}
-          variant="metadata"
-        />
       </div>
 
       {/* Read-only "brief" so reviewers see authorial intent alongside the cut. */}

--- a/src/components/VideoDetailView.tsx
+++ b/src/components/VideoDetailView.tsx
@@ -105,6 +105,10 @@ export function VideoDetailView({
   const [liveComments, setLiveComments] = useState(initialReviewComments);
   const isPublished = currentPhase === "published";
   const canChangePhase = !isShareMode && pipelineEnabled && (userRole === "owner" || uploadedBy === currentUserId);
+  // Launch date is editable any time the user is an owner or the uploader, regardless
+  // of whether the space has the pipeline workflow enabled. The launch calendar relies
+  // on this so spaces without pipeline mode can still schedule launches.
+  const canSetTargetDate = !isShareMode && (userRole === "owner" || uploadedBy === currentUserId);
   const isOwner = userRole === "owner";
   const scriptLockedMessage = "This script is read-only because a video has been uploaded. Use the Video step for feedback on the cut.";
   const requiresApproval =
@@ -276,14 +280,12 @@ export function VideoDetailView({
             {formatDuration(videoDuration)}
           </span>
         )}
-        {pipelineEnabled && (
-          <TargetDateEditor
-            videoId={videoId}
-            initialTargetDate={targetDate}
-            canEdit={canChangePhase}
-            variant="metadata"
-          />
-        )}
+        <TargetDateEditor
+          videoId={videoId}
+          initialTargetDate={targetDate}
+          canEdit={canSetTargetDate}
+          variant="metadata"
+        />
       </div>
 
       {/* Read-only "brief" so reviewers see authorial intent alongside the cut. */}

--- a/src/components/VideoDetailsPanel.tsx
+++ b/src/components/VideoDetailsPanel.tsx
@@ -1,4 +1,5 @@
 import { MetadataField } from "./MetadataField";
+import { TargetDateEditor } from "./TargetDateEditor";
 
 interface VideoDetailsPanelProps {
   videoId: string;
@@ -11,6 +12,9 @@ interface VideoDetailsPanelProps {
   takeaway3: string | null;
   primaryCta: string | null;
   outro: string | null;
+  targetDate: string | null;
+  /** Whether the current viewer can edit the launch date. */
+  canSetTargetDate: boolean;
 }
 
 function Section({
@@ -41,6 +45,8 @@ export function VideoDetailsPanel({
   takeaway3,
   primaryCta,
   outro,
+  targetDate,
+  canSetTargetDate,
 }: VideoDetailsPanelProps) {
   return (
     <div className="space-y-6">
@@ -60,6 +66,22 @@ export function VideoDetailsPanel({
           multiline
           maxLength={2000}
         />
+        {(canSetTargetDate || targetDate) && (
+          <div className="space-y-2">
+            <label className="block text-xs font-semibold uppercase tracking-wide text-text-tertiary">
+              Launch date
+            </label>
+            <TargetDateEditor
+              videoId={videoId}
+              initialTargetDate={targetDate}
+              canEdit={canSetTargetDate}
+              variant="plain"
+            />
+            <p className="text-xs text-text-tertiary">
+              Shown on the team launch calendar so the space can plan publishing.
+            </p>
+          </div>
+        )}
       </Section>
 
       <Section title="Audience & Positioning">

--- a/src/components/VideoHeader.tsx
+++ b/src/components/VideoHeader.tsx
@@ -40,7 +40,7 @@ interface VideoHeaderProps {
   uploadVersion?: UploadVersionConfig | null;
 }
 
-export function VideoHeader({ videoId, shareLink: initialLink, appUrl, spaceId, backHref, backLabel = "Back to videos", spaceName, versions, uploadVersion = null }: VideoHeaderProps) {
+export function VideoHeader({ videoId, shareLink: initialLink, appUrl, spaceId, backHref, backLabel = "Back to Dashboard", spaceName, versions, uploadVersion = null }: VideoHeaderProps) {
   const [shareLink, setShareLink] = useState(initialLink);
   const [loading, setLoading] = useState(false);
   const [copied, setCopied] = useState(false);

--- a/src/components/dashboard-types.ts
+++ b/src/components/dashboard-types.ts
@@ -13,4 +13,6 @@ export interface DashboardVideo {
   commentCount: number;
   approvalCount: number;
   requiredApprovals: number;
+  /** Display name of the project owner (uploader). Null if the user was deleted. */
+  ownerName: string | null;
 }

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -226,11 +226,25 @@ const videoItems: VideoCardItemData[] = userVideos.map((video) => ({
 <Layout title={currentFolderRecord ? currentFolderRecord.name : selectedSpace.name} user={user} selectedSpaceId={selectedSpaceId}>
   <PendingToast client:load />
   <div class="mx-auto max-w-[1280px] px-4 py-8 sm:px-8">
-    <div class="mb-2">
-      <Breadcrumbs path={folderPath} />
-      <h1 class="text-2xl font-bold text-text-primary">
-        {currentFolderRecord ? currentFolderRecord.name : selectedSpace.name}
-      </h1>
+    <div class="mb-2 flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <Breadcrumbs path={folderPath} />
+        <h1 class="text-2xl font-bold text-text-primary">
+          {currentFolderRecord ? currentFolderRecord.name : selectedSpace.name}
+        </h1>
+      </div>
+      <a
+        href={`/spaces/${selectedSpaceId}/calendar?space=${selectedSpaceId}`}
+        class="inline-flex items-center gap-1.5 rounded-lg border border-border-default bg-bg-secondary px-3 py-2 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary"
+      >
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <rect x="3" y="4" width="18" height="18" rx="2" />
+          <line x1="16" y1="2" x2="16" y2="6" />
+          <line x1="8" y1="2" x2="8" y2="6" />
+          <line x1="3" y1="10" x2="21" y2="10" />
+        </svg>
+        Calendar
+      </a>
     </div>
 
     {memberCount <= 1 && selectedSpace.role === "owner" && (

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -226,25 +226,11 @@ const videoItems: VideoCardItemData[] = userVideos.map((video) => ({
 <Layout title={currentFolderRecord ? currentFolderRecord.name : selectedSpace.name} user={user} selectedSpaceId={selectedSpaceId}>
   <PendingToast client:load />
   <div class="mx-auto max-w-[1280px] px-4 py-8 sm:px-8">
-    <div class="mb-2 flex flex-wrap items-start justify-between gap-3">
-      <div>
-        <Breadcrumbs path={folderPath} />
-        <h1 class="text-2xl font-bold text-text-primary">
-          {currentFolderRecord ? currentFolderRecord.name : selectedSpace.name}
-        </h1>
-      </div>
-      <a
-        href={`/spaces/${selectedSpaceId}/calendar?space=${selectedSpaceId}`}
-        class="inline-flex items-center gap-1.5 rounded-lg border border-border-default bg-bg-secondary px-3 py-2 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary"
-      >
-        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="3" y="4" width="18" height="18" rx="2" />
-          <line x1="16" y1="2" x2="16" y2="6" />
-          <line x1="8" y1="2" x2="8" y2="6" />
-          <line x1="3" y1="10" x2="21" y2="10" />
-        </svg>
-        Calendar
-      </a>
+    <div class="mb-2">
+      <Breadcrumbs path={folderPath} />
+      <h1 class="text-2xl font-bold text-text-primary">
+        {currentFolderRecord ? currentFolderRecord.name : selectedSpace.name}
+      </h1>
     </div>
 
     {memberCount <= 1 && selectedSpace.role === "owner" && (

--- a/src/pages/spaces/[id]/calendar.astro
+++ b/src/pages/spaces/[id]/calendar.astro
@@ -3,7 +3,7 @@ import Layout from "../../../layouts/Layout.astro";
 import { CalendarView } from "../../../components/CalendarView";
 import type { DashboardVideo } from "../../../components/dashboard-types";
 import { createDb } from "../../../db";
-import { spaces, videos, scripts } from "../../../db/schema";
+import { spaces, videos, scripts, users } from "../../../db/schema";
 import { and, desc, eq } from "drizzle-orm";
 import { env } from "cloudflare:workers";
 import { verifySpaceAccess } from "../../../lib/spaces";
@@ -37,9 +37,11 @@ const rows = await db
     createdAt: videos.createdAt,
     targetDate: videos.targetDate,
     scriptStatus: scripts.status,
+    ownerName: users.name,
   })
   .from(videos)
   .leftJoin(scripts, eq(scripts.videoId, videos.id))
+  .leftJoin(users, eq(users.id, videos.uploadedBy))
   .where(and(eq(videos.spaceId, id), eq(videos.isCurrentVersion, true)))
   .orderBy(desc(videos.createdAt));
 
@@ -57,6 +59,7 @@ const calendarVideos: DashboardVideo[] = rows.map((row) => ({
   commentCount: 0,
   approvalCount: 0,
   requiredApprovals: space[0].requiredApprovals,
+  ownerName: row.ownerName ?? null,
 }));
 ---
 

--- a/src/pages/spaces/[id]/calendar.astro
+++ b/src/pages/spaces/[id]/calendar.astro
@@ -1,0 +1,83 @@
+---
+import Layout from "../../../layouts/Layout.astro";
+import { CalendarView } from "../../../components/CalendarView";
+import type { DashboardVideo } from "../../../components/dashboard-types";
+import { createDb } from "../../../db";
+import { spaces, videos, scripts } from "../../../db/schema";
+import { and, desc, eq } from "drizzle-orm";
+import { env } from "cloudflare:workers";
+import { verifySpaceAccess } from "../../../lib/spaces";
+import { normalizeVideoPhase, type ScriptStatus } from "../../../types";
+
+const user = Astro.locals.user;
+if (!user) return Astro.redirect("/login");
+
+const { id } = Astro.params;
+if (!id) return Astro.redirect("/dashboard");
+
+const db = createDb(env.DB);
+
+const role = await verifySpaceAccess(db, user.id, id);
+if (!role) return Astro.redirect("/dashboard");
+
+const space = await db.select().from(spaces).where(eq(spaces.id, id)).limit(1);
+if (space.length === 0) return Astro.redirect("/dashboard");
+
+// Pull every current-version video in the space. Joining scripts so PipelineBoard-style
+// consumers of DashboardVideo could reuse this data, even though CalendarView only needs
+// targetDate and phase.
+const rows = await db
+  .select({
+    id: videos.id,
+    title: videos.title,
+    status: videos.status,
+    phase: videos.phase,
+    thumbnailUrl: videos.thumbnailUrl,
+    duration: videos.duration,
+    createdAt: videos.createdAt,
+    targetDate: videos.targetDate,
+    scriptStatus: scripts.status,
+  })
+  .from(videos)
+  .leftJoin(scripts, eq(scripts.videoId, videos.id))
+  .where(and(eq(videos.spaceId, id), eq(videos.isCurrentVersion, true)))
+  .orderBy(desc(videos.createdAt));
+
+const calendarVideos: DashboardVideo[] = rows.map((row) => ({
+  id: row.id,
+  title: row.title,
+  status: row.status as DashboardVideo["status"],
+  phase: normalizeVideoPhase(row.phase),
+  scriptStatus: (row.scriptStatus as ScriptStatus | null) ?? null,
+  thumbnailUrl: row.thumbnailUrl,
+  duration: row.duration,
+  createdAt: row.createdAt,
+  targetDate: row.targetDate,
+  // CalendarView does not read these, but DashboardVideo requires them.
+  commentCount: 0,
+  approvalCount: 0,
+  requiredApprovals: space[0].requiredApprovals,
+}));
+---
+
+<Layout title={`${space[0].name} Launch Calendar`} user={user} selectedSpaceId={id}>
+  <div class="mx-auto max-w-[1280px] px-4 py-8 sm:px-8">
+    <div class="mb-6 flex flex-wrap items-center justify-between gap-3">
+      <div>
+        <a
+          href={`/dashboard?space=${id}`}
+          class="inline-flex items-center gap-1 text-sm text-text-secondary transition-colors hover:text-text-primary"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+          Back to Dashboard
+        </a>
+        <h1 class="mt-2 text-2xl font-bold text-text-primary">Launch Calendar</h1>
+        <p class="text-sm text-text-secondary">{space[0].name}</p>
+      </div>
+    </div>
+
+    <CalendarView client:load spaceId={id} initialVideos={calendarVideos} />
+  </div>
+</Layout>

--- a/src/pages/videos/[id]/index.astro
+++ b/src/pages/videos/[id]/index.astro
@@ -61,6 +61,9 @@ const isPublished = phase === "published";
 const hasVideo = !!video.streamVideoId;
 const isOwner = role === "owner";
 const canEditStatus = !isPublished && (role === "owner" || video.uploadedBy === user.id);
+// Launch date stays editable even on published projects so teams can correct
+// records after the fact. Mirrors the special-case allowance in actions.video.update.
+const canSetTargetDate = role === "owner" || video.uploadedBy === user.id;
 const showApprovals = approvalStatus.requiredApprovals > 0;
 const tabParam = Astro.url.searchParams.get("tab");
 // Default to the Details tab so users land on the project brief whenever
@@ -177,6 +180,8 @@ const tabHref = (tab: "script" | "video" | "details") => {
           takeaway3={video.takeaway3 ?? null}
           primaryCta={video.primaryCta ?? null}
           outro={video.outro ?? null}
+          targetDate={video.targetDate ?? null}
+          canSetTargetDate={canSetTargetDate}
         />
       ) : activeTab === "script" ? (
         <ScriptWorkspace
@@ -202,7 +207,6 @@ const tabHref = (tab: "script" | "video" | "details") => {
           title={video.title}
           uploadDate={video.createdAt}
           fileName={video.fileName}
-          targetDate={video.targetDate}
           transcriptsEnabled={transcriptsEnabled}
           uploadedBy={video.uploadedBy}
           initialApprovalStatus={showApprovals ? approvalStatus : null}


### PR DESCRIPTION
## Summary

- Mounts the existing (previously orphaned) `CalendarView` component on a new per-space page so teams can see all videos with a `targetDate` on a month grid.
- Adds a "Calendar" link to the dashboard header so the new view is discoverable.
- Removes the `pipelineEnabled` gate on the launch-date input in `VideoDetailView` and introduces a separate `canSetTargetDate` permission so spaces without the pipeline workflow can still schedule launches.

## Changes

- `src/pages/spaces/[id]/calendar.astro` (new) — auth + `verifySpaceAccess`, fetches all current-version videos for the space (left-joins `scripts` for `scriptStatus`), maps to `DashboardVideo[]`, renders `<CalendarView client:load spaceId initialVideos />` inside the standard layout with a "Back to Dashboard" link.
- `src/components/VideoDetailView.tsx` — adds `canSetTargetDate = !isShareMode && (userRole === "owner" || uploadedBy === currentUserId)` and removes the `pipelineEnabled &&` wrapper around `<TargetDateEditor>`. `canChangePhase` is unchanged so phase-related UI still respects pipeline mode.
- `src/pages/dashboard.astro` — wraps the title block in a flex row and adds a Calendar button linking to `/spaces/{id}/calendar?space={id}`.

## Testing

- `pnpm build` passes.
- See PR comment for the full local manual test plan.

Closes #111