### PR TITLE
feat(db): projects table — phase 1 (add + backfill + dual-write)

### DIFF
--- a/migrations/0024_create_projects_table.sql
+++ b/migrations/0024_create_projects_table.sql
@@ -1,0 +1,81 @@
+-- Issue #121, phase 1: introduce a `projects` table that owns project-level
+-- fields. `videos` becomes a version row that points at a project via
+-- `project_id`. This phase only ADDS the new structure and backfills it from
+-- the existing `version_group_id` grouping. Read sites and writes are still
+-- on `videos` for now and are migrated in follow-up PRs. The duplicated
+-- columns on `videos` are intentionally kept until then so a rollback is
+-- possible without data loss.
+
+CREATE TABLE IF NOT EXISTS `projects` (
+  `id` text PRIMARY KEY NOT NULL,
+  `space_id` text NOT NULL REFERENCES `spaces`(`id`) ON DELETE CASCADE,
+  `uploaded_by` text REFERENCES `users`(`id`) ON DELETE SET NULL,
+  `folder_id` text REFERENCES `folders`(`id`) ON DELETE SET NULL,
+  `title` text NOT NULL,
+  `description` text,
+  `phase` text DEFAULT 'reviewing_video' NOT NULL,
+  `target_date` text,
+  `target_audience` text,
+  `hook` text,
+  `takeaway1` text,
+  `takeaway2` text,
+  `takeaway3` text,
+  `primary_cta` text,
+  `outro` text,
+  `created_at` text DEFAULT (datetime('now')) NOT NULL,
+  `updated_at` text DEFAULT (datetime('now')) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS `projects_space_id_idx` ON `projects` (`space_id`);
+CREATE INDEX IF NOT EXISTS `projects_folder_id_idx` ON `projects` (`folder_id`);
+
+-- Nullable for now. A later phase makes it NOT NULL and drops the
+-- duplicated columns on `videos`.
+ALTER TABLE `videos` ADD `project_id` text REFERENCES `projects`(`id`) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS `videos_project_id_idx` ON `videos` (`project_id`);
+
+-- Backfill: one project row per distinct version group. The project id is
+-- the canonical version's id (preferring is_current_version, then the
+-- lowest version_number, then the earliest created_at). Project-level
+-- fields are taken from that same canonical row.
+INSERT INTO `projects` (
+  `id`, `space_id`, `uploaded_by`, `folder_id`, `title`, `description`,
+  `phase`, `target_date`, `target_audience`, `hook`, `takeaway1`,
+  `takeaway2`, `takeaway3`, `primary_cta`, `outro`,
+  `created_at`, `updated_at`
+)
+SELECT
+  v.`id`, v.`space_id`, v.`uploaded_by`, v.`folder_id`, v.`title`, v.`description`,
+  v.`phase`, v.`target_date`, v.`target_audience`, v.`hook`, v.`takeaway1`,
+  v.`takeaway2`, v.`takeaway3`, v.`primary_cta`, v.`outro`,
+  v.`created_at`, v.`updated_at`
+FROM `videos` v
+WHERE v.`id` = (
+  SELECT inner_v.`id`
+  FROM `videos` inner_v
+  WHERE COALESCE(inner_v.`version_group_id`, inner_v.`id`)
+      = COALESCE(v.`version_group_id`, v.`id`)
+  ORDER BY inner_v.`is_current_version` DESC,
+           inner_v.`version_number` ASC,
+           inner_v.`created_at` ASC
+  LIMIT 1
+);
+
+-- Point every video at its project. Projects were keyed by the canonical
+-- version's id, which equals `version_group_id` when set, else the row's
+-- own id (for single-version projects).
+UPDATE `videos`
+SET `project_id` = (
+  SELECT p.`id` FROM `projects` p
+  WHERE p.`id` IN (
+    SELECT inner_v.`id`
+    FROM `videos` inner_v
+    WHERE COALESCE(inner_v.`version_group_id`, inner_v.`id`)
+        = COALESCE(`videos`.`version_group_id`, `videos`.`id`)
+    ORDER BY inner_v.`is_current_version` DESC,
+             inner_v.`version_number` ASC,
+             inner_v.`created_at` ASC
+    LIMIT 1
+  )
+);

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -14,6 +14,7 @@ import {
   approvals,
   approvalRequests,
   comments,
+  projects,
   scripts,
   shareLinks,
   transcripts,
@@ -225,6 +226,7 @@ export const server = {
 
         const now = new Date().toISOString();
         const versionGroupId = video.versionGroupId || video.id;
+        const projectId = video.projectId || versionGroupId;
 
         if (Object.keys(updates).length > 0) {
           await db
@@ -236,6 +238,11 @@ export const server = {
                 eq(videos.versionGroupId, versionGroupId),
               ),
             );
+
+          await db
+            .update(projects)
+            .set({ ...updates, updatedAt: now })
+            .where(eq(projects.id, projectId));
 
           if (input.targetDate !== undefined && input.targetDate !== video.targetDate) {
             await logProjectActivity(db, {
@@ -254,6 +261,11 @@ export const server = {
             .update(videos)
             .set({ folderId: folderUpdate, updatedAt: now })
             .where(and(eq(videos.spaceId, video.spaceId), eq(videos.versionGroupId, versionGroupId)));
+
+          await db
+            .update(projects)
+            .set({ folderId: folderUpdate, updatedAt: now })
+            .where(eq(projects.id, projectId));
         }
 
         const updated = await db
@@ -294,6 +306,7 @@ export const server = {
         }
 
         const versionGroupId = video.versionGroupId || video.id;
+        const projectId = video.projectId || versionGroupId;
         const projectVersions = await db
           .select({ id: videos.id, streamVideoId: videos.streamVideoId })
           .from(videos)
@@ -315,6 +328,8 @@ export const server = {
         for (const version of projectVersions) {
           await db.delete(videos).where(eq(videos.id, version.id));
         }
+
+        await db.delete(projects).where(eq(projects.id, projectId));
 
         return { success: true, redirectVideoId: null };
       },
@@ -388,10 +403,16 @@ export const server = {
         }
 
         const now = new Date().toISOString();
+        const projectId = video.projectId || video.versionGroupId || video.id;
         await db
           .update(videos)
           .set({ phase, updatedAt: now })
           .where(eq(videos.id, id));
+
+        await db
+          .update(projects)
+          .set({ phase, updatedAt: now })
+          .where(eq(projects.id, projectId));
 
         await logProjectActivity(db, {
           videoId: id,
@@ -758,11 +779,17 @@ export const server = {
         }
 
         const versionGroupId = video.versionGroupId || video.id;
+        const projectId = video.projectId || versionGroupId;
         const now = new Date().toISOString();
         await db
           .update(videos)
           .set({ folderId, updatedAt: now })
           .where(and(eq(videos.spaceId, video.spaceId), eq(videos.versionGroupId, versionGroupId)));
+
+        await db
+          .update(projects)
+          .set({ folderId, updatedAt: now })
+          .where(eq(projects.id, projectId));
 
         const updated = await db
           .select()
@@ -799,13 +826,28 @@ export const server = {
         }
 
         const videoId = crypto.randomUUID();
+        const projectId = videoId;
         const now = new Date().toISOString();
+
+        await db.insert(projects).values({
+          id: projectId,
+          spaceId,
+          uploadedBy: user.id,
+          folderId: folderId || null,
+          title,
+          description: description || null,
+          phase: "creating_script",
+          targetDate: null,
+          createdAt: now,
+          updatedAt: now,
+        });
 
         await db.insert(videos).values({
           id: videoId,
           spaceId,
           uploadedBy: user.id,
           folderId: folderId || null,
+          projectId,
           title,
           description: description || null,
           status: "draft",
@@ -919,6 +961,12 @@ export const server = {
           })
           .where(eq(videos.id, id));
 
+        const projectId = project.projectId || project.versionGroupId || project.id;
+        await db
+          .update(projects)
+          .set({ uploadedBy: user.id, phase: "reviewing_video", updatedAt: now })
+          .where(eq(projects.id, projectId));
+
         await logProjectActivity(db, {
           videoId: id,
           actorUserId: user.id,
@@ -1031,11 +1079,13 @@ export const server = {
           );
 
         const trimmedNotes = versionNotes?.trim();
+        const projectId = baseVideo.projectId || versionGroupId;
         await db.insert(videos).values({
           id: videoId,
           spaceId: baseVideo.spaceId,
           uploadedBy: user.id,
           folderId: baseVideo.folderId,
+          projectId,
           title: baseVideo.title,
           description: baseVideo.description,
           status: "processing",
@@ -2409,6 +2459,10 @@ export const server = {
           .update(videos)
           .set({ folderId: null, updatedAt: now })
           .where(inArray(videos.folderId, ids));
+        await db
+          .update(projects)
+          .set({ folderId: null, updatedAt: now })
+          .where(inArray(projects.folderId, ids));
         await db.delete(folders).where(inArray(folders.id, ids));
 
         return { success: true };

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -87,6 +87,40 @@ export const folders = sqliteTable("folders", {
     .default(sql`(datetime('now'))`),
 });
 
+export const projects = sqliteTable("projects", {
+  id: text("id").primaryKey(),
+  spaceId: text("space_id")
+    .notNull()
+    .references(() => spaces.id, { onDelete: "cascade" }),
+  uploadedBy: text("uploaded_by").references(() => users.id, {
+    onDelete: "set null",
+  }),
+  folderId: text("folder_id").references(() => folders.id, {
+    onDelete: "set null",
+  }),
+  title: text("title").notNull(),
+  description: text("description"),
+  phase: text("phase", {
+    enum: ["creating_script", "reviewing_script", "reviewing_video", "video_approved", "published"],
+  })
+    .notNull()
+    .default("reviewing_video"),
+  targetDate: text("target_date"),
+  targetAudience: text("target_audience"),
+  hook: text("hook"),
+  takeaway1: text("takeaway1"),
+  takeaway2: text("takeaway2"),
+  takeaway3: text("takeaway3"),
+  primaryCta: text("primary_cta"),
+  outro: text("outro"),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+  updatedAt: text("updated_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+});
+
 export const videos = sqliteTable("videos", {
   id: text("id").primaryKey(),
   spaceId: text("space_id")
@@ -97,6 +131,9 @@ export const videos = sqliteTable("videos", {
   }),
   folderId: text("folder_id").references(() => folders.id, {
     onDelete: "set null",
+  }),
+  projectId: text("project_id").references(() => projects.id, {
+    onDelete: "cascade",
   }),
   title: text("title").notNull(),
   description: text("description"),


### PR DESCRIPTION
## Summary

Phase 1 of #121. Lays the new `projects` table down alongside the existing
`videos` columns so subsequent PRs can migrate read sites incrementally.
This PR is intentionally **additive** — no read sites change, no columns
are dropped.

- New `projects` table owns project-level fields: `title`, `description`,
  `phase`, `target_date`, `target_audience`, `hook`, `takeaway1-3`,
  `primary_cta`, `outro`, `folder_id`, `uploaded_by`, `space_id`,
  `created_at`, `updated_at`.
- `videos.project_id` added as a **nullable** FK to `projects.id`
  (`ON DELETE CASCADE`). Indexed.
- Backfill in the migration creates one `projects` row per distinct
  `version_group_id` from the canonical version (preferring
  `is_current_version = 1`, then lowest `version_number`, then earliest
  `created_at`). Every existing `videos` row is updated to reference its
  project.
- Action handlers (`createProject`, `uploadFirstCut`, `uploadVersion`,
  `video.update`, `video.move`, `video.setPhase`, `video.delete`,
  `folder.delete` cascade) now **dual-write** the same project-level
  changes to both `videos` (existing duplicated columns) and `projects`,
  so the new table stays in sync until reads cut over.

## Why split into phases

Issue #121 calls for dropping the duplicated columns from `videos`
**only after every read site has been migrated**. Doing the whole thing
in one PR would mean a giant, hard-to-revert change. The plan is:

- **Phase 1 (this PR):** add table, backfill, dual-write. No behavior
  change.
- **Phase 2:** migrate read sites in `src/lib/versions.ts`,
  `src/pages/dashboard.astro`, `src/pages/api/videos/index.ts`,
  `src/pages/api/videos/[id]/index.ts`, `src/pages/s/[token].astro`, and
  the React components to read project-level fields from `projects`.
  Make `videos.project_id` `NOT NULL`.
- **Phase 3:** drop the duplicated columns from `videos` and the
  `version_group_id` column. Split `validation.ts` into
  `projectSchema` + `videoVersionSchema`.

## Changes

- `migrations/0024_create_projects_table.sql` — new table, FK column,
  backfill SQL.
- `src/db/schema.ts` — `projects` table, `videos.projectId` column.
- `src/actions/index.ts` — dual-writes at every project-level write site.

## Testing

See manual test plan in the next comment / chat.

Closes #121 (phase 1 of 3)