### PR TITLE
feat(actions): auto-advance project phase on final approval

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -514,6 +514,37 @@ export const server = {
           createdAt: now,
         });
 
+        if (status.isApproved) {
+          const projectId = video.projectId || video.versionGroupId || video.id;
+          const projectRow = await db
+            .select({ phase: projects.phase })
+            .from(projects)
+            .where(eq(projects.id, projectId))
+            .limit(1);
+          const currentPhase = projectRow[0]?.phase;
+          if (currentPhase === "reviewing_video") {
+            await db
+              .update(projects)
+              .set({ phase: "video_approved", updatedAt: now })
+              .where(eq(projects.id, projectId));
+
+            await logProjectActivity(db, {
+              videoId: id,
+              actorUserId: user.id,
+              actorDisplayName: user.name,
+              type: "phase.changed",
+              data: { from: currentPhase, to: "video_approved", auto: true },
+              createdAt: now,
+            });
+
+            await broadcastPhaseChange(env, id, {
+              videoId: id,
+              phase: "video_approved",
+              changedBy: user.name,
+            });
+          }
+        }
+
         return { approvalStatus: status };
       },
     }),
@@ -559,6 +590,7 @@ export const server = {
         const status = await getApprovalStatus(db, id, video.spaceId);
         await broadcastApprovalUpdate(env, id, status);
 
+        const now = new Date().toISOString();
         await logProjectActivity(db, {
           videoId: id,
           actorUserId: user.id,
@@ -568,7 +600,39 @@ export const server = {
             approverUserId: user.id,
             approverDisplayName: user.name,
           },
+          createdAt: now,
         });
+
+        if (!status.isApproved) {
+          const projectId = video.projectId || video.versionGroupId || video.id;
+          const projectRow = await db
+            .select({ phase: projects.phase })
+            .from(projects)
+            .where(eq(projects.id, projectId))
+            .limit(1);
+          const currentPhase = projectRow[0]?.phase;
+          if (currentPhase === "video_approved") {
+            await db
+              .update(projects)
+              .set({ phase: "reviewing_video", updatedAt: now })
+              .where(eq(projects.id, projectId));
+
+            await logProjectActivity(db, {
+              videoId: id,
+              actorUserId: user.id,
+              actorDisplayName: user.name,
+              type: "phase.changed",
+              data: { from: currentPhase, to: "reviewing_video", auto: true },
+              createdAt: now,
+            });
+
+            await broadcastPhaseChange(env, id, {
+              videoId: id,
+              phase: "reviewing_video",
+              changedBy: user.name,
+            });
+          }
+        }
 
         return { approvalStatus: status };
       },

--- a/src/lib/approvals.ts
+++ b/src/lib/approvals.ts
@@ -18,12 +18,17 @@ export interface ApprovalStatus {
 }
 
 /**
- * Compute a video's approval state on demand. There is no stored review
- * status on the video — the state is always derived from the count of rows
- * in the `approvals` table compared against the space's `requiredApprovals`
- * threshold. This is the single source of truth for whether a video is
- * "approved" and is used by API responses, the video detail UI, dashboard
- * badges, and the share-link view.
+ * Compute a video's approval state on demand from the count of rows in the
+ * `approvals` table compared against the space's `requiredApprovals`
+ * threshold. This is the single source of truth for `isApproved` and is
+ * used by API responses, the video detail UI, dashboard badges, and the
+ * share-link view.
+ *
+ * Side-effect to be aware of: the `video.approve` / `video.unapprove`
+ * actions auto-advance `projects.phase` between `reviewing_video` and
+ * `video_approved` based on this status. The phase is therefore a
+ * persisted reflection of approval state for those two phases, but
+ * `getApprovalStatus` itself remains a pure read.
  *
  * Note: when `requiredApprovals` is 0 the workflow is disabled. We still
  * return the (possibly stale) approval rows in case the threshold was


### PR DESCRIPTION
## Summary
- When the final required approval is recorded on a video, the project's `phase` automatically flips from `reviewing_video` → `video_approved`. Symmetric on revoke: dropping below threshold reverts to `reviewing_video`.
- Reuses the existing `phase.changed` activity type (with `auto: true` in the data payload) and `broadcastPhaseChange` so the pipeline board, video detail view, and phase dropdown update in real time.
- Only triggers transitions to/from `video_approved` ↔ `reviewing_video` — never touches `published`, `creating_script`, or `reviewing_script`.

## Changes
- `src/actions/index.ts` — `video.approve` and `video.unapprove` handlers now read the project's current phase after the approval is recorded and, when appropriate, update `projects.phase`, log activity, and broadcast.
- `src/lib/approvals.ts` — updated the doc-comment on `getApprovalStatus` to note the side-effect that approve/unapprove now drives the auto-phase transition.

## Testing
See test plan in the PR conversation. Build (`pnpm build`) passes locally.

Closes #134