### PR TITLE
fix(share): use logged-in identity on share links

### DIFF
--- a/src/components/ShareView.tsx
+++ b/src/components/ShareView.tsx
@@ -31,6 +31,11 @@ interface Video {
   versionNotes: string | null;
 }
 
+interface ShareViewCurrentUser {
+  id: string;
+  name: string;
+}
+
 interface ShareViewProps {
   activeTab: "details" | "script" | "video";
   video: Video;
@@ -41,6 +46,7 @@ interface ShareViewProps {
   initialActivity: ProjectActivityItem[];
   pipelineEnabled: boolean;
   initialTranscriptData: TranscriptResponse | null;
+  currentUser: ShareViewCurrentUser | null;
 }
 
 const ANON_NAME_KEY = "quickcut_anonymous_name";
@@ -55,23 +61,28 @@ export function ShareView({
   initialActivity,
   pipelineEnabled,
   initialTranscriptData,
+  currentUser,
 }: ShareViewProps) {
   const [anonymousName, setAnonymousName] = useState<string | null>(() => {
+    if (currentUser) return null;
     if (typeof window === "undefined") return null;
     return localStorage.getItem(ANON_NAME_KEY);
   });
 
+  const viewerName = currentUser?.name ?? anonymousName;
+  const viewerId = currentUser?.id ?? "";
+
   useEffect(() => {
-    if (!anonymousName) return;
+    if (!viewerName) return;
     fetch(`/api/share/${shareToken}/view`, { method: "POST" }).catch(() => {});
-  }, [shareToken, anonymousName]);
+  }, [shareToken, viewerName]);
 
   const handleNameSubmit = (name: string) => {
     localStorage.setItem(ANON_NAME_KEY, name);
     setAnonymousName(name);
   };
 
-  if (!anonymousName) {
+  if (!currentUser && !anonymousName) {
     return (
       <NamePromptModal
         isOpen
@@ -110,10 +121,10 @@ export function ShareView({
         spaceId={video.spaceId}
         initialContent={initialScriptContent}
         initialComments={initialComments}
-        currentUserName={anonymousName}
+        currentUserName={viewerName}
         readOnly={video.phase === "published"}
         shareToken={shareToken}
-        anonymousName={anonymousName}
+        anonymousName={viewerName}
       />
     );
   }
@@ -126,8 +137,8 @@ export function ShareView({
       status={video.status}
       duration={video.duration}
       initialComments={initialComments}
-      currentUserId=""
-      currentUserName={anonymousName}
+      currentUserId={viewerId}
+      currentUserName={viewerName}
       title={video.title}
       uploadDate={video.createdAt}
       fileName={video.fileName}

--- a/src/pages/api/share/[token]/comments.ts
+++ b/src/pages/api/share/[token]/comments.ts
@@ -77,7 +77,7 @@ export const GET: APIRoute = async ({ params, url }) => {
   });
 };
 
-export const POST: APIRoute = async ({ params, request }) => {
+export const POST: APIRoute = async ({ params, request, locals }) => {
   const { token } = params;
   if (!token) {
     return new Response(JSON.stringify({ error: "Token required" }), {
@@ -101,6 +101,7 @@ export const POST: APIRoute = async ({ params, request }) => {
     });
   }
 
+  const sessionUser = locals.user;
   const videoId = shareLinkResult[0].videoId;
   const body = await request.json();
   const { text, timestamp, name, parentId, annotation, urgency, phase, textRange } = body;
@@ -132,7 +133,7 @@ export const POST: APIRoute = async ({ params, request }) => {
     });
   }
 
-  if (!name || !name.trim()) {
+  if (!sessionUser && (!name || !name.trim())) {
     return new Response(
       JSON.stringify({ error: "Name is required" }),
       { status: 400, headers: { "Content-Type": "application/json" } },
@@ -178,33 +179,54 @@ export const POST: APIRoute = async ({ params, request }) => {
     commentPhase = parentRows[0].phase;
   }
 
-  const newComment = {
-    id: commentId,
-    videoId,
-    authorType: "anonymous" as const,
-    authorUserId: null,
-    authorDisplayName: name.trim(),
-    timestamp: timestamp != null ? Number(timestamp) : null,
-    text: text.trim(),
-    parentId: parentId || null,
-    isResolved: false,
-    resolvedBy: null,
-    resolvedAt: null,
-    resolvedReason: null,
-    annotation: annotation ? JSON.stringify(annotation) : null,
-    urgency: commentUrgency,
-    phase: commentPhase,
-    textRange: textRange ? JSON.stringify(textRange) : null,
-  };
+  const newComment = sessionUser
+    ? {
+        id: commentId,
+        videoId,
+        authorType: "user" as const,
+        authorUserId: sessionUser.id,
+        authorDisplayName: null,
+        timestamp: timestamp != null ? Number(timestamp) : null,
+        text: text.trim(),
+        parentId: parentId || null,
+        isResolved: false,
+        resolvedBy: null,
+        resolvedAt: null,
+        resolvedReason: null,
+        annotation: annotation ? JSON.stringify(annotation) : null,
+        urgency: commentUrgency,
+        phase: commentPhase,
+        textRange: textRange ? JSON.stringify(textRange) : null,
+      }
+    : {
+        id: commentId,
+        videoId,
+        authorType: "anonymous" as const,
+        authorUserId: null,
+        authorDisplayName: name.trim(),
+        timestamp: timestamp != null ? Number(timestamp) : null,
+        text: text.trim(),
+        parentId: parentId || null,
+        isResolved: false,
+        resolvedBy: null,
+        resolvedAt: null,
+        resolvedReason: null,
+        annotation: annotation ? JSON.stringify(annotation) : null,
+        urgency: commentUrgency,
+        phase: commentPhase,
+        textRange: textRange ? JSON.stringify(textRange) : null,
+      };
 
   await db.insert(comments).values(newComment);
+
+  const displayName = sessionUser?.name ?? newComment.authorDisplayName ?? "Anonymous";
 
   try {
     await createCommentNotifications(db, {
       commentId,
       videoId,
-      actorUserId: null,
-      actorDisplayName: newComment.authorDisplayName,
+      actorUserId: sessionUser?.id ?? null,
+      actorDisplayName: displayName,
       text: newComment.text,
       parentCommentId: newComment.parentId,
       phase: newComment.phase,
@@ -222,7 +244,7 @@ export const POST: APIRoute = async ({ params, request }) => {
     annotation: annotation || null,
     textRange: textRange || null,
     createdAt: new Date().toISOString(),
-    name: name.trim(),
+    name: displayName,
     reactions: [],
   };
 

--- a/src/pages/s/[token].astro
+++ b/src/pages/s/[token].astro
@@ -14,6 +14,10 @@ import { normalizeVideoPhase } from "../../types";
 const { token } = Astro.params;
 if (!token) return Astro.redirect("/");
 
+const currentUser = Astro.locals.user
+  ? { id: Astro.locals.user.id, name: Astro.locals.user.name }
+  : null;
+
 const db = createDb(env.DB);
 
 // Find share link
@@ -183,6 +187,7 @@ const isPublished = phase === "published";
             initialActivity={projectActivityItems}
             pipelineEnabled={videoSpace?.pipelineEnabled || false}
             initialTranscriptData={initialTranscriptData}
+            currentUser={currentUser}
           />
         )}
 


### PR DESCRIPTION
## Summary
- Skip the guest name prompt on `/s/<token>` when the visitor already has an authenticated session.
- The share comments API now reads `Astro.locals.user` and attributes new comments with `authorType: "user"` + `authorUserId` so they show up as the real account instead of as anonymous entries.
- Anonymous viewers keep the existing flow: name modal blocks the page until they enter a name, comments stored with `authorType: "anonymous"`.

## Why
A logged-in user opening a share link was asked to type their name and saw their own comments rendered as guest comments. Now we use what the app already knows.

## Changes
- `src/pages/s/[token].astro` — pass `Astro.locals.user` (id + name) into `ShareView` as a `currentUser` prop.
- `src/components/ShareView.tsx` — accept `currentUser`; skip `NamePromptModal` when present; propagate the real name/id to `ScriptWorkspace` and `VideoDetailView`. Anonymous fallback unchanged.
- `src/pages/api/share/[token]/comments.ts` — read `locals.user`. When set, insert `authorType: "user"` + `authorUserId`, omit `authorDisplayName`, and stop requiring `name` in the body. Notification `actorUserId` / `actorDisplayName` use the session user, which also keeps the "don't notify yourself" filter working correctly.

The share token is still the credential — a logged-in user from outside the space can use the share link; we just attribute their comment to their account when we know who they are.

## Testing
See test plan in the comment that follows the PR description (also produced for the user in chat).

Closes #127