### PR TITLE
feat(projects): migrate read sites to projects table

### DIFF
--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -4,6 +4,7 @@ import {
   approvalRequests,
   comments,
   notifications,
+  projects,
   spaceMembers,
   spaces,
   users,
@@ -91,12 +92,13 @@ export async function createCommentNotifications(
   const videoRows = await db
     .select({
       id: videos.id,
-      title: videos.title,
+      title: projects.title,
       uploadedBy: videos.uploadedBy,
       spaceId: videos.spaceId,
       spaceOwnerId: spaces.ownerId,
     })
     .from(videos)
+    .innerJoin(projects, eq(projects.id, videos.projectId))
     .innerJoin(spaces, eq(videos.spaceId, spaces.id))
     .where(eq(videos.id, input.videoId))
     .limit(1);
@@ -239,10 +241,11 @@ export async function createTargetedApprovalRequestNotifications(
   const videoRows = await db
     .select({
       id: videos.id,
-      title: videos.title,
+      title: projects.title,
       spaceId: videos.spaceId,
     })
     .from(videos)
+    .innerJoin(projects, eq(projects.id, videos.projectId))
     .where(eq(videos.id, input.videoId))
     .limit(1);
 
@@ -359,7 +362,7 @@ export async function getPendingApprovalRequestsForUser(
     .select({
       id: approvalRequests.id,
       videoId: approvalRequests.videoId,
-      videoTitle: videos.title,
+      videoTitle: projects.title,
       spaceId: approvalRequests.spaceId,
       spaceName: spaces.name,
       requesterDisplayName: approvalRequests.requesterDisplayName,
@@ -367,6 +370,7 @@ export async function getPendingApprovalRequestsForUser(
     })
     .from(approvalRequests)
     .innerJoin(videos, eq(approvalRequests.videoId, videos.id))
+    .innerJoin(projects, eq(projects.id, videos.projectId))
     .innerJoin(spaces, eq(approvalRequests.spaceId, spaces.id))
     .where(
       and(

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,0 +1,259 @@
+import { and, count, desc, eq, inArray, isNull } from "drizzle-orm";
+import type { Database } from "../db";
+import { projects, videos } from "../db/schema";
+
+export type ProjectRow = typeof projects.$inferSelect;
+export type VideoRow = typeof videos.$inferSelect;
+
+/**
+ * The shape every existing call site expects: a flat object that looks
+ * like a `videos` row, but with project-level fields sourced from the
+ * `projects` table. During the multi-phase refactor (#121) the
+ * duplicated columns on `videos` are still read by callers; merging
+ * them here means callers don't change shape.
+ */
+export type MergedVideo = VideoRow & {
+  title: string;
+  description: string | null;
+  phase: ProjectRow["phase"];
+  targetDate: string | null;
+  targetAudience: string | null;
+  hook: string | null;
+  takeaway1: string | null;
+  takeaway2: string | null;
+  takeaway3: string | null;
+  primaryCta: string | null;
+  outro: string | null;
+  folderId: string | null;
+};
+
+const PROJECT_OVERRIDE_COLUMNS = {
+  title: projects.title,
+  description: projects.description,
+  phase: projects.phase,
+  targetDate: projects.targetDate,
+  targetAudience: projects.targetAudience,
+  hook: projects.hook,
+  takeaway1: projects.takeaway1,
+  takeaway2: projects.takeaway2,
+  takeaway3: projects.takeaway3,
+  primaryCta: projects.primaryCta,
+  outro: projects.outro,
+  folderId: projects.folderId,
+} as const;
+
+function mergeRow(
+  video: VideoRow,
+  project: Pick<ProjectRow,
+    | "title"
+    | "description"
+    | "phase"
+    | "targetDate"
+    | "targetAudience"
+    | "hook"
+    | "takeaway1"
+    | "takeaway2"
+    | "takeaway3"
+    | "primaryCta"
+    | "outro"
+    | "folderId"
+  > | null,
+): MergedVideo {
+  if (!project) return video as MergedVideo;
+  return {
+    ...video,
+    title: project.title,
+    description: project.description,
+    phase: project.phase,
+    targetDate: project.targetDate,
+    targetAudience: project.targetAudience,
+    hook: project.hook,
+    takeaway1: project.takeaway1,
+    takeaway2: project.takeaway2,
+    takeaway3: project.takeaway3,
+    primaryCta: project.primaryCta,
+    outro: project.outro,
+    folderId: project.folderId,
+  };
+}
+
+export async function getMergedVideoById(
+  db: Database,
+  id: string,
+): Promise<MergedVideo | null> {
+  const rows = await db
+    .select({ video: videos, project: PROJECT_OVERRIDE_COLUMNS })
+    .from(videos)
+    .leftJoin(projects, eq(projects.id, videos.projectId))
+    .where(eq(videos.id, id))
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  return mergeRow(row.video, row.project);
+}
+
+interface CurrentVideoListOptions {
+  spaceIds: string[];
+  folderId?: string | null;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * List the current version of every project visible to a user. Filters
+ * by folder when `folderId` is provided ("root" → folderId IS NULL).
+ * Folder filtering uses `projects.folder_id`, the source of truth for
+ * project-level placement after #121.
+ */
+export async function listCurrentMergedVideos(
+  db: Database,
+  options: CurrentVideoListOptions,
+): Promise<{ rows: MergedVideo[]; total: number }> {
+  const { spaceIds, folderId, limit, offset } = options;
+  if (spaceIds.length === 0) return { rows: [], total: 0 };
+
+  const folderFilter =
+    folderId === undefined || folderId === null
+      ? null
+      : folderId === "root"
+        ? isNull(projects.folderId)
+        : eq(projects.folderId, folderId);
+
+  const where = and(
+    inArray(videos.spaceId, spaceIds),
+    eq(videos.isCurrentVersion, true),
+    ...(folderFilter ? [folderFilter] : []),
+  );
+
+  let query = db
+    .select({ video: videos, project: PROJECT_OVERRIDE_COLUMNS })
+    .from(videos)
+    .leftJoin(projects, eq(projects.id, videos.projectId))
+    .where(where)
+    .orderBy(desc(videos.createdAt));
+
+  if (typeof limit === "number") query = query.limit(limit) as typeof query;
+  if (typeof offset === "number") query = query.offset(offset) as typeof query;
+
+  const rows = await query;
+
+  const totalRow = await db
+    .select({ count: count() })
+    .from(videos)
+    .leftJoin(projects, eq(projects.id, videos.projectId))
+    .where(where);
+
+  return {
+    rows: rows.map((row) => mergeRow(row.video, row.project)),
+    total: totalRow[0]?.count ?? 0,
+  };
+}
+
+/**
+ * Count of versions per project. Returns a map keyed by `projectId`
+ * (the `videos.project_id` value, identical to `projects.id`).
+ */
+export async function getVersionCountsByProjectId(
+  db: Database,
+  projectIds: string[],
+): Promise<Record<string, number>> {
+  const unique = [...new Set(projectIds.filter((id): id is string => Boolean(id)))];
+  if (unique.length === 0) return {};
+
+  const rows = await db
+    .select({ projectId: videos.projectId, count: count() })
+    .from(videos)
+    .where(inArray(videos.projectId, unique))
+    .groupBy(videos.projectId);
+
+  return Object.fromEntries(
+    rows.map((row) => [row.projectId ?? "", row.count] as const),
+  );
+}
+
+/**
+ * Count current-version videos per folder, filtered to a space and a
+ * set of folder ids. Reads `projects.folder_id` and joins through to
+ * the current `videos` row so the count reflects "active projects".
+ */
+export async function getCurrentVideoCountsByFolder(
+  db: Database,
+  spaceId: string,
+  folderIds: string[],
+): Promise<Record<string, number>> {
+  if (folderIds.length === 0) return {};
+  const rows = await db
+    .select({ folderId: projects.folderId, count: count() })
+    .from(videos)
+    .innerJoin(projects, eq(projects.id, videos.projectId))
+    .where(
+      and(
+        eq(videos.spaceId, spaceId),
+        eq(videos.isCurrentVersion, true),
+        inArray(projects.folderId, folderIds),
+      ),
+    )
+    .groupBy(projects.folderId);
+
+  return Object.fromEntries(
+    rows.map((row) => [row.folderId ?? "", row.count] as const),
+  );
+}
+
+/**
+ * Fetch up to 4 thumbnails per folder for the dashboard folder cards.
+ * Reads from `videos` joined to `projects` so folder placement is
+ * sourced from the projects table.
+ */
+export async function getCurrentVideoThumbnailsByFolder(
+  db: Database,
+  spaceId: string,
+  folderIds: string[],
+): Promise<Record<string, string[]>> {
+  if (folderIds.length === 0) return {};
+  const rows = await db
+    .select({
+      folderId: projects.folderId,
+      thumbnailUrl: videos.thumbnailUrl,
+      createdAt: videos.createdAt,
+    })
+    .from(videos)
+    .innerJoin(projects, eq(projects.id, videos.projectId))
+    .where(
+      and(
+        eq(videos.spaceId, spaceId),
+        eq(videos.isCurrentVersion, true),
+        inArray(projects.folderId, folderIds),
+      ),
+    )
+    .orderBy(desc(videos.createdAt));
+
+  return rows.reduce<Record<string, string[]>>((acc, row) => {
+    if (!row.folderId || !row.thumbnailUrl) return acc;
+    const bucket = acc[row.folderId] ?? [];
+    if (bucket.length < 4) bucket.push(row.thumbnailUrl);
+    acc[row.folderId] = bucket;
+    return acc;
+  }, {});
+}
+
+/**
+ * Lightweight project lookup used by mutation handlers that need the
+ * canonical project row (e.g. for activity logging or to find the
+ * project id from a video). Returns null if the video has no project
+ * yet (should only occur during a partial rollout).
+ */
+export async function getProjectForVideoId(
+  db: Database,
+  videoId: string,
+): Promise<ProjectRow | null> {
+  const rows = await db
+    .select({ project: projects })
+    .from(videos)
+    .leftJoin(projects, eq(projects.id, videos.projectId))
+    .where(eq(videos.id, videoId))
+    .limit(1);
+  return rows[0]?.project ?? null;
+}
+
+export type { ProjectRow as Project };

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -1,6 +1,6 @@
-import { and, count, desc, eq, sql } from "drizzle-orm";
+import { count, desc, eq, sql } from "drizzle-orm";
 import type { Database } from "../db";
-import { comments, videos } from "../db/schema";
+import { comments, projects, videos } from "../db/schema";
 
 export interface VersionSummary {
   id: string;
@@ -18,6 +18,7 @@ export interface VersionSummary {
 interface VersionContext {
   id: string;
   spaceId: string;
+  projectId: string | null;
   versionGroupId: string | null;
 }
 
@@ -25,20 +26,19 @@ export async function getVideoVersions(
   db: Database,
   video: VersionContext,
 ): Promise<VersionSummary[]> {
-  const versionGroupId = video.versionGroupId || video.id;
+  const projectId = video.projectId ?? video.versionGroupId ?? video.id;
 
-  const versionRows = await db
-    .select()
+  const rows = await db
+    .select({
+      video: videos,
+      projectTitle: projects.title,
+    })
     .from(videos)
-    .where(
-      and(
-        eq(videos.spaceId, video.spaceId),
-        eq(videos.versionGroupId, versionGroupId),
-      ),
-    )
+    .leftJoin(projects, eq(projects.id, videos.projectId))
+    .where(eq(videos.projectId, projectId))
     .orderBy(desc(videos.versionNumber));
 
-  const versionIds = versionRows.map((version) => version.id);
+  const versionIds = rows.map((row) => row.video.id);
   let commentCounts: Record<string, number> = {};
 
   if (versionIds.length > 0) {
@@ -58,9 +58,9 @@ export async function getVideoVersions(
     );
   }
 
-  return versionRows.map((version) => ({
+  return rows.map(({ video: version, projectTitle }) => ({
     id: version.id,
-    title: version.title,
+    title: projectTitle ?? version.title,
     status: version.status,
     thumbnailUrl: version.thumbnailUrl,
     duration: version.duration,

--- a/src/pages/api/videos/[id]/index.ts
+++ b/src/pages/api/videos/[id]/index.ts
@@ -1,10 +1,11 @@
 import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
 import { createDb } from "../../../../db";
-import { videos, shareLinks, comments } from "../../../../db/schema";
-import { and, eq, count } from "drizzle-orm";
+import { shareLinks, comments, videos } from "../../../../db/schema";
+import { eq, count } from "drizzle-orm";
 import { verifySpaceAccess } from "../../../../lib/spaces";
 import { getApprovalStatus } from "../../../../lib/approvals";
+import { getMergedVideoById } from "../../../../lib/projects";
 
 export const GET: APIRoute = async ({ params, locals }) => {
   if (!locals.user) {
@@ -24,22 +25,14 @@ export const GET: APIRoute = async ({ params, locals }) => {
 
   const db = createDb(env.DB);
 
-  const videoResult = await db
-    .select()
-    .from(videos)
-    .where(eq(videos.id, id))
-    .limit(1);
-
-  if (videoResult.length === 0) {
+  const video = await getMergedVideoById(db, id);
+  if (!video) {
     return new Response(JSON.stringify({ error: "Video not found" }), {
       status: 404,
       headers: { "Content-Type": "application/json" },
     });
   }
 
-  const video = videoResult[0];
-
-  // Verify the user is a member of the video's space
   const role = await verifySpaceAccess(db, locals.user.id, video.spaceId);
   if (!role) {
     return new Response(JSON.stringify({ error: "Forbidden" }), {
@@ -48,28 +41,23 @@ export const GET: APIRoute = async ({ params, locals }) => {
     });
   }
 
-  // Get share link
   const shareLinkResult = await db
     .select()
     .from(shareLinks)
     .where(eq(shareLinks.videoId, id))
     .limit(1);
 
-  // Get comment count
   const commentCountResult = await db
     .select({ count: count() })
     .from(comments)
     .where(eq(comments.videoId, id));
 
-  const versionGroupId = video.versionGroupId || video.id;
+  const projectId = video.projectId ?? video.versionGroupId ?? video.id;
   const versionCountResult = await db
     .select({ count: count() })
     .from(videos)
-    .where(and(eq(videos.spaceId, video.spaceId), eq(videos.versionGroupId, versionGroupId)));
+    .where(eq(videos.projectId, projectId));
 
-  // Approval state is computed on demand from the approvals table compared
-  // against the space's required threshold. Only attached when the
-  // workflow is actually enabled for this space (requiredApprovals > 0).
   const approvalStatus = await getApprovalStatus(db, id, video.spaceId);
   const includeApprovalStatus = approvalStatus.requiredApprovals > 0;
 

--- a/src/pages/api/videos/index.ts
+++ b/src/pages/api/videos/index.ts
@@ -1,8 +1,12 @@
 import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
 import { createDb } from "../../../db";
-import { videos, comments, spaceMembers } from "../../../db/schema";
-import { and, eq, desc, sql, count, isNull, inArray } from "drizzle-orm";
+import { comments, spaceMembers } from "../../../db/schema";
+import { count, eq, sql } from "drizzle-orm";
+import {
+  getVersionCountsByProjectId,
+  listCurrentMergedVideos,
+} from "../../../lib/projects";
 
 export const GET: APIRoute = async ({ locals, url }) => {
   if (!locals.user) {
@@ -17,7 +21,6 @@ export const GET: APIRoute = async ({ locals, url }) => {
   const offset = parseInt(url.searchParams.get("offset") || "0");
   const folderId = url.searchParams.get("folderId");
 
-  // Get all space IDs the user belongs to
   const memberRows = await db
     .select({ spaceId: spaceMembers.spaceId })
     .from(spaceMembers)
@@ -31,27 +34,13 @@ export const GET: APIRoute = async ({ locals, url }) => {
     );
   }
 
-  const spaceFilter = inArray(videos.spaceId, spaceIds);
-  const where = folderId
-    ? folderId === "root"
-      ? and(spaceFilter, isNull(videos.folderId), eq(videos.isCurrentVersion, true))
-      : and(spaceFilter, eq(videos.folderId, folderId), eq(videos.isCurrentVersion, true))
-    : and(spaceFilter, eq(videos.isCurrentVersion, true));
+  const { rows: userVideos, total } = await listCurrentMergedVideos(db, {
+    spaceIds,
+    folderId,
+    limit,
+    offset,
+  });
 
-  const userVideos = await db
-    .select()
-    .from(videos)
-    .where(where)
-    .orderBy(desc(videos.createdAt))
-    .limit(limit)
-    .offset(offset);
-
-  const totalResult = await db
-    .select({ count: count() })
-    .from(videos)
-    .where(where);
-
-  // Get comment counts for each video
   const videoIds = userVideos.map((v) => v.id);
   let commentCounts: Record<string, number> = {};
 
@@ -68,29 +57,21 @@ export const GET: APIRoute = async ({ locals, url }) => {
     commentCounts = Object.fromEntries(counts.map((c) => [c.videoId, c.count]));
   }
 
-  const versionGroupIds = userVideos.map((v) => v.versionGroupId || v.id);
-  let versionCounts: Record<string, number> = {};
-
-  if (versionGroupIds.length > 0) {
-    const counts = await db
-      .select({ versionGroupId: videos.versionGroupId, count: count() })
-      .from(videos)
-      .where(sql`${videos.versionGroupId} IN (${sql.join(versionGroupIds.map((id) => sql`${id}`), sql`, `)})`)
-      .groupBy(videos.versionGroupId);
-
-    versionCounts = Object.fromEntries(counts.map((c) => [c.versionGroupId || "", c.count]));
-  }
+  const versionCounts = await getVersionCountsByProjectId(
+    db,
+    userVideos.map((v) => v.projectId).filter((id): id is string => Boolean(id)),
+  );
 
   const videosWithCounts = userVideos.map((v) => ({
     ...v,
     commentCount: commentCounts[v.id] || 0,
-    versionCount: versionCounts[v.versionGroupId || v.id] || 1,
+    versionCount: versionCounts[v.projectId ?? ""] || 1,
   }));
 
   return new Response(
     JSON.stringify({
       videos: videosWithCounts,
-      total: totalResult[0]?.count || 0,
+      total,
     }),
     { headers: { "Content-Type": "application/json" } },
   );

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -6,10 +6,15 @@ import { PendingToast } from "../components/PendingToast";
 import type { FolderCardItemData } from "../components/FolderCardItem";
 import type { VideoCardItemData } from "../components/VideoCardItem";
 import { createDb } from "../db";
-import { folders, videos, comments, spaceMembers, approvals } from "../db/schema";
+import { folders, videos, comments, spaceMembers, approvals, projects } from "../db/schema";
 import { and, asc, desc, count, eq, inArray, sql } from "drizzle-orm";
 import { env } from "cloudflare:workers";
 import { getUserSpaces } from "../lib/spaces";
+import {
+  getCurrentVideoCountsByFolder,
+  getCurrentVideoThumbnailsByFolder,
+  getVersionCountsByProjectId,
+} from "../lib/projects";
 
 const user = Astro.locals.user;
 if (!user) return Astro.redirect("/login");
@@ -69,37 +74,27 @@ const folderOptions = allFolders.map((folder) => ({
 }));
 const childFolderIds = childFolders.map((folder) => folder.id);
 
-let folderVideoCounts: Record<string, number> = {};
-let folderThumbnails: Record<string, string[]> = {};
+const folderVideoCounts = await getCurrentVideoCountsByFolder(db, selectedSpaceId, childFolderIds);
+const folderThumbnails = await getCurrentVideoThumbnailsByFolder(db, selectedSpaceId, childFolderIds);
 
-if (childFolderIds.length > 0) {
-  const counts = await db
-    .select({ folderId: videos.folderId, count: count() })
-    .from(videos)
-    .where(and(eq(videos.spaceId, selectedSpaceId), eq(videos.isCurrentVersion, true), inArray(videos.folderId, childFolderIds)))
-    .groupBy(videos.folderId);
-
-  folderVideoCounts = Object.fromEntries(counts.map((row) => [row.folderId || "", row.count]));
-
-  const folderVideos = await db
-    .select({ folderId: videos.folderId, thumbnailUrl: videos.thumbnailUrl })
-    .from(videos)
-    .where(and(eq(videos.spaceId, selectedSpaceId), eq(videos.isCurrentVersion, true), inArray(videos.folderId, childFolderIds)))
-    .orderBy(desc(videos.createdAt));
-
-  folderThumbnails = folderVideos.reduce<Record<string, string[]>>((acc, video) => {
-    if (!video.folderId || !video.thumbnailUrl) return acc;
-    acc[video.folderId] = acc[video.folderId] || [];
-    if (acc[video.folderId].length < 4) acc[video.folderId].push(video.thumbnailUrl);
-    return acc;
-  }, {});
-}
-
-const allSpaceVideos = await db
-  .select()
+const allSpaceVideoRows = await db
+  .select({
+    video: videos,
+    projectTitle: projects.title,
+    projectFolderId: projects.folderId,
+    projectPhase: projects.phase,
+  })
   .from(videos)
+  .leftJoin(projects, eq(projects.id, videos.projectId))
   .where(and(eq(videos.spaceId, selectedSpaceId), eq(videos.isCurrentVersion, true)))
   .orderBy(desc(videos.createdAt));
+
+const allSpaceVideos = allSpaceVideoRows.map((row) => ({
+  ...row.video,
+  title: row.projectTitle ?? row.video.title,
+  folderId: row.projectFolderId ?? row.video.folderId,
+  phase: row.projectPhase ?? row.video.phase,
+}));
 
 const userVideos = allSpaceVideos.filter((video) => {
   if (currentFolderId) return video.folderId === currentFolderId;
@@ -158,17 +153,10 @@ if (allSpaceVideos.length > 0) {
   );
 }
 
-let versionCounts: Record<string, number> = {};
-if (allSpaceVideos.length > 0) {
-  const versionGroupIds = allSpaceVideos.map((video) => video.versionGroupId || video.id);
-  const counts = await db
-    .select({ versionGroupId: videos.versionGroupId, count: count() })
-    .from(videos)
-    .where(sql`${videos.versionGroupId} IN (${sql.join(versionGroupIds.map((id) => sql`${id}`), sql`, `)})`)
-    .groupBy(videos.versionGroupId);
-
-  versionCounts = Object.fromEntries(counts.map((row) => [row.versionGroupId || "", row.count]));
-}
+const versionCounts = await getVersionCountsByProjectId(
+  db,
+  allSpaceVideos.map((video) => video.projectId).filter((id): id is string => Boolean(id)),
+);
 
 // Approval badges only render when the selected space enables approvals.
 const approvalCountsByVideo: Record<string, number> = {};
@@ -216,7 +204,7 @@ const videoItems: VideoCardItemData[] = userVideos.map((video) => ({
   commentCount: commentCounts[video.id] || 0,
   urgencyCounts: urgencyCounts[video.id] || { idea: 0, suggestion: 0, important: 0, critical: 0 },
   versionNumber: video.versionNumber ?? 1,
-  versionCount: versionCounts[video.versionGroupId || video.id] || 1,
+  versionCount: versionCounts[video.projectId ?? ""] || 1,
   requiredApprovals: selectedSpace.requiredApprovals,
   approvalCount: approvalCountsByVideo[video.id] || 0,
   phase: video.phase,

--- a/src/pages/s/[token].astro
+++ b/src/pages/s/[token].astro
@@ -3,12 +3,13 @@ import Layout from "../../layouts/Layout.astro";
 import { ShareView } from "../../components/ShareView";
 import { createDb } from "../../db";
 import { shareLinks, scripts, spaces, videos } from "../../db/schema";
-import { and, count, eq } from "drizzle-orm";
+import { count, eq } from "drizzle-orm";
 import { env } from "cloudflare:workers";
 import { getCommentsWithNames } from "../../lib/comments";
 import { getApprovalStatus, type ApprovalStatus } from "../../lib/approvals";
 import { getProjectActivity } from "../../lib/activity";
 import { loadTranscriptPanelData, type TranscriptPanelData } from "../../lib/transcripts";
+import { getMergedVideoById, type MergedVideo } from "../../lib/projects";
 import { normalizeVideoPhase } from "../../types";
 
 const { token } = Astro.params;
@@ -31,8 +32,7 @@ const shareLink = shareLinkResult[0];
 
 const isRevoked = shareLink.status === "revoked";
 
-// Get video and associated data
-let video = null;
+let video: MergedVideo | null = null;
 let allComments: any[] = [];
 let versionCount = 1;
 let approvalStatus: ApprovalStatus | null = null;
@@ -42,24 +42,19 @@ let videoSpace: { id: string; name: string; pipelineEnabled: boolean } | null = 
 let initialTranscriptData: TranscriptPanelData | null = null;
 
 if (!isRevoked) {
-  const videoResult = await db
-    .select()
-    .from(videos)
-    .where(eq(videos.id, shareLink.videoId))
-    .limit(1);
+  video = await getMergedVideoById(db, shareLink.videoId);
 
-  if (videoResult.length === 0) {
+  if (!video) {
     return Astro.redirect("/404");
   }
 
-  video = videoResult[0];
   allComments = await getCommentsWithNames(db, shareLink.videoId);
 
-  const versionGroupId = video.versionGroupId || video.id;
+  const projectId = video.projectId ?? video.versionGroupId ?? video.id;
   const versionCountResult = await db
     .select({ count: count() })
     .from(videos)
-    .where(and(eq(videos.spaceId, video.spaceId), eq(videos.versionGroupId, versionGroupId)));
+    .where(eq(videos.projectId, projectId));
   versionCount = versionCountResult[0]?.count || 1;
 
   const status = await getApprovalStatus(db, video.id, video.spaceId);

--- a/src/pages/spaces/[id]/calendar.astro
+++ b/src/pages/spaces/[id]/calendar.astro
@@ -3,7 +3,7 @@ import Layout from "../../../layouts/Layout.astro";
 import { CalendarView } from "../../../components/CalendarView";
 import type { DashboardVideo } from "../../../components/dashboard-types";
 import { createDb } from "../../../db";
-import { spaces, videos, scripts, users } from "../../../db/schema";
+import { projects, spaces, videos, scripts, users } from "../../../db/schema";
 import { and, desc, eq } from "drizzle-orm";
 import { env } from "cloudflare:workers";
 import { verifySpaceAccess } from "../../../lib/spaces";
@@ -29,17 +29,18 @@ if (space.length === 0) return Astro.redirect("/dashboard");
 const rows = await db
   .select({
     id: videos.id,
-    title: videos.title,
+    title: projects.title,
     status: videos.status,
-    phase: videos.phase,
+    phase: projects.phase,
     thumbnailUrl: videos.thumbnailUrl,
     duration: videos.duration,
     createdAt: videos.createdAt,
-    targetDate: videos.targetDate,
+    targetDate: projects.targetDate,
     scriptStatus: scripts.status,
     ownerName: users.name,
   })
   .from(videos)
+  .innerJoin(projects, eq(projects.id, videos.projectId))
   .leftJoin(scripts, eq(scripts.videoId, videos.id))
   .leftJoin(users, eq(users.id, videos.uploadedBy))
   .where(and(eq(videos.spaceId, id), eq(videos.isCurrentVersion, true)))

--- a/src/pages/videos/[id]/index.astro
+++ b/src/pages/videos/[id]/index.astro
@@ -11,13 +11,14 @@ import { VideoHeader } from "../../../components/VideoHeader";
 import { env } from "cloudflare:workers";
 import { eq } from "drizzle-orm";
 import { createDb } from "../../../db";
-import { scripts, shareLinks, spaces, videos } from "../../../db/schema";
+import { scripts, shareLinks, spaces } from "../../../db/schema";
 import { getApprovalStatus } from "../../../lib/approvals";
 import { getCommentsWithNames } from "../../../lib/comments";
 import { isTranscriptGenerationEnabled } from "../../../lib/flags";
 import { getProjectActivity } from "../../../lib/activity";
 import { verifySpaceAccess } from "../../../lib/spaces";
 import { loadTranscriptPanelData } from "../../../lib/transcripts";
+import { getMergedVideoById } from "../../../lib/projects";
 import { getVideoVersions } from "../../../lib/versions";
 import { normalizeVideoPhase } from "../../../types";
 
@@ -28,8 +29,7 @@ const { id } = Astro.params;
 if (!id) return Astro.redirect("/dashboard");
 
 const db = createDb(env.DB);
-const videoResult = await db.select().from(videos).where(eq(videos.id, id)).limit(1);
-const video = videoResult[0];
+const video = await getMergedVideoById(db, id);
 if (!video) return Astro.redirect("/dashboard");
 
 const role = await verifySpaceAccess(db, user.id, video.spaceId);


### PR DESCRIPTION
## Summary

Phase 2 of #121. Switches every read site that previously sourced
project-level fields (title, description, phase, target_date,
target_audience, hook, takeaways, primary_cta, outro, folder_id)
off the duplicated columns on `videos` to read them from the new
`projects` table joined through `videos.project_id`.

Components stay flat. A new helper layer in `src/lib/projects.ts`
performs the join and overrides the duplicated fields at the data
boundary, so React components keep receiving the same `{ id, title,
phase, hook, ... }` shape they did before.

## Changes

### New
- `src/lib/projects.ts` — helpers used by every read site:
  - `getMergedVideoById(db, id)` — single-row read merging the
    current video row with its project.
  - `listCurrentMergedVideos(db, { spaceIds, folderId, limit, offset })`
    — list query that filters by `projects.folder_id`.
  - `getCurrentVideoCountsByFolder` and
    `getCurrentVideoThumbnailsByFolder` — dashboard folder cards.
  - `getVersionCountsByProjectId` — replaces the `version_group_id`
    keyed counts.

### Migrated
- `src/lib/versions.ts` — version list now joins to `projects` for the
  authoritative title; lookup keyed by `videos.project_id` instead of
  `version_group_id`.
- `src/lib/notifications.ts` — comment, approval-request, and pending
  approval-request queries all read `videos.title` from `projects.title`.
- `src/pages/dashboard.astro` — folder counts/thumbnails read from
  `projects.folder_id`; current-video list joins through projects;
  version counts keyed by `projects.id`.
- `src/pages/api/videos/index.ts` — list endpoint uses
  `listCurrentMergedVideos`.
- `src/pages/api/videos/[id]/index.ts` — detail endpoint uses
  `getMergedVideoById`; version count keyed by `projectId`.
- `src/pages/s/[token].astro` — share page uses `getMergedVideoById`.
- `src/pages/videos/[id]/index.astro` — project page uses
  `getMergedVideoById`.
- `src/pages/spaces/[id]/calendar.astro` — `INNER JOIN projects` so
  title/phase/target_date come from the project row.

## Why NOT NULL on `videos.project_id` is deferred

The issue mentions making `videos.project_id` `NOT NULL` as part of
this work, but adding NOT NULL to an existing SQLite column requires a
full table rebuild. Phase 3 already needs to do that rebuild to drop
the duplicated columns. Folding the NOT NULL into that single rebuild
in phase 3 means we don't pay the rebuild cost twice and keeps phase 2
purely DML/read-side. It also makes phase 2 trivially revertible.

## What this does NOT change

- `actions/index.ts` writes still hit both tables (dual-write from
  phase 1). That stays in place until phase 3 drops the duplicated
  columns; until then writes must continue going to both.
- The duplicated columns on `videos` (`title`, `description`, `phase`,
  `target_date`, `target_audience`, `hook`, `takeaway1-3`,
  `primary_cta`, `outro`, `folder_id`, `uploaded_by`) are still in the
  schema. They're write-only at this point — no read site references
  them anymore. Phase 3 will remove them.

## Testing

See manual test plan in chat / next comment. Net code change:

```
9 files changed, 348 insertions(+), 132 deletions(-)
```

(Numbers reflect read-site shrinkage; `lib/projects.ts` adds the
helper layer.)

Refs #121 (phase 2 of 3)