### PR TITLE
feat(notifications): auto-mark read when viewing referenced content

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -30,6 +30,7 @@ import {
   projectCreateSchema,
   uploadSchema,
   scriptUpdateSchema,
+  notificationsMarkReadByContextSchema,
 } from "../lib/validation";
 import { verifySpaceAccess, getDefaultSpaceForUser } from "../lib/spaces";
 import { generateShareToken } from "../lib/share";
@@ -44,6 +45,7 @@ import {
   broadcastNewComment,
   broadcastCommentReactions,
   broadcastNotification,
+  broadcastNotificationsRead,
 } from "../lib/broadcast";
 import {
   isCommentReactionEmoji,
@@ -54,6 +56,7 @@ import {
   createTargetedApprovalRequestNotifications,
   resolveApprovalRequestsForApprover,
   markNotificationRead,
+  markNotificationsReadByVideoTab,
 } from "../lib/notifications";
 import { buildInviteAuthPath, buildInviteEmail } from "../lib/email";
 
@@ -2143,6 +2146,37 @@ export const server = {
         }
 
         return { success: true };
+      },
+    }),
+
+    markReadByContext: defineAction({
+      input: notificationsMarkReadByContextSchema,
+      handler: async ({ videoId, tab }, context) => {
+        const user = requireUser(context);
+        const db = createDb(env.DB);
+
+        const videoRow = await db
+          .select({ spaceId: videos.spaceId })
+          .from(videos)
+          .where(eq(videos.id, videoId))
+          .limit(1);
+
+        if (videoRow.length === 0) {
+          throw new ActionError({ code: "NOT_FOUND", message: "Video not found" });
+        }
+
+        const role = await verifySpaceAccess(db, user.id, videoRow[0].spaceId);
+        if (!role) {
+          throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
+        }
+
+        const ids = await markNotificationsReadByVideoTab(db, user.id, videoId, tab);
+
+        if (ids.length > 0) {
+          await broadcastNotificationsRead(env, user.id, ids);
+        }
+
+        return { ids, count: ids.length };
       },
     }),
   },

--- a/src/components/NotificationCenter.tsx
+++ b/src/components/NotificationCenter.tsx
@@ -1,5 +1,5 @@
 import { actions } from "astro:actions";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { PendingInviteForUser } from "../lib/invites";
 import type {
   PendingApprovalRequestForUser,
@@ -45,6 +45,29 @@ export function NotificationCenter({
   const [markingId, setMarkingId] = useState<string | null>(null);
   const [acceptedSpaces, setAcceptedSpaces] = useState<AcceptedSpace[]>([]);
   const { toasts, showToast, dismissToast } = useToast();
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+      const ids: string[] | undefined = Array.isArray(detail?.ids)
+        ? detail.ids
+        : undefined;
+      if (!ids || ids.length === 0) return;
+      const idSet = new Set(ids);
+      const readAt = new Date().toISOString();
+      setCommentNotifications((current) =>
+        current.map((notification) =>
+          idSet.has(notification.id) && !notification.readAt
+            ? { ...notification, readAt }
+            : notification,
+        ),
+      );
+    };
+    window.addEventListener("quickcut:notifications-read", handler);
+    return () => {
+      window.removeEventListener("quickcut:notifications-read", handler);
+    };
+  }, []);
 
   const markRead = async (notificationId: string) => {
     const wasUnread = commentNotifications.some(

--- a/src/components/ScriptWorkspace.tsx
+++ b/src/components/ScriptWorkspace.tsx
@@ -266,6 +266,30 @@ export function ScriptWorkspace({
     isReviewModeRef.current = isReviewMode;
   }, [isReviewMode]);
 
+  useEffect(() => {
+    if (isShareMode || !currentUserId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { data, error } = await actions.notification.markReadByContext({
+          videoId,
+          tab: "script",
+        });
+        if (cancelled || error || !data || data.count === 0) return;
+        window.dispatchEvent(
+          new CustomEvent("quickcut:notifications-read", {
+            detail: { ids: data.ids, count: data.count },
+          }),
+        );
+      } catch {
+        // Best-effort; the badge will reconcile on next page load.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [videoId, isShareMode, currentUserId]);
+
   const sortedComments = useMemo(
     () =>
       comments

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -87,12 +87,27 @@ export function UserMenu({ name, email, notificationCount = 0 }: UserMenuProps) 
   };
 
   useEffect(() => {
-    const handler = () => setCount((current) => Math.max(0, current - 1));
-    window.addEventListener("quickcut:invite-accepted", handler);
-    window.addEventListener("quickcut:notification-read", handler);
+    const decrementOne = () => setCount((current) => Math.max(0, current - 1));
+    const decrementMany = (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+      const amount =
+        typeof detail === "number"
+          ? detail
+          : detail && typeof detail === "object" && typeof detail.count === "number"
+            ? detail.count
+            : Array.isArray(detail?.ids)
+              ? detail.ids.length
+              : 0;
+      if (amount <= 0) return;
+      setCount((current) => Math.max(0, current - amount));
+    };
+    window.addEventListener("quickcut:invite-accepted", decrementOne);
+    window.addEventListener("quickcut:notification-read", decrementOne);
+    window.addEventListener("quickcut:notifications-read", decrementMany);
     return () => {
-      window.removeEventListener("quickcut:invite-accepted", handler);
-      window.removeEventListener("quickcut:notification-read", handler);
+      window.removeEventListener("quickcut:invite-accepted", decrementOne);
+      window.removeEventListener("quickcut:notification-read", decrementOne);
+      window.removeEventListener("quickcut:notifications-read", decrementMany);
     };
   }, []);
 
@@ -117,6 +132,13 @@ export function UserMenu({ name, email, notificationCount = 0 }: UserMenuProps) 
         window.dispatchEvent(
           new CustomEvent("quickcut:notification-received", {
             detail: notification,
+          }),
+        );
+      },
+      onNotificationsRead: (ids) => {
+        window.dispatchEvent(
+          new CustomEvent("quickcut:notifications-read", {
+            detail: { ids, count: ids.length },
           }),
         );
       },

--- a/src/components/VideoDetailView.tsx
+++ b/src/components/VideoDetailView.tsx
@@ -1,3 +1,4 @@
+import { actions } from "astro:actions";
 import { useState, useEffect, useRef, useCallback } from "react";
 import { CommentTimeline } from "./CommentTimeline";
 import { CommentThread } from "./CommentThread";
@@ -174,6 +175,30 @@ export function VideoDetailView({
     setPendingAnnotation(null);
     setActiveTool("none");
   }, []);
+
+  useEffect(() => {
+    if (isShareMode || !currentUserId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { data, error } = await actions.notification.markReadByContext({
+          videoId,
+          tab: "video",
+        });
+        if (cancelled || error || !data || data.count === 0) return;
+        window.dispatchEvent(
+          new CustomEvent("quickcut:notifications-read", {
+            detail: { ids: data.ids, count: data.count },
+          }),
+        );
+      } catch {
+        // Best-effort; the badge will reconcile on next page load.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [videoId, isShareMode, currentUserId]);
 
   // Poll for video status when processing
   useEffect(() => {

--- a/src/durable-objects/UserNotifications.ts
+++ b/src/durable-objects/UserNotifications.ts
@@ -19,10 +19,18 @@ export interface BroadcastUserNotification {
 	createdAt: string;
 }
 
-type ServerMessage = {
-	type: "notification.new";
-	notification: BroadcastUserNotification;
-};
+/**
+ * Broadcast envelope for "these notifications were just marked read"
+ * fan-out. Sent to every connected tab so the badge count and any
+ * /notifications view can update without refetching.
+ */
+export interface BroadcastNotificationsRead {
+	ids: string[];
+}
+
+type ServerMessage =
+	| { type: "notification.new"; notification: BroadcastUserNotification }
+	| { type: "notification.read.bulk"; ids: string[] };
 
 /**
  * UserNotifications coordinates real-time delivery of badge-count signals
@@ -71,8 +79,23 @@ export class UserNotifications extends DurableObject<Env> {
 		notification: BroadcastUserNotification,
 	): Promise<void> {
 		const message: ServerMessage = { type: "notification.new", notification };
-		const payload = JSON.stringify(message);
+		this.send(message);
+	}
 
+	/**
+	 * RPC method called after a bulk mark-read (e.g. user opened the tab
+	 * containing the referenced content). Fans out the affected
+	 * notification ids so other open tabs can decrement their badge and
+	 * update any /notifications view in place.
+	 */
+	async broadcastNotificationsRead(ids: string[]): Promise<void> {
+		if (ids.length === 0) return;
+		const message: ServerMessage = { type: "notification.read.bulk", ids };
+		this.send(message);
+	}
+
+	private send(message: ServerMessage): void {
+		const payload = JSON.stringify(message);
 		for (const ws of this.ctx.getWebSockets()) {
 			try {
 				ws.send(payload);

--- a/src/lib/broadcast.ts
+++ b/src/lib/broadcast.ts
@@ -91,3 +91,24 @@ export async function broadcastNotification(
 		console.error("UserNotifications broadcast failed", { userId, err });
 	}
 }
+
+/**
+ * Best-effort fan-out of "these notification ids just transitioned to
+ * read" to every tab the user has open. Used by the auto-mark-read flow
+ * when the user opens the tab containing the referenced content. Failures
+ * are swallowed — D1 already reflects the change, so the next page load
+ * recovers.
+ */
+export async function broadcastNotificationsRead(
+	env: Env,
+	userId: string,
+	ids: string[],
+): Promise<void> {
+	if (ids.length === 0) return;
+	try {
+		const stub = env.USER_NOTIFICATIONS.getByName(userId);
+		await stub.broadcastNotificationsRead(ids);
+	} catch (err) {
+		console.error("UserNotifications read broadcast failed", { userId, err });
+	}
+}

--- a/src/lib/notifications-realtime.ts
+++ b/src/lib/notifications-realtime.ts
@@ -2,13 +2,13 @@ import type { BroadcastUserNotification } from "../durable-objects/UserNotificat
 
 export type { BroadcastUserNotification } from "../durable-objects/UserNotifications";
 
-type ServerMessage = {
-	type: "notification.new";
-	notification: BroadcastUserNotification;
-};
+type ServerMessage =
+	| { type: "notification.new"; notification: BroadcastUserNotification }
+	| { type: "notification.read.bulk"; ids: string[] };
 
 export interface UserNotificationHandlers {
 	onNotification?: (notification: BroadcastUserNotification) => void;
+	onNotificationsRead?: (ids: string[]) => void;
 }
 
 export interface UserNotificationConnection {
@@ -60,6 +60,8 @@ export function connectUserNotifications(
 			}
 			if (parsed.type === "notification.new") {
 				handlers.onNotification?.(parsed.notification);
+			} else if (parsed.type === "notification.read.bulk") {
+				handlers.onNotificationsRead?.(parsed.ids);
 			}
 		});
 

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -452,3 +452,54 @@ export async function markNotificationRead(
 
   return true;
 }
+
+export type VideoNotificationTab = "video" | "script";
+
+const TAB_NOTIFICATION_TYPES: Record<VideoNotificationTab, NotificationType[]> = {
+  video: ["comment.created", "comment.reply", "approval.requested"],
+  script: ["script_comment.created", "script_comment.reply"],
+};
+
+/**
+ * Bulk mark all of a user's unread notifications for a given video+tab as
+ * read. Returns the ids of rows that were transitioned from unread to read,
+ * so callers can broadcast that subset to other open tabs/devices.
+ *
+ * Caller is responsible for checking access to the video (via
+ * `verifySpaceAccess` on the video's space) before invoking this helper.
+ */
+export async function markNotificationsReadByVideoTab(
+  db: Database,
+  userId: string,
+  videoId: string,
+  tab: VideoNotificationTab,
+): Promise<string[]> {
+  const types = TAB_NOTIFICATION_TYPES[tab];
+
+  const unreadRows = await db
+    .select({ id: notifications.id })
+    .from(notifications)
+    .where(
+      and(
+        eq(notifications.userId, userId),
+        eq(notifications.videoId, videoId),
+        inArray(notifications.type, types),
+        isNull(notifications.readAt),
+      ),
+    );
+
+  const ids = unreadRows.map((row) => row.id);
+  if (ids.length === 0) return [];
+
+  await db
+    .update(notifications)
+    .set({ readAt: new Date().toISOString() })
+    .where(
+      and(
+        eq(notifications.userId, userId),
+        inArray(notifications.id, ids),
+      ),
+    );
+
+  return ids;
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -156,3 +156,12 @@ export const inviteCreateSchema = z.object({
 export const approveVideoSchema = z.object({
   comment: z.string().max(500).optional(),
 });
+
+// ---------------------------------------------------------------------------
+// Notifications
+// ---------------------------------------------------------------------------
+
+export const notificationsMarkReadByContextSchema = z.object({
+  videoId: z.string().min(1),
+  tab: z.enum(["video", "script"]),
+});


### PR DESCRIPTION
## Summary
- Adds `actions.notification.markReadByContext`, a bulk server action that marks every unread notification for the current user matching a `videoId`+`tab` filter as read in a single `UPDATE`.
- Wires it into `ScriptWorkspace` (`tab=script`) and `VideoDetailView` (`tab=video`) on mount, so notifications transition to read on initial render and on tab switches without a full reload — not only when a row is clicked in `/notifications`.
- Broadcasts the change via the per-user `UserNotifications` Durable Object (`notification.read.bulk`) so badge counts update live across other open tabs/devices, and `/notifications` reflects the change without a hard refresh.

## Changes
- `src/lib/notifications.ts`: new `markNotificationsReadByVideoTab` helper. Returns the ids that transitioned, so callers can broadcast just that subset.
- `src/lib/validation.ts`: new `notificationsMarkReadByContextSchema` (`{ videoId, tab: "video" | "script" }`).
- `src/actions/index.ts`: new `notification.markReadByContext` action — verifies `verifySpaceAccess` against the video's space, runs the bulk update, fans out via the DO.
- `src/durable-objects/UserNotifications.ts`: discriminated `ServerMessage` union and a new `broadcastNotificationsRead(ids)` RPC.
- `src/lib/broadcast.ts`: `broadcastNotificationsRead` helper mirroring the existing `broadcastNotification`.
- `src/lib/notifications-realtime.ts`: client handles the new `notification.read.bulk` server message via an `onNotificationsRead` callback.
- `src/components/UserMenu.tsx`: subscribes to a new `quickcut:notifications-read` window event (carrying `count`/`ids`) and decrements the badge accordingly. Existing single-mark-read path is unchanged.
- `src/components/NotificationCenter.tsx`: listens for `quickcut:notifications-read` and updates affected rows in place so an already-open `/notifications` page reflects the change without a refresh.
- `src/components/ScriptWorkspace.tsx` / `src/components/VideoDetailView.tsx`: trigger the bulk action on mount when the user is signed in (skipped in share-mode).

## Tab → notification-type mapping
Strict mapping per the issue table. `tab=details` does not auto-mark anything.
- `tab=video` → `comment.created`, `comment.reply`, `approval.requested`
- `tab=script` → `script_comment.created`, `script_comment.reply`

## Edge cases
- Share-mode views are skipped (no auth context, action would 401 anyway).
- The DO broadcast is fire-and-forget — D1 is the source of truth, so a broadcast failure just means other tabs reconcile on next nav.
- The action is gated by `verifySpaceAccess`, so a user who has lost access cannot mark anything by guessing a `videoId`.

## Testing
See manual test plan in the comment that follows.

Closes #120