### PR TITLE
feat(versions): treat title/description as project-level

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
   adapter: cloudflare({
-    remoteBindings: false,
+    remoteBindings: true,
   }),
   integrations: [react()],
   vite: {

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -224,12 +224,18 @@ export const server = {
         }
 
         const now = new Date().toISOString();
+        const versionGroupId = video.versionGroupId || video.id;
 
         if (Object.keys(updates).length > 0) {
           await db
             .update(videos)
             .set({ ...updates, updatedAt: now })
-            .where(eq(videos.id, id));
+            .where(
+              and(
+                eq(videos.spaceId, video.spaceId),
+                eq(videos.versionGroupId, versionGroupId),
+              ),
+            );
 
           if (input.targetDate !== undefined && input.targetDate !== video.targetDate) {
             await logProjectActivity(db, {
@@ -244,7 +250,6 @@ export const server = {
         }
 
         if (folderUpdate !== undefined) {
-          const versionGroupId = video.versionGroupId || video.id;
           await db
             .update(videos)
             .set({ folderId: folderUpdate, updatedAt: now })
@@ -948,7 +953,7 @@ export const server = {
         .extend({ id: z.string().min(1) }),
       handler: async (input, context) => {
         const user = requireUser(context);
-        const { id, fileName, fileSize, title, description, generateTranscript, versionNotes } = input;
+        const { id, fileName, fileSize, generateTranscript, versionNotes } = input;
 
         validateUploadFile(fileName, fileSize);
 
@@ -1031,11 +1036,8 @@ export const server = {
           spaceId: baseVideo.spaceId,
           uploadedBy: user.id,
           folderId: baseVideo.folderId,
-          title: title?.trim() || baseVideo.title,
-          description:
-            description !== undefined
-              ? description.trim() || null
-              : baseVideo.description,
+          title: baseVideo.title,
+          description: baseVideo.description,
           status: "processing",
           versionGroupId,
           versionNumber: nextVersionNumber,

--- a/src/components/UploadVersionModal.tsx
+++ b/src/components/UploadVersionModal.tsx
@@ -10,8 +10,6 @@ type UploadState = "idle" | "selected" | "uploading" | "processing" | "error";
 
 interface UploadVersionModalProps {
   videoId: string;
-  title: string;
-  description: string;
   transcriptsEnabled?: boolean;
   // When `open` is provided, the parent controls open state and is
   // responsible for rendering its own trigger. The component's built-in
@@ -28,8 +26,6 @@ function formatFileSize(bytes: number): string {
 
 export function UploadVersionModal({
   videoId,
-  title: initialTitle,
-  description: initialDescription,
   transcriptsEnabled = false,
   open: controlledOpen,
   onOpenChange,
@@ -45,8 +41,6 @@ export function UploadVersionModal({
   };
   const [state, setState] = useState<UploadState>("idle");
   const [file, setFile] = useState<File | null>(null);
-  const [title, setTitle] = useState(initialTitle);
-  const [description, setDescription] = useState(initialDescription);
   const [versionNotes, setVersionNotes] = useState("");
   const [generateTranscript, setGenerateTranscript] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -56,8 +50,6 @@ export function UploadVersionModal({
   const reset = () => {
     setState("idle");
     setFile(null);
-    setTitle(initialTitle);
-    setDescription(initialDescription);
     setVersionNotes("");
     setGenerateTranscript(false);
     setProgress(0);
@@ -104,8 +96,6 @@ export function UploadVersionModal({
         id: videoId,
         fileName: file.name,
         fileSize: file.size,
-        title: title.trim() || undefined,
-        description: description.trim(),
         generateTranscript: transcriptsEnabled ? generateTranscript : false,
         versionNotes: versionNotes.trim() || undefined,
       });
@@ -228,28 +218,6 @@ export function UploadVersionModal({
           )}
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-text-secondary">Title</label>
-            <input
-              type="text"
-              value={title}
-              onChange={(event) => setTitle(event.target.value)}
-              disabled={state === "uploading"}
-              className="w-full rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary focus:border-accent-primary focus:outline-none disabled:opacity-50"
-            />
-          </div>
-
-          <div>
-            <label className="mb-1 block text-sm font-medium text-text-secondary">Description</label>
-            <textarea
-              value={description}
-              onChange={(event) => setDescription(event.target.value)}
-              disabled={state === "uploading"}
-              rows={3}
-              className="w-full resize-none rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary focus:border-accent-primary focus:outline-none disabled:opacity-50"
-            />
-          </div>
-
-          <div>
             <label className="mb-1 block text-sm font-medium text-text-secondary">What changed?</label>
             <textarea
               value={versionNotes}
@@ -307,7 +275,7 @@ export function UploadVersionModal({
             <button
               type="button"
               onClick={upload}
-              disabled={!file || !title.trim() || state === "uploading"}
+              disabled={!file || state === "uploading"}
               className="flex-1 rounded-lg bg-accent-primary px-4 py-2 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover disabled:opacity-50"
             >
               {state === "uploading" ? "Uploading..." : "Upload version"}

--- a/src/components/UploadView.tsx
+++ b/src/components/UploadView.tsx
@@ -9,8 +9,6 @@ type UploadState = "idle" | "selected" | "uploading" | "processing" | "error";
 
 interface UploadViewProps {
   videoId: string;
-  title: string;
-  description: string;
   isFirstCut: boolean;
   transcriptsEnabled: boolean;
 }
@@ -23,16 +21,12 @@ function formatFileSize(bytes: number): string {
 
 export function UploadView({
   videoId,
-  title: initialTitle,
-  description: initialDescription,
   isFirstCut,
   transcriptsEnabled,
 }: UploadViewProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [state, setState] = useState<UploadState>("idle");
   const [file, setFile] = useState<File | null>(null);
-  const [title, setTitle] = useState(initialTitle);
-  const [description, setDescription] = useState(initialDescription);
   const [versionNotes, setVersionNotes] = useState("");
   const [generateTranscript, setGenerateTranscript] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -79,8 +73,6 @@ export function UploadView({
             id: videoId,
             fileName: file.name,
             fileSize: file.size,
-            title: title.trim() || undefined,
-            description: description.trim(),
             generateTranscript: transcriptsEnabled ? generateTranscript : false,
             versionNotes: versionNotes.trim() || undefined,
           });
@@ -185,45 +177,21 @@ export function UploadView({
         )}
 
         {!isFirstCut && (
-          <>
-            <div>
-              <label className="mb-1 block text-sm font-medium text-text-secondary">Title</label>
-              <input
-                type="text"
-                value={title}
-                onChange={(event) => setTitle(event.target.value)}
-                disabled={state === "uploading"}
-                className="w-full rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary focus:border-accent-primary focus:outline-none disabled:opacity-50"
-              />
-            </div>
-
-            <div>
-              <label className="mb-1 block text-sm font-medium text-text-secondary">Description</label>
-              <textarea
-                value={description}
-                onChange={(event) => setDescription(event.target.value)}
-                disabled={state === "uploading"}
-                rows={3}
-                className="w-full resize-none rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary focus:border-accent-primary focus:outline-none disabled:opacity-50"
-              />
-            </div>
-
-            <div>
-              <label className="mb-1 block text-sm font-medium text-text-secondary">What changed?</label>
-              <textarea
-                value={versionNotes}
-                onChange={(event) => setVersionNotes(event.target.value)}
-                disabled={state === "uploading"}
-                rows={3}
-                maxLength={2000}
-                placeholder="Example: tightened intro, replaced b-roll at 0:42, fixed audio levels."
-                className="w-full resize-none rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary focus:border-accent-primary focus:outline-none disabled:opacity-50"
-              />
-              <p className="mt-1 text-xs text-text-tertiary">
-                Optional. Summarize what reviewers should look for in this cut.
-              </p>
-            </div>
-          </>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-text-secondary">What changed?</label>
+            <textarea
+              value={versionNotes}
+              onChange={(event) => setVersionNotes(event.target.value)}
+              disabled={state === "uploading"}
+              rows={3}
+              maxLength={2000}
+              placeholder="Example: tightened intro, replaced b-roll at 0:42, fixed audio levels."
+              className="w-full resize-none rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary focus:border-accent-primary focus:outline-none disabled:opacity-50"
+            />
+            <p className="mt-1 text-xs text-text-tertiary">
+              Optional. Summarize what reviewers should look for in this cut.
+            </p>
+          </div>
         )}
 
         {transcriptsEnabled && (
@@ -266,7 +234,7 @@ export function UploadView({
           <button
             type="button"
             onClick={upload}
-            disabled={!file || (!isFirstCut && !title.trim()) || state === "uploading"}
+            disabled={!file || state === "uploading"}
             className="rounded-lg bg-accent-primary px-5 py-2.5 text-sm font-medium text-white transition-all duration-150 hover:bg-accent-hover disabled:opacity-50"
           >
             {state === "uploading" ? "Uploading..." : isFirstCut ? "Upload Video" : "Upload Version"}

--- a/src/components/VersionSwitcher.tsx
+++ b/src/components/VersionSwitcher.tsx
@@ -2,27 +2,13 @@ import { useEffect, useRef, useState } from "react";
 
 interface VersionSummary {
   id: string;
-  title: string;
-  status: string;
-  thumbnailUrl: string | null;
   versionNumber: number;
   isCurrentVersion: boolean;
-  createdAt: string;
-  commentCount: number;
-  versionNotes: string | null;
 }
 
 interface VersionSwitcherProps {
   videoId: string;
   versions: VersionSummary[];
-}
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
 }
 
 export function VersionSwitcher({ videoId, versions }: VersionSwitcherProps) {
@@ -72,35 +58,14 @@ export function VersionSwitcher({ videoId, versions }: VersionSwitcherProps) {
               key={version.id}
               role="menuitem"
               href={`/videos/${version.id}?tab=video`}
-              className={`flex gap-3 rounded-lg p-2 transition-colors hover:bg-bg-tertiary ${version.id === videoId ? "bg-bg-tertiary" : ""}`}
+              className={`flex items-center gap-2 rounded-lg p-2 transition-colors hover:bg-bg-tertiary ${version.id === videoId ? "bg-bg-tertiary" : ""}`}
             >
-              <div className="flex h-12 w-20 shrink-0 items-center justify-center overflow-hidden rounded bg-bg-primary">
-                {version.thumbnailUrl ? (
-                  <img src={version.thumbnailUrl} alt="" className="h-full w-full object-cover" />
-                ) : (
-                  <span className="text-xs text-text-tertiary">V{version.versionNumber}</span>
-                )}
-              </div>
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-semibold text-text-primary">V{version.versionNumber}</span>
-                  {version.isCurrentVersion && (
-                    <span className="rounded-full bg-accent-secondary/15 px-2 py-0.5 text-[10px] font-medium text-accent-secondary">
-                      Current
-                    </span>
-                  )}
-                </div>
-                <p className="truncate text-xs text-text-secondary">{version.title}</p>
-                <p className="mt-0.5 text-xs text-text-tertiary">
-                  {formatDate(version.createdAt)} - {version.commentCount} comment{version.commentCount === 1 ? "" : "s"}
-                </p>
-                {version.versionNotes && (
-                  <p className="mt-1 line-clamp-2 text-xs text-text-secondary">
-                    <span className="font-medium text-text-tertiary">Changes:</span>{" "}
-                    {version.versionNotes}
-                  </p>
-                )}
-              </div>
+              <span className="text-sm font-semibold text-text-primary">V{version.versionNumber}</span>
+              {version.isCurrentVersion && (
+                <span className="rounded-full bg-accent-secondary/15 px-2 py-0.5 text-[10px] font-medium text-accent-secondary">
+                  Current
+                </span>
+              )}
             </a>
           ))}
         </div>

--- a/src/components/VideoHeader.tsx
+++ b/src/components/VideoHeader.tsx
@@ -13,19 +13,11 @@ interface ShareLink {
 
 interface VersionSummary {
   id: string;
-  title: string;
-  status: string;
-  thumbnailUrl: string | null;
   versionNumber: number;
   isCurrentVersion: boolean;
-  createdAt: string;
-  commentCount: number;
-  versionNotes: string | null;
 }
 
 interface UploadVersionConfig {
-  title: string;
-  description: string;
   transcriptsEnabled: boolean;
 }
 
@@ -219,8 +211,6 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl, spaceId, 
             </button>
             <UploadVersionModal
               videoId={videoId}
-              title={uploadVersion.title}
-              description={uploadVersion.description}
               transcriptsEnabled={uploadVersion.transcriptsEnabled}
               open={uploadVersionOpen}
               onOpenChange={setUploadVersionOpen}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -29,8 +29,6 @@ export const uploadSchema = z.object({
   fileName: z.string().min(1, "File name is required"),
   fileSize: z.number().positive().max(5 * 1024 * 1024 * 1024, "File exceeds 5GB limit"),
   spaceId: z.string().uuid().optional(),
-  title: z.string().optional(),
-  description: z.string().max(2000).optional(),
   folderId: z.string().uuid().nullable().optional(),
   generateTranscript: z.boolean().optional(),
   // Issue #23: optional per-version note explaining what changed since the

--- a/src/pages/videos/[id]/index.astro
+++ b/src/pages/videos/[id]/index.astro
@@ -91,8 +91,6 @@ const tabHref = (tab: "script" | "video" | "details") => {
       spaceName={videoSpace.name}
       versions={versions}
       uploadVersion={hasVideo && !isPublished && isOwner ? {
-        title: video.title,
-        description: video.description || "",
         transcriptsEnabled,
       } : null}
     />
@@ -230,8 +228,6 @@ const tabHref = (tab: "script" | "video" | "details") => {
         <UploadView
           client:load
           videoId={video.id}
-          title={video.title}
-          description={video.description || ""}
           isFirstCut={true}
           transcriptsEnabled={transcriptsEnabled}
         />

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "quickcut",
   "main": "./src/worker.ts",
+  "account_id": "4426cbeacb457b1ca1b865d6c36ced0d",
   "compatibility_date": "2026-04-21",
   "compatibility_flags": ["nodejs_compat"],
   "assets": {


### PR DESCRIPTION
## Summary

Two unrelated changes bundled together for convenience.

### 1. Treat title and description as project-level (primary change)

- New-version uploads (`UploadVersionModal` and `UploadView`) no longer collect title or description. The new version inherits both from the existing project, so they stay in sync across the dashboard, share view, and every version page.
- `video.update` now cascades project-level field writes (title, description, target date, audience, hook, takeaways, primary CTA, outro) across the entire version group, mirroring the existing folder cascade. Editing inline on the project page updates every version in lockstep.
- `VersionSwitcher` simplified to show `V{n}` plus the Current badge. Per-version title, date, comment count, and version-notes details were removed.
- `uploadSchema` (in `src/lib/validation.ts`) drops `title` and `description`. The `versionNotes` field added in #117 is preserved as the only optional per-upload annotation.

### 2. Restore real email delivery in local dev

- Set `remoteBindings: true` in `astro.config.mjs`, reverting the workaround from commit `3668101`. The original Cloudflare edge-preview 10023 error was a platform-side issue, now resolved upstream, so the global kill switch is no longer needed.
- Pin `account_id` in `wrangler.jsonc`. The remote proxy session needs a selected account to fetch the preview token, and `wrangler dev` / `astro build` run non-interactively where account picking would otherwise fail with "More than one account available". The id matches the existing `STREAM_ACCOUNT_ID`.

Net effect: `astro dev` proxies the `EMAIL` binding to real Send Email again, so OTP sign-in emails are delivered to the real inbox instead of being mocked to Miniflare temp files.

## Why

**(1)** Title and description are project identity. Asking for them again on every version added friction and produced a real inconsistency: edits on one version's row drifted away from the rest of the group, while folder moves cascaded correctly. This change makes the data behavior match the mental model the UI presents. A future refactor will extract a proper `projects` table so these fields stop being duplicated per row entirely. That work is tracked in #121.

**(2)** Local dev was silently mocking OTP emails to disk, breaking the real sign-in flow.

## Manual test plan

### Project-level title/description

1. Create a new project, upload v1, then upload v2.
   - Confirm the v2 upload modal does not show Title or Description fields.
   - Confirm only "What changed?" remains as an optional per-upload field.
2. Inline-edit the project title on the project page.
   - Open `/videos/<v1-id>` and `/videos/<v2-id>` directly. Both should reflect the new title.
   - Open the dashboard. The project title should be up to date.
   - Open an active share link. The title should match.
3. Edit the description, target date, audience, hook, takeaways, primary CTA, and outro inline.
   - Switch versions via the version switcher and confirm the values are identical across versions.
4. Open the version switcher.
   - Confirm each entry shows only `V1`, `V2`, etc., with the Current badge on the latest version. No date, comment count, or notes preview.

### Email in local dev

5. Run `pnpm dev`, sign out, then request a sign-in OTP.
   - Confirm a real email arrives at the address (no more Miniflare `email-text/<uuid>.txt` log lines).
6. Confirm `pnpm build` still passes cleanly.

Refs #121