### PR TITLE
fix(webhooks): parse Cloudflare Stream signature header correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 *.log
 worker-configuration.d.ts
 .worktrees/
+tmp/

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,7 +5,9 @@ import react from "@astrojs/react";
 import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
-  adapter: cloudflare(),
+  adapter: cloudflare({
+    remoteBindings: false,
+  }),
   integrations: [react()],
   vite: {
     plugins: [tailwindcss()],

--- a/src/pages/api/webhooks/stream.ts
+++ b/src/pages/api/webhooks/stream.ts
@@ -21,66 +21,105 @@ interface StreamWebhookPayload {
   };
 }
 
+type SignatureFailureReason =
+  | "missing_header"
+  | "missing_secret"
+  | "unparseable_header"
+  | "signature_mismatch";
+
+interface SignatureVerificationResult {
+  valid: boolean;
+  reason?: SignatureFailureReason;
+  parsed: {
+    hasTime: boolean;
+    hasSig1: boolean;
+  };
+}
+
 async function verifyWebhookSignature(
   body: string,
   signature: string | null,
-  secret: string,
-): Promise<boolean> {
-  if (!signature || !secret) return false;
+  secret: string | undefined,
+): Promise<SignatureVerificationResult> {
+  const empty = { hasTime: false, hasSig1: false };
 
-  try {
-    // Cloudflare Stream webhook signatures use a time-based HMAC
-    // For simplicity in MVP, we'll verify the secret matches
-    // In production, implement full signature verification
-    const encoder = new TextEncoder();
-    const key = await crypto.subtle.importKey(
-      "raw",
-      encoder.encode(secret),
-      { name: "HMAC", hash: "SHA-256" },
-      false,
-      ["sign", "verify"],
-    );
-
-    const parts = signature.split(",");
-    const timestampPart = parts.find((p) => p.startsWith("t="));
-    const sigPart = parts.find((p) => p.startsWith("v1="));
-
-    if (!timestampPart || !sigPart) return false;
-
-    const timestamp = timestampPart.slice(2);
-    const expectedSig = sigPart.slice(3);
-
-    const signedPayload = `${timestamp}.${body}`;
-    const mac = await crypto.subtle.sign(
-      "HMAC",
-      key,
-      encoder.encode(signedPayload),
-    );
-
-    const computedSig = [...new Uint8Array(mac)]
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
-
-    return computedSig === expectedSig;
-  } catch {
-    return false;
+  if (!signature) {
+    return { valid: false, reason: "missing_header", parsed: empty };
   }
+  if (!secret) {
+    return { valid: false, reason: "missing_secret", parsed: empty };
+  }
+
+  const parts = Object.fromEntries(
+    signature.split(",").map((part) => {
+      const [key, value] = part.split("=");
+      return [key, value];
+    }),
+  );
+
+  const time = parts["time"];
+  const receivedSig = parts["sig1"];
+  const parsed = { hasTime: !!time, hasSig1: !!receivedSig };
+
+  if (!time || !receivedSig) {
+    return { valid: false, reason: "unparseable_header", parsed };
+  }
+
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+
+  const mac = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(`${time}.${body}`),
+  );
+
+  const expectedSig = [...new Uint8Array(mac)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  const expectedBytes = encoder.encode(expectedSig);
+  const receivedBytes = encoder.encode(receivedSig);
+
+  // Compare against self when lengths differ to avoid leaking expected length
+  // via early-return timing; per Cloudflare's reference verifier.
+  const lengthsMatch = expectedBytes.byteLength === receivedBytes.byteLength;
+  const signaturesMatch = lengthsMatch
+    ? crypto.subtle.timingSafeEqual(expectedBytes, receivedBytes)
+    : !crypto.subtle.timingSafeEqual(expectedBytes, expectedBytes);
+
+  if (!signaturesMatch) {
+    return { valid: false, reason: "signature_mismatch", parsed };
+  }
+
+  return { valid: true, parsed };
 }
 
 export const POST: APIRoute = async ({ request }) => {
   const body = await request.text();
-  const signature = request.headers.get("webhook-signature");
+  const signature = request.headers.get("Webhook-Signature");
 
-  // Verify webhook signature if secret is configured
   if (env.STREAM_WEBHOOK_SECRET) {
-    const valid = await verifyWebhookSignature(
+    const result = await verifyWebhookSignature(
       body,
       signature,
       env.STREAM_WEBHOOK_SECRET,
     );
-    if (!valid) {
-      console.error("Invalid webhook signature");
-      return new Response("Invalid signature", { status: 401 });
+    if (!result.valid) {
+      console.error("Invalid webhook signature", {
+        hasHeader: signature !== null,
+        hasSecret: !!env.STREAM_WEBHOOK_SECRET,
+        parsed: result.parsed,
+        bodyLength: body.length,
+        reason: result.reason,
+      });
+      return new Response("Invalid signature", { status: 403 });
     }
   }
 
@@ -93,7 +132,6 @@ export const POST: APIRoute = async ({ request }) => {
 
   const db = createDb(env.DB);
 
-  // Find video by Stream video ID
   const videoRecords = await db
     .select()
     .from(videos)


### PR DESCRIPTION
## Summary

Stream webhooks were failing signature verification in production with `Invalid webhook signature` for every event. Root cause: the verifier in `src/pages/api/webhooks/stream.ts` was looking for Stripe-format prefixes (`t=` / `v1=`) instead of Stream's actual format (`time=` / `sig1=`). Parsing returned false before any HMAC computation ran, so no secret value (correct or otherwise) could ever validate.

## What changed

- **Parser fix.** Port the official Cloudflare reference verifier from the [Stream test webhooks docs](https://developers.cloudflare.com/stream/examples/test-webhooks-locally/). Uses `Object.fromEntries` to parse `time=` / `sig1=` and accepts whatever order/extra fields Stream may send.
- **Timing-safe comparison.** Replace string `===` with `crypto.subtle.timingSafeEqual`, including the compare-against-self pattern when lengths differ so the function doesn't leak expected signature length via early-return timing.
- **Drop the swallowing try/catch.** The previous `try { ... } catch { return false }` masked WebCrypto-level failures as ordinary signature mismatches; now they propagate and surface in Workers Logs.
- **Structured failure log.** Replace bare `console.error("Invalid webhook signature")` with a structured object: `{ hasHeader, hasSecret, parsed: { hasTime, hasSig1 }, bodyLength, reason }`. No secret values, no body content. This would have diagnosed the original bug from logs alone — `parsed.hasTime: false` + `parsed.hasSig1: false` + `hasHeader: true` points straight at parser failure.
- **403 on signature failure** (was 401). Matches Cloudflare's reference implementation.
- **Canonical `Webhook-Signature` header casing.** Functionally equivalent (case-insensitive lookup) but matches docs verbatim.

## Verification

Off-line test script (`tmp/verify-stream-sig.mjs`, gitignored per `AGENTS.md`) covering 8 cases / 19 assertions:

- Valid signature passes.
- Tampered signature byte fails with `signature_mismatch`.
- Wrong secret fails with `signature_mismatch`.
- Missing header / missing secret return their respective `reason` codes.
- **Stripe-format header (the original production bug) reproduces and now fails with `unparseable_header`** — confirms regression coverage.
- Tampered body fails.
- Hand-built deterministic fixture (matches Cloudflare docs example timestamp) passes.

`pnpm build` succeeds with no type errors.

## Notes for review

- This change should be deployed before any further attempts at secret rotation. Until this lands, every Stream webhook fails regardless of secret value, and the polling fallback in `src/pages/api/videos/[id]/status.ts` is masking the issue (uploads transition to `ready` only when the user keeps the page open long enough for a poll, which is why the bug appeared "intermittent" across users).
- Replay-protection (rejecting old `time` claims) is recommended in Cloudflare's docs but intentionally out of scope for this PR. Worth a follow-up issue.
- A checked-in vitest unit test would prevent regression. Currently only the throwaway `tmp/` script exercises the verifier. Worth a follow-up issue.