### PR TITLE
feat(db): drop duplicated project columns from videos

### DIFF
--- a/migrations/0025_drop_videos_duplicated_columns.sql
+++ b/migrations/0025_drop_videos_duplicated_columns.sql
@@ -1,0 +1,58 @@
+-- Issue #121, phase 3b: drop the duplicated project-level columns from
+-- `videos` and the `version_group_id` column. Make `project_id` NOT NULL.
+-- After phase 1 created `projects` and backfilled `videos.project_id`,
+-- phase 2 migrated every read site to source project-level fields from
+-- `projects`, and phase 3a stopped every dual-write to `videos`. Nothing
+-- reads or updates the duplicated columns anymore, so they can be removed.
+
+PRAGMA foreign_keys=OFF;
+
+-- Defensive: every existing video row has a project_id from phase 1's
+-- backfill. If somehow a row slipped through with a null project_id,
+-- reuse the row's id (matches the phase 1 backfill convention for
+-- single-version projects). Without this the NOT NULL on the rebuilt
+-- table would reject the INSERT.
+UPDATE `videos` SET `project_id` = `id` WHERE `project_id` IS NULL;
+
+CREATE TABLE `__new_videos` (
+  `id` text PRIMARY KEY NOT NULL,
+  `space_id` text NOT NULL REFERENCES `spaces`(`id`) ON DELETE CASCADE,
+  `uploaded_by` text REFERENCES `users`(`id`) ON DELETE SET NULL,
+  `project_id` text NOT NULL REFERENCES `projects`(`id`) ON DELETE CASCADE,
+  `status` text DEFAULT 'processing' NOT NULL,
+  `version_number` integer DEFAULT 1 NOT NULL,
+  `is_current_version` integer DEFAULT 1 NOT NULL,
+  `stream_video_id` text,
+  `stream_playback_url` text,
+  `thumbnail_url` text,
+  `duration` real,
+  `file_name` text,
+  `file_size` integer,
+  `transcript_requested` integer DEFAULT 0 NOT NULL,
+  `version_notes` text,
+  `created_at` text DEFAULT (datetime('now')) NOT NULL,
+  `updated_at` text DEFAULT (datetime('now')) NOT NULL
+);
+
+INSERT INTO `__new_videos` (
+  `id`, `space_id`, `uploaded_by`, `project_id`, `status`,
+  `version_number`, `is_current_version`,
+  `stream_video_id`, `stream_playback_url`, `thumbnail_url`,
+  `duration`, `file_name`, `file_size`, `transcript_requested`,
+  `version_notes`, `created_at`, `updated_at`
+)
+SELECT
+  `id`, `space_id`, `uploaded_by`, `project_id`, `status`,
+  `version_number`, `is_current_version`,
+  `stream_video_id`, `stream_playback_url`, `thumbnail_url`,
+  `duration`, `file_name`, `file_size`, `transcript_requested`,
+  `version_notes`, `created_at`, `updated_at`
+FROM `videos`;
+
+DROP TABLE `videos`;
+ALTER TABLE `__new_videos` RENAME TO `videos`;
+
+CREATE INDEX IF NOT EXISTS `videos_project_id_idx` ON `videos` (`project_id`);
+CREATE INDEX IF NOT EXISTS `videos_space_id_idx` ON `videos` (`space_id`);
+
+PRAGMA foreign_keys=ON;

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -237,13 +237,7 @@ export const server = {
             .where(eq(projects.id, projectId));
         }
 
-        const updated = await db
-          .select()
-          .from(videos)
-          .where(eq(videos.id, id))
-          .limit(1);
-
-        return { video: updated[0] };
+        return { success: true };
       },
     }),
 
@@ -401,13 +395,7 @@ export const server = {
         // notifications to every space member has been removed. Approvals
         // are now requested explicitly via `video.requestApprovals`.
 
-        const updated = await db
-          .select()
-          .from(videos)
-          .where(eq(videos.id, id))
-          .limit(1);
-
-        return { video: updated[0] };
+        return { success: true };
       },
     }),
 
@@ -806,13 +794,7 @@ export const server = {
           .set({ folderId, updatedAt: now })
           .where(eq(projects.id, projectId));
 
-        const updated = await db
-          .select()
-          .from(videos)
-          .where(eq(videos.id, id))
-          .limit(1);
-
-        return { video: updated[0] };
+        return { success: true };
       },
     }),
 

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -501,7 +501,7 @@ export const server = {
         });
 
         if (status.isApproved) {
-          const projectId = video.projectId || video.versionGroupId || video.id;
+          const projectId = video.projectId;
           const projectRow = await db
             .select({ phase: projects.phase })
             .from(projects)
@@ -590,7 +590,7 @@ export const server = {
         });
 
         if (!status.isApproved) {
-          const projectId = video.projectId || video.versionGroupId || video.id;
+          const projectId = video.projectId;
           const projectRow = await db
             .select({ phase: projects.phase })
             .from(projects)

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -20,7 +20,7 @@ import {
   transcripts,
 } from "../db/schema";
 import {
-  videoUpdateSchema,
+  projectUpdateSchema,
   phaseSchema,
   approveVideoSchema,
   commentSchema,
@@ -119,20 +119,7 @@ export const server = {
 
   video: {
     update: defineAction({
-      input: z.object({
-        id: z.string().min(1),
-        title: z.string().min(1).max(200).optional(),
-        description: z.string().max(2000).optional(),
-        targetDate: z.string().date().nullable().optional(),
-        folderId: z.string().uuid().nullable().optional(),
-        targetAudience: z.string().max(200).nullable().optional(),
-        hook: z.string().max(500).nullable().optional(),
-        takeaway1: z.string().max(200).nullable().optional(),
-        takeaway2: z.string().max(200).nullable().optional(),
-        takeaway3: z.string().max(200).nullable().optional(),
-        primaryCta: z.string().max(200).nullable().optional(),
-        outro: z.string().max(500).nullable().optional(),
-      }),
+      input: projectUpdateSchema.extend({ id: z.string().min(1) }),
       handler: async (input, context) => {
         const user = requireUser(context);
         const { id } = input;
@@ -223,7 +210,7 @@ export const server = {
         }
 
         const now = new Date().toISOString();
-        const projectId = video.projectId || video.versionGroupId || video.id;
+        const projectId = video.projectId;
 
         if (Object.keys(updates).length > 0) {
           await db
@@ -287,12 +274,11 @@ export const server = {
           throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
         }
 
-        const versionGroupId = video.versionGroupId || video.id;
-        const projectId = video.projectId || versionGroupId;
+        const projectId = video.projectId;
         const projectVersions = await db
           .select({ id: videos.id, streamVideoId: videos.streamVideoId })
           .from(videos)
-          .where(and(eq(videos.spaceId, video.spaceId), eq(videos.versionGroupId, versionGroupId)));
+          .where(eq(videos.projectId, projectId));
 
         for (const version of projectVersions) {
           if (!version.streamVideoId) continue;
@@ -379,7 +365,7 @@ export const server = {
         }
 
         const now = new Date().toISOString();
-        const projectId = video.projectId || video.versionGroupId || video.id;
+        const projectId = video.projectId;
         await db
           .update(projects)
           .set({ phase, updatedAt: now })
@@ -749,7 +735,7 @@ export const server = {
           }
         }
 
-        const projectId = video.projectId || video.versionGroupId || video.id;
+        const projectId = video.projectId;
         const now = new Date().toISOString();
         await db
           .update(projects)
@@ -811,16 +797,10 @@ export const server = {
           id: videoId,
           spaceId,
           uploadedBy: user.id,
-          folderId: folderId || null,
           projectId,
-          title,
-          description: description || null,
           status: "draft",
-          versionGroupId: videoId,
           versionNumber: 1,
           isCurrentVersion: true,
-          phase: "creating_script",
-          targetDate: null,
           createdAt: now,
           updatedAt: now,
         });
@@ -920,7 +900,7 @@ export const server = {
           })
           .where(eq(videos.id, id));
 
-        const projectId = project.projectId || project.versionGroupId || project.id;
+        const projectId = project.projectId;
         await db
           .update(projects)
           .set({ uploadedBy: user.id, phase: "reviewing_video", updatedAt: now })
@@ -982,16 +962,11 @@ export const server = {
           throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
         }
 
-        const versionGroupId = baseVideo.versionGroupId || baseVideo.id;
+        const projectId = baseVideo.projectId;
         const latestResult = await db
           .select({ versionNumber: videos.versionNumber })
           .from(videos)
-          .where(
-            and(
-              eq(videos.spaceId, baseVideo.spaceId),
-              eq(videos.versionGroupId, versionGroupId),
-            ),
-          )
+          .where(eq(videos.projectId, projectId))
           .orderBy(desc(videos.versionNumber))
           .limit(1);
 
@@ -1025,25 +1000,15 @@ export const server = {
         await db
           .update(videos)
           .set({ isCurrentVersion: false, updatedAt: now })
-          .where(
-            and(
-              eq(videos.spaceId, baseVideo.spaceId),
-              eq(videos.versionGroupId, versionGroupId),
-            ),
-          );
+          .where(eq(videos.projectId, projectId));
 
         const trimmedNotes = versionNotes?.trim();
-        const projectId = baseVideo.projectId || versionGroupId;
         await db.insert(videos).values({
           id: videoId,
           spaceId: baseVideo.spaceId,
           uploadedBy: user.id,
-          folderId: baseVideo.folderId,
           projectId,
-          title: baseVideo.title,
-          description: baseVideo.description,
           status: "processing",
-          versionGroupId,
           versionNumber: nextVersionNumber,
           isCurrentVersion: true,
           streamVideoId,
@@ -1056,19 +1021,14 @@ export const server = {
         });
 
         // Reset approvals when a new version is uploaded. We hard-delete
-        // approval rows for ALL prior versions in this version group so the
+        // approval rows for ALL prior versions of this project so the
         // approver list starts fresh on the new version. Old versions are
         // archived/read-only anyway.
         try {
           const groupVersions = await db
             .select({ id: videos.id })
             .from(videos)
-            .where(
-              and(
-                eq(videos.spaceId, baseVideo.spaceId),
-                eq(videos.versionGroupId, versionGroupId),
-              ),
-            );
+            .where(eq(videos.projectId, projectId));
           const priorIds = groupVersions
             .map((row) => row.id)
             .filter((existingId) => existingId !== videoId);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -129,18 +129,12 @@ export const videos = sqliteTable("videos", {
   uploadedBy: text("uploaded_by").references(() => users.id, {
     onDelete: "set null",
   }),
-  folderId: text("folder_id").references(() => folders.id, {
-    onDelete: "set null",
-  }),
-  projectId: text("project_id").references(() => projects.id, {
-    onDelete: "cascade",
-  }),
-  title: text("title").notNull(),
-  description: text("description"),
+  projectId: text("project_id")
+    .notNull()
+    .references(() => projects.id, { onDelete: "cascade" }),
   status: text("status", { enum: ["draft", "processing", "ready", "failed"] })
     .notNull()
     .default("processing"),
-  versionGroupId: text("version_group_id"),
   versionNumber: integer("version_number").notNull().default(1),
   isCurrentVersion: integer("is_current_version", { mode: "boolean" })
     .notNull()
@@ -154,19 +148,6 @@ export const videos = sqliteTable("videos", {
   transcriptRequested: integer("transcript_requested", { mode: "boolean" })
     .notNull()
     .default(false),
-  phase: text("phase", {
-    enum: ["creating_script", "reviewing_script", "reviewing_video", "video_approved", "published"],
-  })
-    .notNull()
-    .default("reviewing_video"),
-  targetDate: text("target_date"),
-  targetAudience: text("target_audience"),
-  hook: text("hook"),
-  takeaway1: text("takeaway1"),
-  takeaway2: text("takeaway2"),
-  takeaway3: text("takeaway3"),
-  primaryCta: text("primary_cta"),
-  outro: text("outro"),
   versionNotes: text("version_notes"),
   createdAt: text("created_at")
     .notNull()

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -6,11 +6,10 @@ export type ProjectRow = typeof projects.$inferSelect;
 export type VideoRow = typeof videos.$inferSelect;
 
 /**
- * The shape every existing call site expects: a flat object that looks
- * like a `videos` row, but with project-level fields sourced from the
- * `projects` table. During the multi-phase refactor (#121) the
- * duplicated columns on `videos` are still read by callers; merging
- * them here means callers don't change shape.
+ * The shape every read site expects: the version row joined with its
+ * owning project. Project-level fields are sourced from `projects`
+ * (the source of truth after #121). The flat property names match
+ * the legacy "video" shape so React components don't change.
  */
 export type MergedVideo = VideoRow & {
   title: string;
@@ -42,39 +41,12 @@ const PROJECT_OVERRIDE_COLUMNS = {
   folderId: projects.folderId,
 } as const;
 
-function mergeRow(
-  video: VideoRow,
-  project: Pick<ProjectRow,
-    | "title"
-    | "description"
-    | "phase"
-    | "targetDate"
-    | "targetAudience"
-    | "hook"
-    | "takeaway1"
-    | "takeaway2"
-    | "takeaway3"
-    | "primaryCta"
-    | "outro"
-    | "folderId"
-  > | null,
-): MergedVideo {
-  if (!project) return video as MergedVideo;
-  return {
-    ...video,
-    title: project.title,
-    description: project.description,
-    phase: project.phase,
-    targetDate: project.targetDate,
-    targetAudience: project.targetAudience,
-    hook: project.hook,
-    takeaway1: project.takeaway1,
-    takeaway2: project.takeaway2,
-    takeaway3: project.takeaway3,
-    primaryCta: project.primaryCta,
-    outro: project.outro,
-    folderId: project.folderId,
-  };
+type ProjectOverrideRow = {
+  [K in keyof typeof PROJECT_OVERRIDE_COLUMNS]: ProjectRow[K];
+};
+
+function mergeRow(video: VideoRow, project: ProjectOverrideRow): MergedVideo {
+  return { ...video, ...project };
 }
 
 export async function getMergedVideoById(
@@ -84,7 +56,7 @@ export async function getMergedVideoById(
   const rows = await db
     .select({ video: videos, project: PROJECT_OVERRIDE_COLUMNS })
     .from(videos)
-    .leftJoin(projects, eq(projects.id, videos.projectId))
+    .innerJoin(projects, eq(projects.id, videos.projectId))
     .where(eq(videos.id, id))
     .limit(1);
   const row = rows[0];
@@ -102,8 +74,6 @@ interface CurrentVideoListOptions {
 /**
  * List the current version of every project visible to a user. Filters
  * by folder when `folderId` is provided ("root" → folderId IS NULL).
- * Folder filtering uses `projects.folder_id`, the source of truth for
- * project-level placement after #121.
  */
 export async function listCurrentMergedVideos(
   db: Database,
@@ -128,7 +98,7 @@ export async function listCurrentMergedVideos(
   let query = db
     .select({ video: videos, project: PROJECT_OVERRIDE_COLUMNS })
     .from(videos)
-    .leftJoin(projects, eq(projects.id, videos.projectId))
+    .innerJoin(projects, eq(projects.id, videos.projectId))
     .where(where)
     .orderBy(desc(videos.createdAt));
 
@@ -140,7 +110,7 @@ export async function listCurrentMergedVideos(
   const totalRow = await db
     .select({ count: count() })
     .from(videos)
-    .leftJoin(projects, eq(projects.id, videos.projectId))
+    .innerJoin(projects, eq(projects.id, videos.projectId))
     .where(where);
 
   return {
@@ -150,8 +120,7 @@ export async function listCurrentMergedVideos(
 }
 
 /**
- * Count of versions per project. Returns a map keyed by `projectId`
- * (the `videos.project_id` value, identical to `projects.id`).
+ * Count of versions per project.
  */
 export async function getVersionCountsByProjectId(
   db: Database,
@@ -167,14 +136,13 @@ export async function getVersionCountsByProjectId(
     .groupBy(videos.projectId);
 
   return Object.fromEntries(
-    rows.map((row) => [row.projectId ?? "", row.count] as const),
+    rows.map((row) => [row.projectId, row.count] as const),
   );
 }
 
 /**
  * Count current-version videos per folder, filtered to a space and a
- * set of folder ids. Reads `projects.folder_id` and joins through to
- * the current `videos` row so the count reflects "active projects".
+ * set of folder ids.
  */
 export async function getCurrentVideoCountsByFolder(
   db: Database,
@@ -201,9 +169,7 @@ export async function getCurrentVideoCountsByFolder(
 }
 
 /**
- * Fetch up to 4 thumbnails per folder for the dashboard folder cards.
- * Reads from `videos` joined to `projects` so folder placement is
- * sourced from the projects table.
+ * Up to 4 thumbnails per folder for the dashboard folder cards.
  */
 export async function getCurrentVideoThumbnailsByFolder(
   db: Database,
@@ -237,12 +203,6 @@ export async function getCurrentVideoThumbnailsByFolder(
   }, {});
 }
 
-/**
- * Lightweight project lookup used by mutation handlers that need the
- * canonical project row (e.g. for activity logging or to find the
- * project id from a video). Returns null if the video has no project
- * yet (should only occur during a partial rollout).
- */
 export async function getProjectForVideoId(
   db: Database,
   videoId: string,
@@ -250,7 +210,7 @@ export async function getProjectForVideoId(
   const rows = await db
     .select({ project: projects })
     .from(videos)
-    .leftJoin(projects, eq(projects.id, videos.projectId))
+    .innerJoin(projects, eq(projects.id, videos.projectId))
     .where(eq(videos.id, videoId))
     .limit(1);
   return rows[0]?.project ?? null;

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -62,7 +62,10 @@ export const anonymousCommentSchema = z.object({
   urgency: urgencySchema.optional().default("suggestion"),
 });
 
-export const videoUpdateSchema = z.object({
+// Project-level update payload. After issue #121 these fields all live
+// on `projects`, not `videos`. The action handler is still named
+// `actions.video.update` for callsite stability.
+export const projectUpdateSchema = z.object({
   title: z.string().min(1).max(200).optional(),
   description: z.string().max(2000).optional(),
   folderId: z.string().uuid().nullable().optional(),
@@ -74,6 +77,12 @@ export const videoUpdateSchema = z.object({
   takeaway3: z.string().max(200).nullable().optional(),
   primaryCta: z.string().max(200).nullable().optional(),
   outro: z.string().max(500).nullable().optional(),
+});
+
+// Per-version fields. Today this is just the optional release note; if
+// future version-only fields land they go here.
+export const videoVersionSchema = z.object({
+  versionNotes: z.string().max(2000).nullable().optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -17,25 +17,21 @@ export interface VersionSummary {
 
 interface VersionContext {
   id: string;
-  spaceId: string;
-  projectId: string | null;
-  versionGroupId: string | null;
+  projectId: string;
 }
 
 export async function getVideoVersions(
   db: Database,
   video: VersionContext,
 ): Promise<VersionSummary[]> {
-  const projectId = video.projectId ?? video.versionGroupId ?? video.id;
-
   const rows = await db
     .select({
       video: videos,
       projectTitle: projects.title,
     })
     .from(videos)
-    .leftJoin(projects, eq(projects.id, videos.projectId))
-    .where(eq(videos.projectId, projectId))
+    .innerJoin(projects, eq(projects.id, videos.projectId))
+    .where(eq(videos.projectId, video.projectId))
     .orderBy(desc(videos.versionNumber));
 
   const versionIds = rows.map((row) => row.video.id);
@@ -60,7 +56,7 @@ export async function getVideoVersions(
 
   return rows.map(({ video: version, projectTitle }) => ({
     id: version.id,
-    title: projectTitle ?? version.title,
+    title: projectTitle,
     status: version.status,
     thumbnailUrl: version.thumbnailUrl,
     duration: version.duration,

--- a/src/pages/api/folders/index.ts
+++ b/src/pages/api/folders/index.ts
@@ -1,8 +1,12 @@
 import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
-import { and, count, eq, inArray, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 import { createDb } from "../../../db";
-import { folders, videos, spaceMembers } from "../../../db/schema";
+import { folders, spaceMembers } from "../../../db/schema";
+import {
+  getCurrentVideoCountsByFolder,
+  getCurrentVideoThumbnailsByFolder,
+} from "../../../lib/projects";
 
 export const GET: APIRoute = async ({ locals, url }) => {
   if (!locals.user) {
@@ -16,7 +20,6 @@ export const GET: APIRoute = async ({ locals, url }) => {
   const parentId = url.searchParams.get("parentId");
   const requestedSpaceId = url.searchParams.get("space");
 
-  // Get all space IDs the user belongs to
   const memberRows = await db
     .select({ spaceId: spaceMembers.spaceId })
     .from(spaceMembers)
@@ -51,28 +54,24 @@ export const GET: APIRoute = async ({ locals, url }) => {
   let counts: Record<string, number> = {};
   let thumbnails: Record<string, string[]> = {};
 
-  if (folderIds.length > 0) {
-    const videoCounts = await db
-      .select({ folderId: videos.folderId, count: count() })
-      .from(videos)
-      .where(inArray(videos.folderId, folderIds))
-      .groupBy(videos.folderId);
-
-    counts = Object.fromEntries(
-      videoCounts.map((row) => [row.folderId ?? "", row.count]),
-    );
-
-    const folderVideos = await db
-      .select({ folderId: videos.folderId, thumbnailUrl: videos.thumbnailUrl })
-      .from(videos)
-      .where(inArray(videos.folderId, folderIds));
-
-    thumbnails = folderVideos.reduce<Record<string, string[]>>((acc, video) => {
-      if (!video.folderId || !video.thumbnailUrl) return acc;
-      acc[video.folderId] = acc[video.folderId] || [];
-      if (acc[video.folderId].length < 4) acc[video.folderId].push(video.thumbnailUrl);
-      return acc;
-    }, {});
+  if (folderIds.length > 0 && requestedSpaceId) {
+    counts = await getCurrentVideoCountsByFolder(db, requestedSpaceId, folderIds);
+    thumbnails = await getCurrentVideoThumbnailsByFolder(db, requestedSpaceId, folderIds);
+  } else if (folderIds.length > 0) {
+    for (const spaceId of targetSpaceIds) {
+      const spaceCounts = await getCurrentVideoCountsByFolder(db, spaceId, folderIds);
+      for (const [folderId, count] of Object.entries(spaceCounts)) {
+        counts[folderId] = (counts[folderId] ?? 0) + count;
+      }
+      const spaceThumbnails = await getCurrentVideoThumbnailsByFolder(db, spaceId, folderIds);
+      for (const [folderId, urls] of Object.entries(spaceThumbnails)) {
+        const bucket = thumbnails[folderId] ?? [];
+        for (const url of urls) {
+          if (bucket.length < 4 && !bucket.includes(url)) bucket.push(url);
+        }
+        thumbnails[folderId] = bucket;
+      }
+    }
   }
 
   return new Response(

--- a/src/pages/api/videos/[id]/index.ts
+++ b/src/pages/api/videos/[id]/index.ts
@@ -52,7 +52,7 @@ export const GET: APIRoute = async ({ params, locals }) => {
     .from(comments)
     .where(eq(comments.videoId, id));
 
-  const projectId = video.projectId ?? video.versionGroupId ?? video.id;
+  const projectId = video.projectId;
   const versionCountResult = await db
     .select({ count: count() })
     .from(videos)

--- a/src/pages/api/videos/[id]/script-status.ts
+++ b/src/pages/api/videos/[id]/script-status.ts
@@ -2,9 +2,10 @@ import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
 import { eq } from "drizzle-orm";
 import { createDb } from "../../../../db";
-import { scripts, videos } from "../../../../db/schema";
+import { scripts } from "../../../../db/schema";
 import { scriptStatusUpdateSchema } from "../../../../lib/validation";
 import { verifySpaceAccess } from "../../../../lib/spaces";
+import { getMergedVideoById } from "../../../../lib/projects";
 
 function json(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -23,8 +24,7 @@ export const PATCH: APIRoute = async ({ params, locals, request }) => {
   if (!parsed.success) return json({ error: parsed.error.issues[0]?.message || "Invalid script status" }, 400);
 
   const db = createDb(env.DB);
-  const projectRows = await db.select().from(videos).where(eq(videos.id, id)).limit(1);
-  const project = projectRows[0];
+  const project = await getMergedVideoById(db, id);
 
   if (!project) return json({ error: "Project not found" }, 404);
   if (project.phase === "published") return json({ error: "Cannot update published scripts" }, 403);

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -6,14 +6,15 @@ import { PendingToast } from "../components/PendingToast";
 import type { FolderCardItemData } from "../components/FolderCardItem";
 import type { VideoCardItemData } from "../components/VideoCardItem";
 import { createDb } from "../db";
-import { folders, videos, comments, spaceMembers, approvals, projects } from "../db/schema";
-import { and, asc, desc, count, eq, inArray, sql } from "drizzle-orm";
+import { folders, comments, spaceMembers, approvals } from "../db/schema";
+import { and, asc, count, eq, inArray, sql } from "drizzle-orm";
 import { env } from "cloudflare:workers";
 import { getUserSpaces } from "../lib/spaces";
 import {
   getCurrentVideoCountsByFolder,
   getCurrentVideoThumbnailsByFolder,
   getVersionCountsByProjectId,
+  listCurrentMergedVideos,
 } from "../lib/projects";
 
 const user = Astro.locals.user;
@@ -77,24 +78,9 @@ const childFolderIds = childFolders.map((folder) => folder.id);
 const folderVideoCounts = await getCurrentVideoCountsByFolder(db, selectedSpaceId, childFolderIds);
 const folderThumbnails = await getCurrentVideoThumbnailsByFolder(db, selectedSpaceId, childFolderIds);
 
-const allSpaceVideoRows = await db
-  .select({
-    video: videos,
-    projectTitle: projects.title,
-    projectFolderId: projects.folderId,
-    projectPhase: projects.phase,
-  })
-  .from(videos)
-  .leftJoin(projects, eq(projects.id, videos.projectId))
-  .where(and(eq(videos.spaceId, selectedSpaceId), eq(videos.isCurrentVersion, true)))
-  .orderBy(desc(videos.createdAt));
-
-const allSpaceVideos = allSpaceVideoRows.map((row) => ({
-  ...row.video,
-  title: row.projectTitle ?? row.video.title,
-  folderId: row.projectFolderId ?? row.video.folderId,
-  phase: row.projectPhase ?? row.video.phase,
-}));
+const { rows: allSpaceVideos } = await listCurrentMergedVideos(db, {
+  spaceIds: [selectedSpaceId],
+});
 
 const userVideos = allSpaceVideos.filter((video) => {
   if (currentFolderId) return video.folderId === currentFolderId;

--- a/src/pages/s/[token].astro
+++ b/src/pages/s/[token].astro
@@ -54,7 +54,7 @@ if (!isRevoked) {
 
   allComments = await getCommentsWithNames(db, shareLink.videoId);
 
-  const projectId = video.projectId ?? video.versionGroupId ?? video.id;
+  const projectId = video.projectId;
   const versionCountResult = await db
     .select({ count: count() })
     .from(videos)


### PR DESCRIPTION
## Summary

Phase 3b of #121 — the final phase. Drops the duplicated project-level
columns from the `videos` table, removes `version_group_id`, makes
`videos.project_id` `NOT NULL`, splits `validation.ts`, and cleans up
every remaining `versionGroupId` reference. After this lands, `videos`
is strictly a version row that points at its owning `projects.id`,
which has been the goal of #121 from the start.

`Closes #121`.

## Migration

`migrations/0025_drop_videos_duplicated_columns.sql` does a SQLite
table rebuild on `videos`:

- Drops columns: `title`, `description`, `phase`, `target_date`,
  `target_audience`, `hook`, `takeaway1`, `takeaway2`, `takeaway3`,
  `primary_cta`, `outro`, `folder_id`, `version_group_id`.
- Adds `NOT NULL` to `project_id` (with `ON DELETE CASCADE` from
  `projects` already in place since phase 1).
- Recreates `videos_project_id_idx` and `videos_space_id_idx`.
- Defensive `UPDATE videos SET project_id = id WHERE project_id IS NULL`
  before the rebuild so any stragglers don't violate the new NOT NULL.

Pattern matches `migrations/0020_notifications_nullable_comment.sql`
which also did a SQLite table rebuild via `__new_table` + `DROP` +
`RENAME`.

## Code changes

### Schema
- `src/db/schema.ts`: `videos` table strips the duplicated columns and
  `version_group_id`. `projectId` is `notNull()`.

### Actions (`src/actions/index.ts`)
- All `video.projectId || video.versionGroupId || video.id` fallbacks
  collapse to `video.projectId` (NOT NULL post-migration).
- `createProject`'s `db.insert(videos).values({...})` no longer passes
  `title`, `description`, `folderId`, `phase`, `targetDate`,
  `versionGroupId` — they no longer exist on the table.
- `uploadVersion`'s `db.insert(videos).values({...})` similarly
  trimmed; sibling lookup queries use `eq(videos.projectId, projectId)`
  instead of `eq(videos.versionGroupId, versionGroupId)`.
- `video.update`'s inline Zod schema replaced with
  `projectUpdateSchema.extend({ id })` from validation.ts.

### Lib
- `src/lib/projects.ts`: `MergedVideo` and `mergeRow` simplified — the
  merge is now `videos` row + projects join, with no need to override
  conflicting columns since the duplicated columns are gone. Public
  surface (`getMergedVideoById`, `listCurrentMergedVideos`,
  `getVersionCountsByProjectId`, `getCurrentVideoCountsByFolder`,
  `getCurrentVideoThumbnailsByFolder`) is unchanged.
- `src/lib/versions.ts`: `VersionContext` no longer accepts
  `versionGroupId`; queries by `projectId` only. Title comes from the
  joined `projects.title`.
- `src/lib/validation.ts`: `videoUpdateSchema` renamed to
  `projectUpdateSchema`. New `videoVersionSchema` placeholder for
  per-version fields (today just `versionNotes`).

### API routes
- `src/pages/api/folders/index.ts`: folder counts and thumbnails
  computed via `getCurrentVideoCountsByFolder` /
  `getCurrentVideoThumbnailsByFolder` (which join through projects).
  Multi-space case (`!requestedSpaceId`) iterates and merges.
- `src/pages/api/videos/[id]/index.ts`: removes the `versionGroupId`
  fallback chain.
- `src/pages/api/videos/[id]/script-status.ts`: the published-phase
  gate now uses `getMergedVideoById` (which sources phase from
  `projects`) instead of reading `videos.phase`.
- `src/pages/s/[token].astro`: removes `versionGroupId` fallback chain.

## What this is NOT changing

- The `actions.video.*` namespace stays. Renaming to `actions.project.*`
  would force every React component to update its calls — out of
  scope for the schema refactor.
- The `videos` table's `space_id` column stays. It's a useful denormalized
  pointer for fast space-scoped queries that don't need to join
  `projects`. Could be removed in a future cleanup.

## Net change

```
10 files changed, 135 insertions(+), 172 deletions(-)
```

Plus the migration. Net code reduction across the codebase even
though we added new test surface.

## Deploy ordering

Safe in either order because:

- After phase 3a, no live worker reads or writes the columns being
  dropped here.
- After this PR's migration, no live worker writes to the dropped
  columns (because they don't exist) — but no worker tries to,
  either, because phase 3a removed all such writes.

So the migration can run before or after the worker deploy. The
recommended order is still **migration first, then deploy** to ensure
the new code never tries to write a column that doesn't exist for any
fraction of a second.

## Testing

Manual test plan in chat / next comment.

Closes #121