### PR TITLE
fix(actions): delete Stream videos when deleting a space

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1767,6 +1767,34 @@ export const server = {
           });
         }
 
+        // Delete Stream videos before the DB cascade removes their rows.
+        // The DB cascade only knows about D1 — it cannot reach Cloudflare
+        // Stream, so without this loop every space deletion permanently
+        // leaks Stream assets. Errors are logged but don't block the
+        // space deletion: a stale Stream asset is recoverable, but a
+        // half-deleted space (rows gone, Stream still there, no way to
+        // reach it) is worse.
+        const spaceVideos = await db
+          .select({ streamVideoId: videos.streamVideoId })
+          .from(videos)
+          .where(eq(videos.spaceId, id));
+
+        for (const video of spaceVideos) {
+          if (!video.streamVideoId) continue;
+          try {
+            await deleteStreamVideo(
+              env.STREAM_ACCOUNT_ID,
+              env.STREAM_API_TOKEN,
+              video.streamVideoId,
+            );
+          } catch (err) {
+            console.error(
+              `Failed to delete Stream video ${video.streamVideoId} during space ${id} deletion:`,
+              err,
+            );
+          }
+        }
+
         // CASCADE will handle space_members, space_invites, folders, videos
         await db.delete(spaces).where(eq(spaces.id, id));
 

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1767,13 +1767,8 @@ export const server = {
           });
         }
 
-        // Delete Stream videos before the DB cascade removes their rows.
-        // The DB cascade only knows about D1 — it cannot reach Cloudflare
-        // Stream, so without this loop every space deletion permanently
-        // leaks Stream assets. Errors are logged but don't block the
-        // space deletion: a stale Stream asset is recoverable, but a
-        // half-deleted space (rows gone, Stream still there, no way to
-        // reach it) is worse.
+        // Delete Stream assets before the DB cascade removes the rows that
+        // reference them, otherwise the Stream videos are leaked permanently.
         const spaceVideos = await db
           .select({ streamVideoId: videos.streamVideoId })
           .from(videos)


### PR DESCRIPTION
## Summary
- Space deletion previously cascaded D1 rows but left Cloudflare Stream videos behind as orphaned, unreferenceable assets that kept accruing storage costs.
- Iterate the space's videos and call `deleteStreamVideo` for each before the DB cascade fires, matching the inline pattern already used by `videos.delete` (`src/actions/index.ts:290-308`).
- Errors are logged but do not block space deletion: a stale Stream asset is recoverable, a half-deleted space is not.

## Changes
- `src/actions/index.ts` (`spaces.delete`): query videos in the space, delete each from Stream with try/catch, then run the existing D1 cascade.

## Testing
See test plan in chat.

## Follow-up
A separate issue tracks moving both `videos.delete` and `spaces.delete` to a formal Cloudflare Workflow with retryable steps for more robust cleanup.

Closes #30