### PR TITLE
docs(skills): document error-handling standards

### DIFF
--- a/.opencode/skills/astro-best-practices/SKILL.md
+++ b/.opencode/skills/astro-best-practices/SKILL.md
@@ -242,15 +242,6 @@ try {
 }
 ```
 
-Reads (`db.select`) typically don't need wrapping — they fail rarely and
-the failure mode is "page won't render", which the SSR layer handles.
-Wrap reads only when a user-triggered fetch hangs on a single query
-where you want a tailored message.
-
-The existing `try/catch` around `createDirectUpload(...)` in
-`actions.video.uploadFirstCut` and `actions.video.uploadVersion` is the
-canonical example to mirror.
-
 ### Rule 2 — Validate before you persist
 
 Catch the bad-input class of error before it ever reaches D1. This

--- a/.opencode/skills/astro-best-practices/SKILL.md
+++ b/.opencode/skills/astro-best-practices/SKILL.md
@@ -199,3 +199,120 @@ The project uses `crypto.randomUUID()` throughout. Do not use `nanoid` or
 | New DB table / column | `src/db/schema.ts` + new migration |
 | Design token | `src/styles/tailwind.css` |
 | Async background job | `src/workflows/` (Cloudflare Workflow) |
+
+---
+
+## 13. Error handling and user-facing messages
+
+User-facing error messages must never include raw server errors (SQL
+statements, stack traces, driver messages, table or column names). The
+goal is that a stranger could read the message without losing trust in
+the app and without learning anything about the internals.
+
+Three rules apply across actions, API routes, and React components.
+
+### Rule 1 — Wrap server-side DB writes and external calls
+
+In Astro actions (`src/actions/index.ts`) and API route handlers
+(`src/pages/api/**/*.ts`), wrap every `db.insert` / `db.update` /
+`db.delete` and every external `fetch` (Stream, mail, AI, etc.) in a
+`try/catch`. On failure:
+
+- `console.error` with a prefix that identifies the handler, e.g.
+  `console.error("[uploadVersion] insert failed:", error)`.
+- Throw a clean `ActionError` (in actions) or return
+  `Response.json({ error: "<friendly message>" }, { status: 500 })`
+  (in API routes).
+- The friendly message must:
+  - Be short — one sentence, ≤ ~120 characters.
+  - Be safe for any user to read.
+  - Suggest a next step when possible ("Please try again",
+    "Refresh the page").
+  - Never include SQL, table names, column names, or stack traces.
+
+```ts
+try {
+  await db.insert(videos).values({ ... });
+} catch (error) {
+  console.error("[uploadVersion] insert failed:", error);
+  throw new ActionError({
+    code: "INTERNAL_SERVER_ERROR",
+    message: "We couldn't save the new version. Please try again.",
+  });
+}
+```
+
+Reads (`db.select`) typically don't need wrapping — they fail rarely and
+the failure mode is "page won't render", which the SSR layer handles.
+Wrap reads only when a user-triggered fetch hangs on a single query
+where you want a tailored message.
+
+The existing `try/catch` around `createDirectUpload(...)` in
+`actions.video.uploadFirstCut` and `actions.video.uploadVersion` is the
+canonical example to mirror.
+
+### Rule 2 — Validate before you persist
+
+Catch the bad-input class of error before it ever reaches D1. This
+removes most of the cases where Rule 1 would fire.
+
+- Use a Zod schema from `src/lib/validation.ts` for every request body.
+  Do not read raw fields off `request.json()`.
+- Verify foreign-key parents exist (e.g. `folder_id` → `folders.id`)
+  with an explicit `db.select` and a `NOT_FOUND` `ActionError` **before**
+  the `insert`. The folder-creation flow already does this; follow that
+  pattern.
+- Coerce empty strings to `null` for nullable text columns
+  (`description: description?.trim() || null`) so D1 doesn't reject
+  on FK or `NOT NULL` constraints when the client sends `""`.
+
+### Rule 3 — Never display raw server errors in the UI
+
+In React components, all `setError(...)` and
+`showToast(..., "error")` calls that consume server-returned messages
+must route through `friendlyActionErrorMessage(message, fallback)` from
+`src/lib/errors.ts`. The helper detects raw SQL / Drizzle / D1 patterns
+and substitutes the fallback.
+
+The fallback is required and should be specific to the action — avoid
+generic strings like "Something went wrong". Give the user something
+they can act on.
+
+```tsx
+import { friendlyActionErrorMessage } from "../lib/errors";
+
+const { data, error: actionError } = await actions.video.uploadVersion({ ... });
+if (actionError) {
+  setError(
+    friendlyActionErrorMessage(
+      actionError.message,
+      "We couldn't start the upload. Please try again.",
+    ),
+  );
+  return;
+}
+```
+
+Anti-pattern — passes the raw server message straight to the UI:
+
+```tsx
+setError(err instanceof Error ? err.message : "Upload failed");
+```
+
+Error containers should also include `break-words` (or equivalent) as a
+layout safety belt so any message that does slip through wraps cleanly
+instead of overflowing the modal.
+
+### Pre-merge checklist
+
+When adding or modifying an action, API route, or any UI that triggers
+a server mutation, confirm before requesting review:
+
+- [ ] Every `db.insert` / `db.update` / `db.delete` and every external
+      `fetch` is wrapped in `try/catch` with a friendly `ActionError` or
+      JSON `Response`.
+- [ ] Every `setError` / `showToast(..., "error")` consuming a server
+      message goes through `friendlyActionErrorMessage` with a
+      non-generic fallback.
+- [ ] No client-facing error string mentions SQL, table/column names,
+      stack traces, or driver-specific text.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,11 @@ If a worktree was created without step 3, symptoms include:
 - Conventional commit messages (e.g. `feat(actions): ...`, `fix(...)`,
   `chore(...)`, `docs(...)`).
 - Reference issues with `Closes #<n>` in the PR body when applicable.
+
+## Error handling
+
+User-facing error messages must never include raw server errors (SQL,
+stack traces, driver messages, table/column names). See section 13
+"Error handling and user-facing messages" in the `astro-best-practices`
+skill for the rules and the `friendlyActionErrorMessage` helper in
+`src/lib/errors.ts`.


### PR DESCRIPTION
## Summary

Codifies the three rules new code must follow so that raw server errors (SQL, stack traces, driver messages) never reach the user-facing UI again. Same pattern that fixed the upload modal in #117 (issue #23) — now generalized so every action, API route, and React component knows the shape.

## Changes

- `.opencode/skills/astro-best-practices/SKILL.md`: new section 13 **Error handling and user-facing messages**
  - Rule 1: wrap server-side DB writes and external `fetch` calls in `try/catch`; throw a clean `ActionError` (or return a JSON `Response`) with a short, user-safe message and `console.error` the raw error server-side
  - Rule 2: validate input with Zod and explicit FK existence checks before persisting; coerce empty strings to `null` for nullable text columns
  - Rule 3: route every client-side `setError` / `showToast` that consumes a server message through `friendlyActionErrorMessage` from `src/lib/errors.ts` with a non-generic fallback; add `break-words` to error containers as a layout safety belt
  - Pre-merge checklist for authors/reviewers
- `AGENTS.md`: 5-line **Error handling** section pointing at the skill so the rule is discoverable from the always-on instructions even if the skill isn't loaded

## Notes

- Lenient ruleset only — documents the standard and points at existing helpers (`friendlyActionErrorMessage`). Does not add new helpers or backfill existing code.
- Existing call sites that currently pass raw `err.message` to `setError` (~27 components) are tracked in a separate follow-up issue. This PR is doc/standards only.
- Build verified locally (`pnpm build`).