### PR TITLE
refactor(actions): drop project-level dual-writes to videos

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -40,6 +40,7 @@ import { createDirectUpload, deleteVideo as deleteStreamVideo } from "../lib/str
 import { isTranscriptGenerationEnabled } from "../lib/flags";
 import { queueTranscriptForVideo } from "../lib/transcripts";
 import { logProjectActivity } from "../lib/activity";
+import { getMergedVideoById } from "../lib/projects";
 import {
   broadcastPhaseChange,
   broadcastApprovalUpdate,
@@ -137,17 +138,11 @@ export const server = {
         const { id } = input;
         const db = createDb(env.DB);
 
-        const videoResult = await db
-          .select()
-          .from(videos)
-          .where(eq(videos.id, id))
-          .limit(1);
-
-        if (videoResult.length === 0) {
+        const video = await getMergedVideoById(db, id);
+        if (!video) {
           throw new ActionError({ code: "NOT_FOUND", message: "Video not found" });
         }
 
-        const video = videoResult[0];
         const role = await verifySpaceAccess(db, user.id, video.spaceId);
         if (!role) {
           throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
@@ -228,20 +223,9 @@ export const server = {
         }
 
         const now = new Date().toISOString();
-        const versionGroupId = video.versionGroupId || video.id;
-        const projectId = video.projectId || versionGroupId;
+        const projectId = video.projectId || video.versionGroupId || video.id;
 
         if (Object.keys(updates).length > 0) {
-          await db
-            .update(videos)
-            .set({ ...updates, updatedAt: now })
-            .where(
-              and(
-                eq(videos.spaceId, video.spaceId),
-                eq(videos.versionGroupId, versionGroupId),
-              ),
-            );
-
           await db
             .update(projects)
             .set({ ...updates, updatedAt: now })
@@ -260,11 +244,6 @@ export const server = {
         }
 
         if (folderUpdate !== undefined) {
-          await db
-            .update(videos)
-            .set({ folderId: folderUpdate, updatedAt: now })
-            .where(and(eq(videos.spaceId, video.spaceId), eq(videos.versionGroupId, versionGroupId)));
-
           await db
             .update(projects)
             .set({ folderId: folderUpdate, updatedAt: now })
@@ -348,17 +327,11 @@ export const server = {
         const user = requireUser(context);
         const db = createDb(env.DB);
 
-        const videoResult = await db
-          .select()
-          .from(videos)
-          .where(eq(videos.id, id))
-          .limit(1);
-
-        if (videoResult.length === 0) {
+        const video = await getMergedVideoById(db, id);
+        if (!video) {
           throw new ActionError({ code: "NOT_FOUND", message: "Video not found" });
         }
 
-        const video = videoResult[0];
         const role = await verifySpaceAccess(db, user.id, video.spaceId);
         if (!role) {
           throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
@@ -407,11 +380,6 @@ export const server = {
 
         const now = new Date().toISOString();
         const projectId = video.projectId || video.versionGroupId || video.id;
-        await db
-          .update(videos)
-          .set({ phase, updatedAt: now })
-          .where(eq(videos.id, id));
-
         await db
           .update(projects)
           .set({ phase, updatedAt: now })
@@ -781,14 +749,8 @@ export const server = {
           }
         }
 
-        const versionGroupId = video.versionGroupId || video.id;
-        const projectId = video.projectId || versionGroupId;
+        const projectId = video.projectId || video.versionGroupId || video.id;
         const now = new Date().toISOString();
-        await db
-          .update(videos)
-          .set({ folderId, updatedAt: now })
-          .where(and(eq(videos.spaceId, video.spaceId), eq(videos.versionGroupId, versionGroupId)));
-
         await db
           .update(projects)
           .set({ folderId, updatedAt: now })
@@ -898,12 +860,7 @@ export const server = {
         validateUploadFile(fileName, fileSize);
 
         const db = createDb(env.DB);
-        const projectResult = await db
-          .select()
-          .from(videos)
-          .where(eq(videos.id, id))
-          .limit(1);
-        const project = projectResult[0];
+        const project = await getMergedVideoById(db, id);
 
         if (!project) {
           throw new ActionError({ code: "NOT_FOUND", message: "Project not found" });
@@ -955,7 +912,6 @@ export const server = {
           .set({
             uploadedBy: user.id,
             status: "processing",
-            phase: "reviewing_video",
             streamVideoId,
             fileName,
             fileSize,
@@ -1009,12 +965,7 @@ export const server = {
         validateUploadFile(fileName, fileSize);
 
         const db = createDb(env.DB);
-        const baseResult = await db
-          .select()
-          .from(videos)
-          .where(eq(videos.id, id))
-          .limit(1);
-        const baseVideo = baseResult[0];
+        const baseVideo = await getMergedVideoById(db, id);
 
         if (!baseVideo) {
           throw new ActionError({ code: "NOT_FOUND", message: "Video not found" });
@@ -1282,12 +1233,7 @@ export const server = {
         const user = requireUser(context);
         const db = createDb(env.DB);
 
-        const videoResult = await db
-          .select()
-          .from(videos)
-          .where(eq(videos.id, videoId))
-          .limit(1);
-        const video = videoResult[0];
+        const video = await getMergedVideoById(db, videoId);
 
         if (!video) {
           throw new ActionError({ code: "NOT_FOUND", message: "Project not found" });
@@ -1390,24 +1336,20 @@ export const server = {
         const { videoId, text, timestamp, annotation, urgency, phase, textRange } = input;
         const db = createDb(env.DB);
 
-        const videoResult = await db
-          .select()
-          .from(videos)
-          .where(eq(videos.id, videoId))
-          .limit(1);
+        const video = await getMergedVideoById(db, videoId);
 
-        if (videoResult.length === 0) {
+        if (!video) {
           throw new ActionError({ code: "NOT_FOUND", message: "Video not found" });
         }
 
-        if (videoResult[0].phase === "published") {
+        if (video.phase === "published") {
           throw new ActionError({
             code: "FORBIDDEN",
             message: "Cannot comment on published videos",
           });
         }
 
-        const role = await verifySpaceAccess(db, user.id, videoResult[0].spaceId);
+        const role = await verifySpaceAccess(db, user.id, video.spaceId);
         if (!role) {
           throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
         }
@@ -1710,8 +1652,9 @@ export const server = {
         }
 
         const videoRow = await db
-          .select({ spaceId: videos.spaceId, phase: videos.phase })
+          .select({ spaceId: videos.spaceId, phase: projects.phase })
           .from(videos)
+          .innerJoin(projects, eq(projects.id, videos.projectId))
           .where(eq(videos.id, comment[0].videoId))
           .limit(1);
 
@@ -2489,10 +2432,6 @@ export const server = {
 
         const ids = Array.from(idsToDelete);
         const now = new Date().toISOString();
-        await db
-          .update(videos)
-          .set({ folderId: null, updatedAt: now })
-          .where(inArray(videos.folderId, ids));
         await db
           .update(projects)
           .set({ folderId: null, updatedAt: now })

--- a/src/pages/api/share/[token]/comments.ts
+++ b/src/pages/api/share/[token]/comments.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
 import { createDb } from "../../../../db";
-import { shareLinks, comments, users, videos } from "../../../../db/schema";
+import { shareLinks, comments, projects, users, videos } from "../../../../db/schema";
 import { eq, asc, gt, and } from "drizzle-orm";
 import { broadcastNewComment } from "../../../../lib/broadcast";
 import { addReactionSummaries } from "../../../../lib/comments";
@@ -107,8 +107,9 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
   const { text, timestamp, name, parentId, annotation, urgency, phase, textRange } = body;
 
   const videoResult = await db
-    .select({ phase: videos.phase })
+    .select({ phase: projects.phase })
     .from(videos)
+    .innerJoin(projects, eq(projects.id, videos.projectId))
     .where(eq(videos.id, videoId))
     .limit(1);
 


### PR DESCRIPTION
## Summary

Phase 3a of #121. Stops every project-level `db.update(videos)` call
introduced in phase 1's dual-write pass. After this lands, writes for
project-level fields (`title`, `description`, `phase`, `target_date`,
`target_audience`, `hook`, `takeaway1-3`, `primary_cta`, `outro`,
`folder_id`) go **only** to `projects`. Reads already source from
`projects` after phase 2 (#129).

This is a deliberately small step before the final schema rebuild in
phase 3b, so the deploy ordering is safe: the live worker after this
PR neither reads nor writes the duplicated columns, so phase 3b can
drop them without a coordination window.

## Changes

### `src/actions/index.ts`
- `video.update`: removed cascading `db.update(videos).set({...})`
  for project-level fields and the cascading folder-only write.
- `video.setPhase`: dropped the `db.update(videos).set({ phase })`;
  phase is owned by projects.
- `video.move`: dropped the cascading folder write to videos.
- `video.uploadFirstCut`: dropped `phase: "reviewing_video"` from the
  videos update; projects already takes that write.
- `folder.delete` cascade: removed the `update(videos).set({folderId:
  null})` call; only `projects.folder_id` is nulled.
- Action handlers that previously gated on `video.phase === "published"`
  by reading the videos row (`video.update`, `setPhase`,
  `uploadFirstCut`, `uploadVersion`, `script.update`, `comment.create`)
  now use `getMergedVideoById` from `lib/projects.ts` which reads
  phase from `projects`. With dual-writes gone, `videos.phase` would
  drift the moment this deploys — these gates need the project value.

### `src/pages/api/share/[token]/comments.ts`
- The "cannot comment on published" gate joins `projects` for the
  authoritative phase.

### Inserts left alone
The two `db.insert(videos).values({ ... })` calls in `createProject`
and `uploadVersion` still pass `title`, `description`, `folder_id`,
and `phase` because those columns are `NOT NULL` in the schema.
Phase 3b's table rebuild drops them; this PR can't remove them yet
without violating the constraint.

## Why this is safe to deploy without a migration

- All read sites already read project-level fields from `projects`
  (phase 2).
- After this PR, no write site touches the duplicated columns on
  `videos` (except inserts, which only write at row creation).
- The duplicated columns become "write-only-dead" — populated at
  insert, never read, never updated. They'll drift, but invisibly.
- Phase 3b drops them in a single SQLite table rebuild.

## What's NOT in this PR

- Schema changes — duplicated columns and `version_group_id` remain
  in `videos`. Phase 3b removes them.
- `NOT NULL` on `videos.project_id` — same.
- Splitting `validation.ts` into `projectSchema` + `videoVersionSchema`
  — phase 3b.
- Switching the remaining `versionGroupId`-based queries
  (`uploadVersion` sibling lookup, etc.) to `projectId` — phase 3b
  with the column drop.

## Testing

See manual test plan in chat.

Refs #121 (phase 3a of 3)