### PR TITLE
docs(agents): remove requirement to confirm before pushing/opening PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,4 +42,3 @@ If a worktree was created without step 3, symptoms include:
 - Conventional commit messages (e.g. `feat(actions): ...`, `fix(...)`,
   `chore(...)`, `docs(...)`).
 - Reference issues with `Closes #<n>` in the PR body when applicable.
-- Don't push to remote or open PRs without confirmation from the user.


### PR DESCRIPTION
## Summary

Removes the line in `AGENTS.md` that required agents to ask for confirmation before pushing to remote or opening pull requests. Push/PR behavior is now governed by the agent's own safety rules and per-task approval rather than a blanket repo-level rule.