### PR TITLE
feat(share): add guest navbar with theme toggle on share links

### DIFF
--- a/src/components/GuestHeader.astro
+++ b/src/components/GuestHeader.astro
@@ -1,0 +1,14 @@
+---
+import Logo from "./Logo.astro";
+import { GuestMenu } from "./GuestMenu";
+---
+
+<header class="sticky top-0 z-50 flex h-14 items-center border-b border-border-default bg-bg-primary px-8">
+  <a href="/" class="flex items-center gap-2 text-lg font-bold text-text-primary">
+    <Logo />
+    Quick Cuts
+  </a>
+  <div class="ml-auto flex items-center gap-3">
+    <GuestMenu client:load />
+  </div>
+</header>

--- a/src/components/GuestMenu.tsx
+++ b/src/components/GuestMenu.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  applyTheme,
+  getInitialTheme,
+  setStoredTheme,
+  type Theme,
+} from "../lib/theme";
+
+function SunIcon() {
+  return (
+    <svg
+      className="h-4 w-4 text-text-tertiary"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 3v1.5m0 15V21m8.485-8.485H21m-18 0h.515M18.364 5.636l-1.06 1.06M6.696 17.304l-1.06 1.06m12.728 0l-1.06-1.06M6.696 6.696l-1.06-1.06M16.5 12a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0z"
+      />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      className="h-4 w-4 text-text-tertiary"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z"
+      />
+    </svg>
+  );
+}
+
+function UserCircleIcon() {
+  return (
+    <svg
+      className="h-5 w-5"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M17.982 18.725A7.488 7.488 0 0012 15.75a7.488 7.488 0 00-5.982 2.975m11.963 0a9 9 0 10-11.963 0m11.963 0A8.966 8.966 0 0112 21a8.966 8.966 0 01-5.982-2.275M15 9.75a3 3 0 11-6 0 3 3 0 016 0z"
+      />
+    </svg>
+  );
+}
+
+export function GuestMenu() {
+  const [open, setOpen] = useState(false);
+  const [theme, setThemeState] = useState<Theme>("dark");
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setThemeState(getInitialTheme());
+  }, []);
+
+  const handleToggleTheme = () => {
+    const next: Theme = theme === "dark" ? "light" : "dark";
+    setThemeState(next);
+    setStoredTheme(next);
+    applyTheme(next);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open]);
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Account menu"
+        className="flex h-9 w-9 items-center justify-center rounded-full bg-bg-secondary text-text-secondary transition-all duration-150 hover:bg-bg-tertiary hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-accent-primary focus:ring-offset-2 focus:ring-offset-bg-primary"
+      >
+        <UserCircleIcon />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 z-50 mt-2 w-56 overflow-hidden rounded-xl border border-border-default bg-bg-secondary py-1 shadow-xl"
+        >
+          <button
+            role="menuitem"
+            type="button"
+            onClick={handleToggleTheme}
+            aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+            className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-text-primary transition-colors hover:bg-bg-tertiary"
+          >
+            {theme === "dark" ? <MoonIcon /> : <SunIcon />}
+            <span>{theme === "dark" ? "Dark mode" : "Light mode"}</span>
+          </button>
+          <div className="border-t border-border-default" />
+          <a
+            role="menuitem"
+            href="/login"
+            className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-text-primary transition-colors hover:bg-bg-tertiary"
+          >
+            <svg
+              className="h-4 w-4 text-text-tertiary"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth="1.75"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3 0l3-3m0 0l-3-3m3 3H9"
+              />
+            </svg>
+            Log in
+          </a>
+          <a
+            role="menuitem"
+            href="/register"
+            className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-text-primary transition-colors hover:bg-bg-tertiary"
+          >
+            <svg
+              className="h-4 w-4 text-text-tertiary"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth="1.75"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M19 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zM4 19.235v-.11a6.375 6.375 0 0112.75 0v.109A12.318 12.318 0 0110.374 21c-2.331 0-4.512-.645-6.374-1.766z"
+              />
+            </svg>
+            Sign up
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/s/[token].astro
+++ b/src/pages/s/[token].astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "../../layouts/Layout.astro";
+import GuestHeader from "../../components/GuestHeader.astro";
 import { ShareView } from "../../components/ShareView";
 import { createDb } from "../../db";
 import { shareLinks, scripts, spaces, videos } from "../../db/schema";
@@ -99,6 +100,7 @@ const isPublished = phase === "published";
 ---
 
 <Layout title={video ? video.title : "Link Unavailable"}>
+  {!currentUser && <GuestHeader />}
   {!isRevoked && video && hasVideo && (
     <script src="https://embed.cloudflarestream.com/embed/sdk.latest.js" is:inline></script>
   )}


### PR DESCRIPTION
## Summary
- Add a top navbar to `/s/:token` share pages for unauthenticated viewers
- Logo (top-left) links to the home page; profile icon (top-right) opens a dropdown with light/dark toggle, Log in, and Sign up links
- Theme persistence reuses the existing `src/lib/theme.ts` helpers so guests get the same FOUC-free dark/light behavior as authenticated users

## Changes
- `src/components/GuestMenu.tsx`: new React dropdown with theme toggle + auth links
- `src/components/GuestHeader.astro`: navbar shell that pairs the existing `Logo.astro` with `GuestMenu`
- `src/pages/s/[token].astro`: render `GuestHeader` only when there is no logged-in user, so the existing authenticated header path is unaffected

## Notes
- Scoped to share link pages only. Other guest-facing routes (`/login`, `/register`, `/`) are unchanged.
- Logged-in users viewing a share link see no navbar today; that behavior is unchanged in this PR.

Closes #131