### PR TITLE
feat(brainstorm): team idea backlog with promote-to-project flow

### DIFF
--- a/migrations/0026_create_brainstorms.sql
+++ b/migrations/0026_create_brainstorms.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS `brainstorms` (
+  `id` text PRIMARY KEY NOT NULL,
+  `space_id` text NOT NULL REFERENCES `spaces`(`id`) ON DELETE CASCADE,
+  `author_user_id` text REFERENCES `users`(`id`) ON DELETE SET NULL,
+  `author_display_name` text NOT NULL,
+  `title` text NOT NULL,
+  `notes` text NOT NULL DEFAULT '',
+  `status` text NOT NULL DEFAULT 'open',
+  `promoted_project_id` text REFERENCES `projects`(`id`) ON DELETE SET NULL,
+  `created_at` text NOT NULL DEFAULT (datetime('now')),
+  `updated_at` text NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS `brainstorms_space_status_created_idx`
+  ON `brainstorms` (`space_id`, `status`, `created_at`);
+
+CREATE TABLE IF NOT EXISTS `brainstorm_reactions` (
+  `id` text PRIMARY KEY NOT NULL,
+  `brainstorm_id` text NOT NULL REFERENCES `brainstorms`(`id`) ON DELETE CASCADE,
+  `reactor_user_id` text NOT NULL REFERENCES `users`(`id`) ON DELETE CASCADE,
+  `reactor_display_name` text,
+  `emoji` text NOT NULL,
+  `created_at` text NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS `brainstorm_reactions_unique`
+  ON `brainstorm_reactions` (`brainstorm_id`, `reactor_user_id`, `emoji`);
+
+CREATE INDEX IF NOT EXISTS `brainstorm_reactions_brainstorm_idx`
+  ON `brainstorm_reactions` (`brainstorm_id`);

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -13,6 +13,7 @@ import {
   spaceInvites,
   approvals,
   approvalRequests,
+  brainstorms,
   comments,
   projects,
   scripts,
@@ -23,6 +24,11 @@ import {
   projectUpdateSchema,
   phaseSchema,
   approveVideoSchema,
+  brainstormCreateSchema,
+  brainstormUpdateSchema,
+  brainstormStatusUpdateSchema,
+  brainstormReactionToggleSchema,
+  brainstormMarkPromotedSchema,
   commentSchema,
   spaceUpdateSchema,
   inviteCreateSchema,
@@ -40,7 +46,7 @@ import { createDirectUpload, deleteVideo as deleteStreamVideo } from "../lib/str
 import { isTranscriptGenerationEnabled } from "../lib/flags";
 import { queueTranscriptForVideo } from "../lib/transcripts";
 import { logProjectActivity } from "../lib/activity";
-import { getMergedVideoById } from "../lib/projects";
+import { getMergedVideoById, createProjectInSpace } from "../lib/projects";
 import {
   broadcastPhaseChange,
   broadcastApprovalUpdate,
@@ -53,6 +59,10 @@ import {
   isCommentReactionEmoji,
   toggleCommentReaction,
 } from "../lib/comments";
+import {
+  getBrainstormById,
+  toggleBrainstormReaction,
+} from "../lib/brainstorms";
 import {
   createCommentNotifications,
   createTargetedApprovalRequestNotifications,
@@ -810,68 +820,25 @@ export const server = {
           throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
         }
 
-        if (folderId) {
-          const folder = await db
-            .select({ id: folders.id })
-            .from(folders)
-            .where(and(eq(folders.id, folderId), eq(folders.spaceId, spaceId)))
-            .limit(1);
-
-          if (folder.length === 0) {
+        try {
+          const { videoId } = await createProjectInSpace(db, {
+            spaceId,
+            folderId: folderId ?? null,
+            title,
+            description,
+            user,
+          });
+          return { videoId };
+        } catch (error) {
+          if (error instanceof Error && error.message === "FOLDER_NOT_FOUND") {
             throw new ActionError({ code: "NOT_FOUND", message: "Folder not found" });
           }
+          console.error("[video.createProject] failed:", error);
+          throw new ActionError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "We couldn't create the project. Please try again.",
+          });
         }
-
-        const videoId = crypto.randomUUID();
-        const projectId = videoId;
-        const now = new Date().toISOString();
-
-        await db.insert(projects).values({
-          id: projectId,
-          spaceId,
-          uploadedBy: user.id,
-          folderId: folderId || null,
-          title,
-          description: description || null,
-          phase: "creating_script",
-          targetDate: null,
-          createdAt: now,
-          updatedAt: now,
-        });
-
-        await db.insert(videos).values({
-          id: videoId,
-          spaceId,
-          uploadedBy: user.id,
-          projectId,
-          status: "draft",
-          versionNumber: 1,
-          isCurrentVersion: true,
-          createdAt: now,
-          updatedAt: now,
-        });
-
-        await db.insert(scripts).values({
-          id: crypto.randomUUID(),
-          videoId,
-          content: "",
-          plainText: "",
-          status: "writing",
-          createdBy: user.id,
-          createdAt: now,
-          updatedAt: now,
-        });
-
-        await logProjectActivity(db, {
-          videoId,
-          actorUserId: user.id,
-          actorDisplayName: user.name,
-          type: "project.created",
-          data: { title },
-          createdAt: now,
-        });
-
-        return { videoId };
       },
     }),
 
@@ -2443,6 +2410,305 @@ export const server = {
           .set({ folderId: null, updatedAt: now })
           .where(inArray(projects.folderId, ids));
         await db.delete(folders).where(inArray(folders.id, ids));
+
+        return { success: true };
+      },
+    }),
+  },
+
+  brainstorm: {
+    create: defineAction({
+      input: brainstormCreateSchema,
+      handler: async (input, context) => {
+        const user = requireUser(context);
+        const db = createDb(env.DB);
+
+        const role = await verifySpaceAccess(db, user.id, input.spaceId);
+        if (!role) {
+          throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
+        }
+
+        const id = crypto.randomUUID();
+        const now = new Date().toISOString();
+        try {
+          await db.insert(brainstorms).values({
+            id,
+            spaceId: input.spaceId,
+            authorUserId: user.id,
+            authorDisplayName: user.name,
+            title: input.title.trim(),
+            notes: input.notes?.trim() ?? "",
+            status: "open",
+            promotedProjectId: null,
+            createdAt: now,
+            updatedAt: now,
+          });
+        } catch (error) {
+          console.error("[brainstorm.create] insert failed:", error);
+          throw new ActionError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "We couldn't save the idea. Please try again.",
+          });
+        }
+
+        return { id };
+      },
+    }),
+
+    update: defineAction({
+      input: brainstormUpdateSchema,
+      handler: async (input, context) => {
+        const user = requireUser(context);
+        const db = createDb(env.DB);
+
+        const current = await getBrainstormById(db, input.id);
+        if (!current) {
+          throw new ActionError({ code: "NOT_FOUND", message: "Idea not found" });
+        }
+
+        const role = await verifySpaceAccess(db, user.id, current.spaceId);
+        if (!role) {
+          throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
+        }
+
+        const isAuthor = current.authorUserId === user.id;
+        const isOwner = role === "owner";
+        if (!isAuthor && !isOwner) {
+          throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
+        }
+
+        const patch: Partial<typeof brainstorms.$inferInsert> = {
+          updatedAt: new Date().toISOString(),
+        };
+        if (input.title !== undefined) patch.title = input.title.trim();
+        if (input.notes !== undefined) patch.notes = input.notes;
+
+        try {
+          await db
+            .update(brainstorms)
+            .set(patch)
+            .where(eq(brainstorms.id, input.id));
+        } catch (error) {
+          console.error("[brainstorm.update] update failed:", error);
+          throw new ActionError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "We couldn't update the idea. Please try again.",
+          });
+        }
+
+        return { success: true };
+      },
+    }),
+
+    archive: defineAction({
+      input: brainstormStatusUpdateSchema,
+      handler: async ({ id }, context) => {
+        const user = requireUser(context);
+        const db = createDb(env.DB);
+
+        const current = await getBrainstormById(db, id);
+        if (!current) {
+          throw new ActionError({ code: "NOT_FOUND", message: "Idea not found" });
+        }
+
+        const role = await verifySpaceAccess(db, user.id, current.spaceId);
+        if (!role) {
+          throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
+        }
+
+        const isAuthor = current.authorUserId === user.id;
+        const isOwner = role === "owner";
+        if (!isAuthor && !isOwner) {
+          throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
+        }
+
+        if (current.status === "promoted") {
+          throw new ActionError({
+            code: "BAD_REQUEST",
+            message: "Promoted ideas can't be archived.",
+          });
+        }
+
+        try {
+          await db
+            .update(brainstorms)
+            .set({ status: "archived", updatedAt: new Date().toISOString() })
+            .where(eq(brainstorms.id, id));
+        } catch (error) {
+          console.error("[brainstorm.archive] update failed:", error);
+          throw new ActionError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "We couldn't archive the idea. Please try again.",
+          });
+        }
+
+        return { success: true };
+      },
+    }),
+
+    unarchive: defineAction({
+      input: brainstormStatusUpdateSchema,
+      handler: async ({ id }, context) => {
+        const user = requireUser(context);
+        const db = createDb(env.DB);
+
+        const current = await getBrainstormById(db, id);
+        if (!current) {
+          throw new ActionError({ code: "NOT_FOUND", message: "Idea not found" });
+        }
+
+        const role = await verifySpaceAccess(db, user.id, current.spaceId);
+        if (!role) {
+          throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
+        }
+
+        const isAuthor = current.authorUserId === user.id;
+        const isOwner = role === "owner";
+        if (!isAuthor && !isOwner) {
+          throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
+        }
+
+        if (current.status !== "archived") {
+          return { success: true };
+        }
+
+        try {
+          await db
+            .update(brainstorms)
+            .set({ status: "open", updatedAt: new Date().toISOString() })
+            .where(eq(brainstorms.id, id));
+        } catch (error) {
+          console.error("[brainstorm.unarchive] update failed:", error);
+          throw new ActionError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "We couldn't restore the idea. Please try again.",
+          });
+        }
+
+        return { success: true };
+      },
+    }),
+
+    delete: defineAction({
+      input: brainstormStatusUpdateSchema,
+      handler: async ({ id }, context) => {
+        const user = requireUser(context);
+        const db = createDb(env.DB);
+
+        const current = await getBrainstormById(db, id);
+        if (!current) {
+          return { success: true };
+        }
+
+        const role = await verifySpaceAccess(db, user.id, current.spaceId);
+        if (!role) {
+          throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
+        }
+
+        const isAuthor = current.authorUserId === user.id;
+        const isOwner = role === "owner";
+        if (!isAuthor && !isOwner) {
+          throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
+        }
+
+        try {
+          await db.delete(brainstorms).where(eq(brainstorms.id, id));
+        } catch (error) {
+          console.error("[brainstorm.delete] delete failed:", error);
+          throw new ActionError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "We couldn't delete the idea. Please try again.",
+          });
+        }
+
+        return { success: true };
+      },
+    }),
+
+    toggleReaction: defineAction({
+      input: brainstormReactionToggleSchema,
+      handler: async ({ brainstormId, emoji }, context) => {
+        const user = requireUser(context);
+        const db = createDb(env.DB);
+
+        const current = await getBrainstormById(db, brainstormId);
+        if (!current) {
+          throw new ActionError({ code: "NOT_FOUND", message: "Idea not found" });
+        }
+
+        const role = await verifySpaceAccess(db, user.id, current.spaceId);
+        if (!role) {
+          throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
+        }
+
+        try {
+          const reactions = await toggleBrainstormReaction(db, brainstormId, emoji, {
+            userId: user.id,
+            name: user.name,
+          });
+          return { reactions };
+        } catch (error) {
+          console.error("[brainstorm.toggleReaction] failed:", error);
+          throw new ActionError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "We couldn't save your reaction. Please try again.",
+          });
+        }
+      },
+    }),
+
+    markPromoted: defineAction({
+      input: brainstormMarkPromotedSchema,
+      handler: async ({ id, videoId }, context) => {
+        const user = requireUser(context);
+        const db = createDb(env.DB);
+
+        const current = await getBrainstormById(db, id);
+        if (!current) {
+          throw new ActionError({ code: "NOT_FOUND", message: "Idea not found" });
+        }
+
+        const role = await verifySpaceAccess(db, user.id, current.spaceId);
+        if (!role) {
+          throw new ActionError({ code: "FORBIDDEN", message: "Forbidden" });
+        }
+
+        if (current.status === "promoted") {
+          throw new ActionError({
+            code: "BAD_REQUEST",
+            message: "This idea is already linked to a project.",
+          });
+        }
+
+        const linkedVideo = await db
+          .select({ projectId: videos.projectId, spaceId: videos.spaceId })
+          .from(videos)
+          .where(eq(videos.id, videoId))
+          .limit(1);
+
+        if (linkedVideo.length === 0 || linkedVideo[0].spaceId !== current.spaceId) {
+          throw new ActionError({
+            code: "BAD_REQUEST",
+            message: "That project doesn't belong to this space.",
+          });
+        }
+
+        try {
+          await db
+            .update(brainstorms)
+            .set({
+              status: "promoted",
+              promotedProjectId: linkedVideo[0].projectId,
+              updatedAt: new Date().toISOString(),
+            })
+            .where(eq(brainstorms.id, id));
+        } catch (error) {
+          console.error("[brainstorm.markPromoted] update failed:", error);
+          throw new ActionError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "We couldn't link the idea to the project. Please try again.",
+          });
+        }
 
         return { success: true };
       },

--- a/src/components/BrainstormBoard.tsx
+++ b/src/components/BrainstormBoard.tsx
@@ -1,0 +1,196 @@
+import { useMemo, useState } from "react";
+import { Button } from "./Button";
+import { BrainstormCard } from "./BrainstormCard";
+import { NewBrainstormDialog } from "./NewBrainstormDialog";
+import { NewProjectDialog } from "./NewProjectDialog";
+import type {
+  BrainstormItem,
+  BrainstormStatus,
+  FolderTreeOption,
+} from "../types";
+
+interface BrainstormBoardProps {
+  spaceId: string;
+  currentUserId: string;
+  isOwner: boolean;
+  initialBrainstorms: BrainstormItem[];
+  folders: FolderTreeOption[];
+}
+
+const STATUS_FILTERS: Array<{ key: BrainstormStatus; label: string }> = [
+  { key: "open", label: "Open" },
+  { key: "promoted", label: "Promoted" },
+  { key: "archived", label: "Archived" },
+];
+
+function sortBrainstorms(items: BrainstormItem[]): BrainstormItem[] {
+  return [...items].sort((a, b) => {
+    if (b.reactionCount !== a.reactionCount) {
+      return b.reactionCount - a.reactionCount;
+    }
+    if (a.createdAt < b.createdAt) return 1;
+    if (a.createdAt > b.createdAt) return -1;
+    return 0;
+  });
+}
+
+export function BrainstormBoard({
+  spaceId,
+  currentUserId,
+  isOwner,
+  initialBrainstorms,
+  folders,
+}: BrainstormBoardProps) {
+  const [brainstorms, setBrainstorms] = useState<BrainstormItem[]>(initialBrainstorms);
+  const [activeStatus, setActiveStatus] = useState<BrainstormStatus>("open");
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editing, setEditing] = useState<BrainstormItem | null>(null);
+  const [promoting, setPromoting] = useState<BrainstormItem | null>(null);
+
+  const counts = useMemo(() => {
+    const out: Record<BrainstormStatus, number> = { open: 0, promoted: 0, archived: 0 };
+    for (const item of brainstorms) {
+      out[item.status] += 1;
+    }
+    return out;
+  }, [brainstorms]);
+
+  const visible = useMemo(
+    () => sortBrainstorms(brainstorms.filter((item) => item.status === activeStatus)),
+    [brainstorms, activeStatus],
+  );
+
+  const handleSaved = () => {
+    setCreateOpen(false);
+    setEditing(null);
+    window.location.reload();
+  };
+
+  const handleChanged = (next: BrainstormItem) => {
+    setBrainstorms((prev) => prev.map((item) => (item.id === next.id ? next : item)));
+  };
+
+  const handleDeleted = (id: string) => {
+    setBrainstorms((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  const emptyCopy = (() => {
+    if (activeStatus === "open") {
+      return {
+        heading: "No ideas yet",
+        body: "Capture something your team should make a video about.",
+      };
+    }
+    if (activeStatus === "promoted") {
+      return {
+        heading: "Nothing promoted yet",
+        body: "Once an idea becomes a project, it'll show up here.",
+      };
+    }
+    return {
+      heading: "Nothing archived",
+      body: "Archived ideas will appear here.",
+    };
+  })();
+
+  return (
+    <div>
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-1">
+          {STATUS_FILTERS.map((filter) => {
+            const isActive = filter.key === activeStatus;
+            return (
+              <button
+                key={filter.key}
+                type="button"
+                onClick={() => setActiveStatus(filter.key)}
+                className={`inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium transition-colors ${
+                  isActive
+                    ? "bg-accent-primary/15 text-text-primary"
+                    : "text-text-secondary hover:bg-bg-tertiary"
+                }`}
+                aria-pressed={isActive}
+              >
+                {filter.label}
+                <span
+                  className={`inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-xs ${
+                    isActive
+                      ? "bg-accent-primary text-white"
+                      : "bg-bg-tertiary text-text-tertiary"
+                  }`}
+                >
+                  {counts[filter.key]}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+        <Button
+          onClick={() => setCreateOpen(true)}
+          aria-label="Capture a new idea"
+          icon={(
+            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+          )}
+        >
+          New Idea
+        </Button>
+      </div>
+
+      {visible.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border-default bg-bg-secondary px-6 py-16 text-center">
+          <h2 className="text-lg font-semibold text-text-primary">{emptyCopy.heading}</h2>
+          <p className="mt-2 text-sm text-text-secondary">{emptyCopy.body}</p>
+          {activeStatus === "open" && (
+            <div className="mt-5">
+              <Button onClick={() => setCreateOpen(true)}>Add the first idea</Button>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          {visible.map((brainstorm) => (
+            <BrainstormCard
+              key={brainstorm.id}
+              brainstorm={brainstorm}
+              spaceId={spaceId}
+              currentUserId={currentUserId}
+              isOwner={isOwner}
+              onEdit={(item) => setEditing(item)}
+              onPromote={(item) => setPromoting(item)}
+              onChanged={handleChanged}
+              onDeleted={handleDeleted}
+            />
+          ))}
+        </div>
+      )}
+
+      <NewBrainstormDialog
+        isOpen={createOpen || editing !== null}
+        spaceId={spaceId}
+        editingId={editing?.id}
+        initialTitle={editing?.title}
+        initialNotes={editing?.notes}
+        onClose={() => {
+          setCreateOpen(false);
+          setEditing(null);
+        }}
+        onSaved={handleSaved}
+      />
+
+      <NewProjectDialog
+        spaceId={spaceId}
+        folderId={null}
+        folders={folders}
+        triggerHidden
+        isOpenExternal={promoting !== null}
+        onClose={() => setPromoting(null)}
+        initialTitle={promoting?.title ?? ""}
+        initialDescription={promoting?.notes ?? ""}
+        brainstormId={promoting?.id}
+      />
+    </div>
+  );
+}

--- a/src/components/BrainstormCard.tsx
+++ b/src/components/BrainstormCard.tsx
@@ -1,0 +1,345 @@
+import { useEffect, useRef, useState } from "react";
+import { actions } from "astro:actions";
+import { ConfirmDialog } from "./ConfirmDialog";
+import { friendlyActionErrorMessage } from "../lib/errors";
+import { relativeTime } from "../lib/time";
+import {
+  BRAINSTORM_REACTION_EMOJIS,
+  type BrainstormItem,
+  type BrainstormReactionEmoji,
+  type BrainstormReactionSummary,
+} from "../types";
+
+interface BrainstormCardProps {
+  brainstorm: BrainstormItem;
+  spaceId: string;
+  currentUserId: string;
+  isOwner: boolean;
+  onEdit: (brainstorm: BrainstormItem) => void;
+  onPromote: (brainstorm: BrainstormItem) => void;
+  onChanged: (brainstorm: BrainstormItem) => void;
+  onDeleted: (id: string) => void;
+}
+
+const STATUS_LABELS: Record<BrainstormItem["status"], string> = {
+  open: "Open",
+  promoted: "Promoted",
+  archived: "Archived",
+};
+
+const STATUS_CLASSES: Record<BrainstormItem["status"], string> = {
+  open: "bg-accent-primary/15 text-accent-primary",
+  promoted: "bg-accent-success/15 text-accent-success",
+  archived: "bg-bg-tertiary text-text-tertiary",
+};
+
+const NOTES_CLAMP_LIMIT = 240;
+
+export function BrainstormCard({
+  brainstorm,
+  spaceId,
+  currentUserId,
+  isOwner,
+  onEdit,
+  onPromote,
+  onChanged,
+  onDeleted,
+}: BrainstormCardProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [notesExpanded, setNotesExpanded] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handler = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [menuOpen]);
+
+  const isAuthor = brainstorm.authorUserId === currentUserId;
+  const canManage = isAuthor || isOwner;
+  const isPromoted = brainstorm.status === "promoted";
+  const isArchived = brainstorm.status === "archived";
+
+  const showLongNotes = brainstorm.notes.length > NOTES_CLAMP_LIMIT;
+  const visibleNotes =
+    notesExpanded || !showLongNotes
+      ? brainstorm.notes
+      : `${brainstorm.notes.slice(0, NOTES_CLAMP_LIMIT)}…`;
+
+  const reactionFor = (emoji: BrainstormReactionEmoji): BrainstormReactionSummary | undefined =>
+    brainstorm.reactions.find((r) => r.emoji === emoji);
+
+  const handleReact = async (emoji: BrainstormReactionEmoji) => {
+    if (busy) return;
+    setBusy(true);
+    setError("");
+    try {
+      const { data, error: actionError } = await actions.brainstorm.toggleReaction({
+        brainstormId: brainstorm.id,
+        emoji,
+      });
+      if (actionError) throw new Error(actionError.message || "");
+      const reactions = (data?.reactions ?? []) as BrainstormReactionSummary[];
+      const reactionCount = reactions.reduce((sum, r) => sum + r.count, 0);
+      onChanged({ ...brainstorm, reactions, reactionCount });
+    } catch (err) {
+      const raw = err instanceof Error ? err.message : "";
+      setError(
+        friendlyActionErrorMessage(
+          raw,
+          "We couldn't save your reaction. Please try again.",
+        ),
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleArchive = async () => {
+    setMenuOpen(false);
+    setBusy(true);
+    setError("");
+    try {
+      const { error: actionError } = await actions.brainstorm.archive({ id: brainstorm.id });
+      if (actionError) throw new Error(actionError.message || "");
+      onChanged({ ...brainstorm, status: "archived" });
+    } catch (err) {
+      const raw = err instanceof Error ? err.message : "";
+      setError(
+        friendlyActionErrorMessage(
+          raw,
+          "We couldn't archive the idea. Please try again.",
+        ),
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleUnarchive = async () => {
+    setMenuOpen(false);
+    setBusy(true);
+    setError("");
+    try {
+      const { error: actionError } = await actions.brainstorm.unarchive({ id: brainstorm.id });
+      if (actionError) throw new Error(actionError.message || "");
+      onChanged({ ...brainstorm, status: "open" });
+    } catch (err) {
+      const raw = err instanceof Error ? err.message : "";
+      setError(
+        friendlyActionErrorMessage(
+          raw,
+          "We couldn't restore the idea. Please try again.",
+        ),
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const confirmDelete = async () => {
+    setDeleting(true);
+    try {
+      const { error: actionError } = await actions.brainstorm.delete({ id: brainstorm.id });
+      if (actionError) throw new Error(actionError.message || "");
+      onDeleted(brainstorm.id);
+      setConfirmOpen(false);
+    } catch (err) {
+      const raw = err instanceof Error ? err.message : "";
+      setError(
+        friendlyActionErrorMessage(
+          raw,
+          "We couldn't delete the idea. Please try again.",
+        ),
+      );
+      setConfirmOpen(false);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <article className="rounded-xl border border-border-default bg-bg-secondary p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-base font-semibold text-text-primary break-words">
+              {brainstorm.title}
+            </h3>
+            <span
+              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_CLASSES[brainstorm.status]}`}
+            >
+              {STATUS_LABELS[brainstorm.status]}
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-text-tertiary">
+            {brainstorm.authorDisplayName} · {relativeTime(brainstorm.createdAt)}
+          </p>
+        </div>
+
+        {canManage && (
+          <div className="relative" ref={menuRef}>
+            <button
+              type="button"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                setMenuOpen((open) => !open);
+              }}
+              disabled={busy}
+              aria-haspopup="menu"
+              aria-expanded={menuOpen}
+              aria-label="Idea options"
+              className="flex h-8 w-8 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-bg-tertiary hover:text-text-primary disabled:opacity-50"
+            >
+              <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path d="M10 6a2 2 0 110-4 2 2 0 010 4zm0 6a2 2 0 110-4 2 2 0 010 4zm0 6a2 2 0 110-4 2 2 0 010 4z" />
+              </svg>
+            </button>
+
+            {menuOpen && (
+              <div
+                role="menu"
+                className="absolute right-0 z-30 mt-1 w-44 overflow-hidden rounded-lg border border-border-default bg-bg-secondary py-1 shadow-lg"
+              >
+                <button
+                  role="menuitem"
+                  onClick={() => {
+                    setMenuOpen(false);
+                    onEdit(brainstorm);
+                  }}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-text-primary transition-colors hover:bg-bg-tertiary"
+                >
+                  Edit
+                </button>
+                {!isPromoted && !isArchived && (
+                  <button
+                    role="menuitem"
+                    onClick={handleArchive}
+                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-text-primary transition-colors hover:bg-bg-tertiary"
+                  >
+                    Archive
+                  </button>
+                )}
+                {isArchived && (
+                  <button
+                    role="menuitem"
+                    onClick={handleUnarchive}
+                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-text-primary transition-colors hover:bg-bg-tertiary"
+                  >
+                    Unarchive
+                  </button>
+                )}
+                <button
+                  role="menuitem"
+                  onClick={() => {
+                    setMenuOpen(false);
+                    setConfirmOpen(true);
+                  }}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-accent-danger transition-colors hover:bg-bg-tertiary"
+                >
+                  Delete
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {brainstorm.notes && (
+        <div className="mt-3 whitespace-pre-wrap break-words text-sm text-text-secondary">
+          {visibleNotes}
+          {showLongNotes && (
+            <button
+              type="button"
+              onClick={() => setNotesExpanded((v) => !v)}
+              className="ml-1 text-xs font-medium text-accent-primary hover:text-accent-hover"
+            >
+              {notesExpanded ? "Show less" : "Show more"}
+            </button>
+          )}
+        </div>
+      )}
+
+      {isPromoted && brainstorm.promotedProjectId && (
+        <a
+          href={`/videos/${brainstorm.promotedProjectId}?space=${spaceId}`}
+          className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-accent-primary hover:text-accent-hover"
+        >
+          View project
+          {brainstorm.promotedProjectTitle ? `: ${brainstorm.promotedProjectTitle}` : ""}
+          <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <line x1="5" y1="12" x2="19" y2="12" />
+            <polyline points="12 5 19 12 12 19" />
+          </svg>
+        </a>
+      )}
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        {BRAINSTORM_REACTION_EMOJIS.map((emoji) => {
+          const summary = reactionFor(emoji);
+          const count = summary?.count ?? 0;
+          const reactedByMe = summary?.reactedByMe ?? false;
+          return (
+            <button
+              key={emoji}
+              type="button"
+              onClick={() => handleReact(emoji)}
+              disabled={busy}
+              className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs transition-colors disabled:opacity-50 ${
+                reactedByMe
+                  ? "border-accent-primary bg-accent-primary/15 text-text-primary"
+                  : "border-border-default text-text-secondary hover:bg-bg-tertiary"
+              }`}
+              aria-pressed={reactedByMe}
+              aria-label={`React with ${emoji}`}
+            >
+              <span aria-hidden="true">{emoji}</span>
+              {count > 0 && <span>{count}</span>}
+            </button>
+          );
+        })}
+
+        {!isPromoted && !isArchived && (
+          <button
+            type="button"
+            onClick={() => onPromote(brainstorm)}
+            className="ml-auto inline-flex items-center gap-1 rounded-lg bg-accent-primary px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-accent-hover"
+          >
+            <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="m22 8-6 4 6 4V8Z" />
+              <rect x="2" y="6" width="14" height="12" rx="2" ry="2" />
+            </svg>
+            Create Project
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="mt-3 rounded-lg bg-accent-danger/15 px-3 py-2 text-xs break-words text-accent-danger">
+          {error}
+        </div>
+      )}
+
+      <ConfirmDialog
+        isOpen={confirmOpen}
+        title="Delete this idea?"
+        description="This idea and all its reactions will be removed. This action cannot be undone."
+        confirmLabel="Delete idea"
+        variant="danger"
+        loading={deleting}
+        onConfirm={confirmDelete}
+        onCancel={() => setConfirmOpen(false)}
+      />
+    </article>
+  );
+}

--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -12,7 +12,7 @@ const { path } = Astro.props;
 ---
 
 <nav class="mb-3 flex flex-wrap items-center gap-2 text-sm text-text-tertiary" aria-label="Breadcrumb">
-  <a href="/dashboard" class="transition-colors hover:text-text-primary">All Videos</a>
+  <a href="/dashboard" class="transition-colors hover:text-text-primary">Projects</a>
   {path.map((crumb, index) => (
     <>
       <span>/</span>

--- a/src/components/DashboardGrid.tsx
+++ b/src/components/DashboardGrid.tsx
@@ -102,20 +102,11 @@ export function DashboardGrid({
       <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
         <div className="flex-1" />
         <div className="flex items-center gap-2 sm:gap-3">
-          <a
-            href={`/spaces/${spaceId}/calendar?space=${spaceId}`}
-            className="inline-flex items-center gap-2 rounded-lg border border-border-default px-3 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary sm:px-5"
-            aria-label="Open launch calendar"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <rect x="3" y="4" width="18" height="18" rx="2" />
-              <line x1="16" y1="2" x2="16" y2="6" />
-              <line x1="8" y1="2" x2="8" y2="6" />
-              <line x1="3" y1="10" x2="21" y2="10" />
-            </svg>
-            <span className="hidden sm:inline">Calendar</span>
-          </a>
-          <NewProjectDialog folderId={currentFolderId} spaceId={spaceId} />
+          <NewProjectDialog
+            folderId={currentFolderId}
+            spaceId={spaceId}
+            folders={allFolders}
+          />
           <CreateFolderDialog
             parentId={currentFolderId}
             spaceId={spaceId}

--- a/src/components/FolderCardMenu.tsx
+++ b/src/components/FolderCardMenu.tsx
@@ -230,7 +230,7 @@ export function FolderCardMenu({
       <ConfirmDialog
         isOpen={confirmOpen}
         title="Delete this folder?"
-        description="Videos inside this folder will move back to All Videos. Nested folders will also be removed."
+        description="Projects inside this folder will move back to the space root. Nested folders will also be removed."
         confirmLabel="Delete folder"
         variant="danger"
         loading={saving}

--- a/src/components/MoveToFolderDialog.tsx
+++ b/src/components/MoveToFolderDialog.tsx
@@ -114,7 +114,7 @@ export function MoveToFolderDialog({
 
   const dropdownOptions: DropdownOption[] = useMemo(
     () => [
-      { value: "root", label: "All Videos" },
+      { value: "root", label: "Projects" },
       ...treeOptions.map((folder) => ({
         value: folder.id,
         label: `${"  ".repeat(folder.depth)}${folder.depth > 0 ? "- " : ""}${folder.name}`,

--- a/src/components/NewBrainstormDialog.tsx
+++ b/src/components/NewBrainstormDialog.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useId, useState } from "react";
+import { actions } from "astro:actions";
+import { Button } from "./Button";
+import { Modal } from "./Modal";
+import { friendlyActionErrorMessage } from "../lib/errors";
+
+interface NewBrainstormDialogProps {
+  isOpen: boolean;
+  spaceId: string;
+  initialTitle?: string;
+  initialNotes?: string;
+  editingId?: string;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+export function NewBrainstormDialog({
+  isOpen,
+  spaceId,
+  initialTitle = "",
+  initialNotes = "",
+  editingId,
+  onClose,
+  onSaved,
+}: NewBrainstormDialogProps) {
+  const headingId = useId();
+  const [title, setTitle] = useState(initialTitle);
+  const [notes, setNotes] = useState(initialNotes);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setTitle(initialTitle);
+    setNotes(initialNotes);
+    setError("");
+  }, [isOpen, initialTitle, initialNotes]);
+
+  const close = () => {
+    if (saving) return;
+    onClose();
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!title.trim()) return;
+
+    setSaving(true);
+    setError("");
+
+    try {
+      if (editingId) {
+        const { error: actionError } = await actions.brainstorm.update({
+          id: editingId,
+          title: title.trim(),
+          notes: notes.trim(),
+        });
+        if (actionError) throw new Error(actionError.message || "");
+      } else {
+        const { error: actionError } = await actions.brainstorm.create({
+          spaceId,
+          title: title.trim(),
+          notes: notes.trim(),
+        });
+        if (actionError) throw new Error(actionError.message || "");
+      }
+      onSaved();
+      setSaving(false);
+    } catch (err) {
+      const raw = err instanceof Error ? err.message : "";
+      setError(
+        friendlyActionErrorMessage(
+          raw,
+          editingId
+            ? "We couldn't save your changes. Please try again."
+            : "We couldn't save the idea. Please try again.",
+        ),
+      );
+      setSaving(false);
+    }
+  };
+
+  const isEditing = Boolean(editingId);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={close}
+      closeOnBackdropClick={!saving}
+      closeOnEscape={!saving}
+      showCloseButton={!saving}
+      ariaLabelledBy={headingId}
+      size="md"
+    >
+      <h2 id={headingId} className="text-lg font-semibold text-text-primary">
+        {isEditing ? "Edit idea" : "Capture an idea"}
+      </h2>
+      <p className="mt-1 text-sm text-text-secondary">
+        Capture something your team should make a video about. You can promote it to a project anytime.
+      </p>
+
+      <form onSubmit={handleSubmit} className="mt-5 space-y-4">
+        <div>
+          <label className="mb-1 block text-sm font-medium text-text-secondary" htmlFor="brainstorm-title">
+            Title
+          </label>
+          <input
+            id="brainstorm-title"
+            type="text"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            disabled={saving}
+            autoFocus
+            maxLength={200}
+            className="w-full rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent-primary focus:outline-none disabled:opacity-50"
+            placeholder="Workers vs Lambda showdown"
+          />
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-text-secondary" htmlFor="brainstorm-notes">
+            Notes <span className="text-text-tertiary">(optional)</span>
+          </label>
+          <textarea
+            id="brainstorm-notes"
+            value={notes}
+            onChange={(event) => setNotes(event.target.value)}
+            disabled={saving}
+            rows={6}
+            maxLength={5000}
+            className="w-full resize-none rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent-primary focus:outline-none disabled:opacity-50"
+            placeholder="Why this matters, the angle, who it's for..."
+          />
+          <p className="mt-1 text-right text-xs text-text-tertiary">
+            {notes.length} / 5000
+          </p>
+        </div>
+
+        {error && (
+          <div className="rounded-lg bg-accent-danger/15 px-4 py-2 text-sm break-words text-accent-danger">
+            {error}
+          </div>
+        )}
+
+        <div className="flex gap-3">
+          <Button
+            variant="secondary"
+            onClick={close}
+            disabled={saving}
+            className="flex-1"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            disabled={saving || !title.trim()}
+            className="flex-1"
+          >
+            {saving ? "Saving..." : isEditing ? "Save" : "Add idea"}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -1,26 +1,98 @@
-import { useId, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import { actions } from "astro:actions";
 import { Button } from "./Button";
 import { Modal } from "./Modal";
+import { Dropdown, type DropdownOption } from "./Dropdown";
+import { friendlyActionErrorMessage } from "../lib/errors";
+import type { FolderTreeOption } from "../types";
 
 interface NewProjectDialogProps {
   spaceId: string;
   folderId?: string | null;
+  folders: FolderTreeOption[];
+  initialTitle?: string;
+  initialDescription?: string;
+  brainstormId?: string;
+  triggerLabel?: string;
+  triggerHidden?: boolean;
+  isOpenExternal?: boolean;
+  onClose?: () => void;
+  onCreated?: (result: { videoId: string; folderId: string | null }) => void;
 }
 
-export function NewProjectDialog({ spaceId, folderId = null }: NewProjectDialogProps) {
+function buildFolderRows(folders: FolderTreeOption[]) {
+  const children = new Map<string | null, FolderTreeOption[]>();
+  for (const folder of folders) {
+    const key = folder.parentId ?? null;
+    children.set(key, [...(children.get(key) || []), folder]);
+  }
+  for (const group of children.values()) {
+    group.sort((a, b) => a.name.localeCompare(b.name));
+  }
+  const rows: Array<FolderTreeOption & { depth: number }> = [];
+  const visit = (parentId: string | null, depth: number) => {
+    for (const folder of children.get(parentId) || []) {
+      rows.push({ ...folder, depth });
+      visit(folder.id, depth + 1);
+    }
+  };
+  visit(null, 0);
+  return rows;
+}
+
+export function NewProjectDialog({
+  spaceId,
+  folderId = null,
+  folders,
+  initialTitle = "",
+  initialDescription = "",
+  brainstormId,
+  triggerLabel = "New Project",
+  triggerHidden = false,
+  isOpenExternal,
+  onClose,
+  onCreated,
+}: NewProjectDialogProps) {
   const headingId = useId();
-  const [open, setOpen] = useState(false);
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
+  const isControlled = typeof isOpenExternal === "boolean";
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = isControlled ? isOpenExternal! : internalOpen;
+
+  const [title, setTitle] = useState(initialTitle);
+  const [description, setDescription] = useState(initialDescription);
+  const [selectedFolderId, setSelectedFolderId] = useState<string>(
+    folderId ?? "root",
+  );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
 
+  useEffect(() => {
+    if (!open) return;
+    setTitle(initialTitle);
+    setDescription(initialDescription);
+    setSelectedFolderId(folderId ?? "root");
+    setError("");
+  }, [open, initialTitle, initialDescription, folderId]);
+
+  const folderRows = useMemo(() => buildFolderRows(folders), [folders]);
+  const dropdownOptions: DropdownOption[] = useMemo(
+    () => [
+      { value: "root", label: "Space root" },
+      ...folderRows.map((folder) => ({
+        value: folder.id,
+        label: `${"  ".repeat(folder.depth)}${folder.depth > 0 ? "- " : ""}${folder.name}`,
+      })),
+    ],
+    [folderRows],
+  );
+
   const close = () => {
     if (saving) return;
-    setOpen(false);
-    setTitle("");
-    setDescription("");
+    if (isControlled) {
+      onClose?.();
+    } else {
+      setInternalOpen(false);
+    }
     setError("");
   };
 
@@ -31,38 +103,61 @@ export function NewProjectDialog({ spaceId, folderId = null }: NewProjectDialogP
     setSaving(true);
     setError("");
 
+    const targetFolderId = selectedFolderId === "root" ? null : selectedFolderId;
+
     try {
       const { data, error: actionError } = await actions.video.createProject({
         title: title.trim(),
         description: description.trim() || undefined,
         spaceId,
-        folderId,
+        folderId: targetFolderId,
       });
       if (actionError || !data?.videoId) {
-        throw new Error(actionError?.message || "Failed to create project");
+        throw new Error(actionError?.message || "");
       }
+
+      if (brainstormId) {
+        try {
+          await actions.brainstorm.markPromoted({
+            id: brainstormId,
+            videoId: data.videoId,
+          });
+        } catch (err) {
+          console.error("[NewProjectDialog] markPromoted failed", err);
+        }
+      }
+
+      onCreated?.({ videoId: data.videoId, folderId: targetFolderId });
       window.location.href = `/videos/${data.videoId}?space=${spaceId}`;
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create project");
+      const raw = err instanceof Error ? err.message : "";
+      setError(
+        friendlyActionErrorMessage(
+          raw,
+          "We couldn't create the project. Please try again.",
+        ),
+      );
       setSaving(false);
     }
   };
 
   return (
     <>
-      <Button
-        onClick={() => setOpen(true)}
-        aria-label="Create a new video project"
-        className="px-3 py-2.5 sm:px-5"
-        icon={(
-          <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-            <path d="m22 8-6 4 6 4V8Z" />
-            <rect x="2" y="6" width="14" height="12" rx="2" ry="2" />
-          </svg>
-        )}
-      >
-        <span className="hidden sm:inline">New Project</span>
-      </Button>
+      {!triggerHidden && !isControlled && (
+        <Button
+          onClick={() => setInternalOpen(true)}
+          aria-label="Create a new video project"
+          className="px-3 py-2.5 sm:px-5"
+          icon={(
+            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="m22 8-6 4 6 4V8Z" />
+              <rect x="2" y="6" width="14" height="12" rx="2" ry="2" />
+            </svg>
+          )}
+        >
+          <span className="hidden sm:inline">{triggerLabel}</span>
+        </Button>
+      )}
 
       <Modal
         isOpen={open}
@@ -112,8 +207,23 @@ export function NewProjectDialog({ spaceId, folderId = null }: NewProjectDialogP
             />
           </div>
 
+          <div>
+            <label className="mb-1 block text-sm font-medium text-text-secondary" htmlFor="project-folder">
+              Folder
+            </label>
+            <Dropdown
+              id="project-folder"
+              options={dropdownOptions}
+              value={selectedFolderId}
+              onChange={setSelectedFolderId}
+              disabled={saving}
+              menuAlign="left"
+              menuWidth="w-full"
+            />
+          </div>
+
           {error && (
-            <div className="rounded-lg bg-accent-danger/15 px-4 py-2 text-sm text-accent-danger">
+            <div className="rounded-lg bg-accent-danger/15 px-4 py-2 text-sm break-words text-accent-danger">
               {error}
             </div>
           )}

--- a/src/components/ScriptWorkspace.tsx
+++ b/src/components/ScriptWorkspace.tsx
@@ -542,7 +542,7 @@ export function ScriptWorkspace({
   };
 
   return (
-    <div className={isReviewMode ? "grid gap-5 xl:grid-cols-[minmax(0,1fr)_360px]" : "space-y-5"}>
+    <div className={isReviewMode ? "grid gap-5 2xl:grid-cols-[minmax(0,1fr)_360px]" : "space-y-5"}>
       <div className="space-y-5">
         <div className="overflow-hidden rounded-xl border border-border-default bg-bg-secondary">
           <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border-default px-4 py-3">

--- a/src/components/SpaceSidebar.astro
+++ b/src/components/SpaceSidebar.astro
@@ -1,0 +1,155 @@
+---
+type SpaceView = "projects" | "calendar" | "brainstorm" | "settings" | "none";
+
+interface Props {
+  spaceId: string;
+  active: SpaceView;
+}
+
+const { spaceId, active } = Astro.props;
+
+const items: Array<{
+  key: SpaceView;
+  label: string;
+  href: string;
+  icon: "projects" | "calendar" | "brainstorm" | "settings";
+}> = [
+  {
+    key: "projects",
+    label: "Projects",
+    href: `/dashboard?space=${spaceId}`,
+    icon: "projects",
+  },
+  {
+    key: "calendar",
+    label: "Calendar",
+    href: `/spaces/${spaceId}/calendar?space=${spaceId}`,
+    icon: "calendar",
+  },
+  {
+    key: "brainstorm",
+    label: "Brainstorm",
+    href: `/spaces/${spaceId}/brainstorm?space=${spaceId}`,
+    icon: "brainstorm",
+  },
+];
+
+const settingsItem = {
+  key: "settings" as const,
+  label: "Settings",
+  href: `/spaces/${spaceId}/settings?space=${spaceId}`,
+  icon: "settings" as const,
+};
+
+const linkBase =
+  "group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors";
+const linkInactive = "text-text-secondary hover:bg-bg-tertiary hover:text-text-primary";
+const linkActive = "bg-bg-tertiary text-text-primary";
+---
+
+<button
+  type="button"
+  data-space-sidebar-toggle
+  aria-controls="space-sidebar"
+  aria-expanded="false"
+  aria-label="Open space navigation"
+  class="fixed bottom-4 right-4 z-50 inline-flex h-12 w-12 items-center justify-center rounded-full border border-border-default bg-bg-secondary text-text-primary shadow-lg md:hidden"
+>
+  <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <line x1="3" y1="6" x2="21" y2="6" />
+    <line x1="3" y1="12" x2="21" y2="12" />
+    <line x1="3" y1="18" x2="21" y2="18" />
+  </svg>
+</button>
+
+<div
+  data-space-sidebar-backdrop
+  data-state="closed"
+  class="fixed inset-x-0 bottom-0 top-14 z-40 bg-black/40 backdrop-blur-sm transition-opacity duration-200 ease-out data-[state=closed]:pointer-events-none data-[state=closed]:opacity-0 data-[state=open]:opacity-100 md:hidden"
+></div>
+
+<aside
+  id="space-sidebar"
+  data-space-sidebar
+  data-state="closed"
+  class="fixed bottom-0 left-0 top-14 z-40 flex w-60 -translate-x-full transform flex-col border-r border-border-default bg-bg-primary shadow-xl transition-transform duration-300 ease-out data-[state=open]:translate-x-0 md:sticky md:h-[calc(100vh-3.5rem)] md:translate-x-0 md:shadow-none"
+  aria-label="Space navigation"
+>
+  <nav class="flex flex-1 flex-col gap-1 px-3 py-6">
+    {items.map((item) => {
+      const isActive = item.key === active;
+      return (
+        <a
+          href={item.href}
+          class={`${linkBase} ${isActive ? linkActive : linkInactive}`}
+          aria-current={isActive ? "page" : undefined}
+        >
+          <span class="flex h-5 w-5 items-center justify-center text-text-tertiary group-hover:text-text-primary">
+            {item.icon === "projects" && (
+              <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
+              </svg>
+            )}
+            {item.icon === "calendar" && (
+              <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="3" y="4" width="18" height="18" rx="2" />
+                <line x1="16" y1="2" x2="16" y2="6" />
+                <line x1="8" y1="2" x2="8" y2="6" />
+                <line x1="3" y1="10" x2="21" y2="10" />
+              </svg>
+            )}
+            {item.icon === "brainstorm" && (
+              <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M9 18h6" />
+                <path d="M10 22h4" />
+                <path d="M12 2a7 7 0 0 0-4 12.7c.6.4 1 1.1 1 1.8V18h6v-1.5c0-.7.4-1.4 1-1.8A7 7 0 0 0 12 2Z" />
+              </svg>
+            )}
+          </span>
+          <span>{item.label}</span>
+        </a>
+      );
+    })}
+  </nav>
+
+  <div class="border-t border-border-default px-3 py-4">
+    <a
+      href={settingsItem.href}
+      class={`${linkBase} ${active === "settings" ? linkActive : linkInactive}`}
+      aria-current={active === "settings" ? "page" : undefined}
+    >
+      <span class="flex h-5 w-5 items-center justify-center text-text-tertiary group-hover:text-text-primary">
+        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="3" />
+          <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h0a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v0a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1Z" />
+        </svg>
+      </span>
+      <span>{settingsItem.label}</span>
+    </a>
+  </div>
+</aside>
+
+<script>
+  const toggle = document.querySelector<HTMLButtonElement>("[data-space-sidebar-toggle]");
+  const sidebar = document.querySelector<HTMLElement>("[data-space-sidebar]");
+  const backdrop = document.querySelector<HTMLElement>("[data-space-sidebar-backdrop]");
+
+  if (toggle && sidebar && backdrop) {
+    const setState = (open: boolean) => {
+      const next = open ? "open" : "closed";
+      sidebar.setAttribute("data-state", next);
+      backdrop.setAttribute("data-state", next);
+      toggle.setAttribute("aria-expanded", open ? "true" : "false");
+    };
+    toggle.addEventListener("click", () => {
+      const isOpen = toggle.getAttribute("aria-expanded") === "true";
+      setState(!isOpen);
+    });
+    backdrop.addEventListener("click", () => setState(false));
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape" && toggle.getAttribute("aria-expanded") === "true") {
+        setState(false);
+      }
+    });
+  }
+</script>

--- a/src/components/VideoPageLayout.tsx
+++ b/src/components/VideoPageLayout.tsx
@@ -19,14 +19,14 @@ export function VideoPageLayout({ topContent, leftColumn, rightColumn, bottomCon
   }
 
   return (
-    <div className="grid grid-cols-1 gap-x-8 gap-y-8 lg:grid-cols-[1fr_380px]">
-      {topContent && <div className="lg:col-span-2">{topContent}</div>}
+    <div className="grid grid-cols-1 gap-x-8 gap-y-8 2xl:grid-cols-[1fr_380px]">
+      {topContent && <div className="2xl:col-span-2">{topContent}</div>}
       <div className="space-y-6">{leftColumn}</div>
       <div className="flex flex-col rounded-xl border border-border-default bg-bg-secondary">
         {rightColumn}
       </div>
       {bottomContent && (
-        <div className="lg:col-start-1">{bottomContent}</div>
+        <div className="2xl:col-start-1">{bottomContent}</div>
       )}
     </div>
   );

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -480,3 +480,64 @@ export const commentReactions = sqliteTable(
       .where(sql`${table.reactorUserId} IS NOT NULL`),
   ],
 );
+
+export const brainstorms = sqliteTable(
+  "brainstorms",
+  {
+    id: text("id").primaryKey(),
+    spaceId: text("space_id")
+      .notNull()
+      .references(() => spaces.id, { onDelete: "cascade" }),
+    authorUserId: text("author_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    authorDisplayName: text("author_display_name").notNull(),
+    title: text("title").notNull(),
+    notes: text("notes").notNull().default(""),
+    status: text("status", { enum: ["open", "promoted", "archived"] })
+      .notNull()
+      .default("open"),
+    promotedProjectId: text("promoted_project_id").references(() => projects.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    index("brainstorms_space_status_created_idx").on(
+      table.spaceId,
+      table.status,
+      table.createdAt,
+    ),
+  ],
+);
+
+export const brainstormReactions = sqliteTable(
+  "brainstorm_reactions",
+  {
+    id: text("id").primaryKey(),
+    brainstormId: text("brainstorm_id")
+      .notNull()
+      .references(() => brainstorms.id, { onDelete: "cascade" }),
+    reactorUserId: text("reactor_user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    reactorDisplayName: text("reactor_display_name"),
+    emoji: text("emoji").notNull(),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    uniqueIndex("brainstorm_reactions_unique").on(
+      table.brainstormId,
+      table.reactorUserId,
+      table.emoji,
+    ),
+    index("brainstorm_reactions_brainstorm_idx").on(table.brainstormId),
+  ],
+);

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,20 +3,25 @@ import "../styles/tailwind.css";
 import { UserMenu } from "../components/UserMenu";
 import { SpaceSwitcher } from "../components/SpaceSwitcher";
 import Logo from "../components/Logo.astro";
+import SpaceSidebar from "../components/SpaceSidebar.astro";
 import { createDb } from "../db";
 import { getPendingInvitesForUser } from "../lib/invites";
 import { getUnreadNotificationCount } from "../lib/notifications";
 import { getUserSpaces } from "../lib/spaces";
 import { env } from "cloudflare:workers";
 
+type SpaceView = "projects" | "calendar" | "brainstorm" | "settings" | "none";
+
 interface Props {
   title: string;
   description?: string;
   user?: { id: string; email: string; name: string } | null;
   selectedSpaceId?: string | null;
+  spaceView?: SpaceView;
 }
 
-const { title, description, user, selectedSpaceId } = Astro.props;
+const { title, description, user, selectedSpaceId, spaceView } = Astro.props;
+const showSidebar = Boolean(user && selectedSpaceId && spaceView);
 const metaDescription = description ?? "Quick Cuts - Collaborative video review";
 const db = createDb(env.DB);
 const userSpaces = user ? await getUserSpaces(db, user.id) : [];
@@ -72,8 +77,17 @@ const headerSpaceId = selectedSpaceId ?? Astro.url.searchParams.get("space") ?? 
         </header>
       )
     }
-    <main>
-      <slot />
-    </main>
+    {showSidebar ? (
+      <div class="flex">
+        <SpaceSidebar spaceId={selectedSpaceId!} active={spaceView!} />
+        <main class="min-w-0 flex-1">
+          <slot />
+        </main>
+      </div>
+    ) : (
+      <main>
+        <slot />
+      </main>
+    )}
   </body>
 </html>

--- a/src/lib/brainstorms.ts
+++ b/src/lib/brainstorms.ts
@@ -1,0 +1,186 @@
+import { and, asc, desc, eq, inArray } from "drizzle-orm";
+import type { Database } from "../db";
+import { brainstormReactions, brainstorms, projects } from "../db/schema";
+import {
+  BRAINSTORM_REACTION_EMOJIS,
+  type BrainstormItem,
+  type BrainstormReactionEmoji,
+  type BrainstormReactionSummary,
+  type BrainstormStatus,
+} from "../types";
+
+export type BrainstormRow = typeof brainstorms.$inferSelect;
+
+export function isBrainstormReactionEmoji(
+  emoji: string,
+): emoji is BrainstormReactionEmoji {
+  return BRAINSTORM_REACTION_EMOJIS.includes(emoji as BrainstormReactionEmoji);
+}
+
+export interface BrainstormReactor {
+  userId: string;
+  name: string;
+}
+
+export async function getBrainstormById(
+  db: Database,
+  id: string,
+): Promise<BrainstormRow | null> {
+  const rows = await db
+    .select()
+    .from(brainstorms)
+    .where(eq(brainstorms.id, id))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getBrainstormsForSpace(
+  db: Database,
+  spaceId: string,
+  reactor?: BrainstormReactor,
+): Promise<BrainstormItem[]> {
+  const rows = await db
+    .select({
+      brainstorm: brainstorms,
+      promotedTitle: projects.title,
+    })
+    .from(brainstorms)
+    .leftJoin(projects, eq(projects.id, brainstorms.promotedProjectId))
+    .where(eq(brainstorms.spaceId, spaceId))
+    .orderBy(desc(brainstorms.createdAt));
+
+  if (rows.length === 0) return [];
+
+  const ids = rows.map((row) => row.brainstorm.id);
+  const summariesById = await getReactionSummaries(db, ids, reactor);
+
+  const items: BrainstormItem[] = rows.map((row) => {
+    const summaries = summariesById[row.brainstorm.id] ?? [];
+    const reactionCount = summaries.reduce((sum, s) => sum + s.count, 0);
+    return {
+      id: row.brainstorm.id,
+      spaceId: row.brainstorm.spaceId,
+      authorUserId: row.brainstorm.authorUserId,
+      authorDisplayName: row.brainstorm.authorDisplayName,
+      title: row.brainstorm.title,
+      notes: row.brainstorm.notes,
+      status: row.brainstorm.status as BrainstormStatus,
+      promotedProjectId: row.brainstorm.promotedProjectId,
+      promotedProjectTitle: row.promotedTitle ?? null,
+      createdAt: row.brainstorm.createdAt,
+      updatedAt: row.brainstorm.updatedAt,
+      reactionCount,
+      reactions: summaries,
+    };
+  });
+
+  items.sort((a, b) => {
+    if (b.reactionCount !== a.reactionCount) {
+      return b.reactionCount - a.reactionCount;
+    }
+    return a.createdAt < b.createdAt ? 1 : a.createdAt > b.createdAt ? -1 : 0;
+  });
+
+  return items;
+}
+
+async function getReactionSummaries(
+  db: Database,
+  brainstormIds: string[],
+  reactor?: BrainstormReactor,
+): Promise<Record<string, BrainstormReactionSummary[]>> {
+  if (brainstormIds.length === 0) return {};
+
+  const rows = await db
+    .select({
+      brainstormId: brainstormReactions.brainstormId,
+      emoji: brainstormReactions.emoji,
+      reactorUserId: brainstormReactions.reactorUserId,
+    })
+    .from(brainstormReactions)
+    .where(inArray(brainstormReactions.brainstormId, brainstormIds))
+    .orderBy(asc(brainstormReactions.createdAt));
+
+  const counts = new Map<string, number>();
+  const mine = new Set<string>();
+
+  for (const row of rows) {
+    if (!isBrainstormReactionEmoji(row.emoji)) continue;
+    const key = `${row.brainstormId}:${row.emoji}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+    if (reactor && row.reactorUserId === reactor.userId) {
+      mine.add(key);
+    }
+  }
+
+  const result: Record<string, BrainstormReactionSummary[]> = {};
+  for (const id of brainstormIds) {
+    result[id] = BRAINSTORM_REACTION_EMOJIS.flatMap((emoji) => {
+      const key = `${id}:${emoji}`;
+      const count = counts.get(key) ?? 0;
+      const reactedByMe = mine.has(key);
+      if (count === 0 && !reactedByMe) return [];
+      return [{ emoji, count, reactedByMe }];
+    });
+  }
+  return result;
+}
+
+export async function getBrainstormReactionSummary(
+  db: Database,
+  brainstormId: string,
+  reactor?: BrainstormReactor,
+): Promise<BrainstormReactionSummary[]> {
+  const map = await getReactionSummaries(db, [brainstormId], reactor);
+  return map[brainstormId] ?? [];
+}
+
+export async function toggleBrainstormReaction(
+  db: Database,
+  brainstormId: string,
+  emoji: BrainstormReactionEmoji,
+  reactor: BrainstormReactor,
+): Promise<BrainstormReactionSummary[]> {
+  const existing = await db
+    .select({ id: brainstormReactions.id })
+    .from(brainstormReactions)
+    .where(
+      and(
+        eq(brainstormReactions.brainstormId, brainstormId),
+        eq(brainstormReactions.emoji, emoji),
+        eq(brainstormReactions.reactorUserId, reactor.userId),
+      ),
+    )
+    .limit(1);
+
+  if (existing.length > 0) {
+    await db
+      .delete(brainstormReactions)
+      .where(eq(brainstormReactions.id, existing[0].id));
+  } else {
+    try {
+      await db.insert(brainstormReactions).values({
+        id: crypto.randomUUID(),
+        brainstormId,
+        emoji,
+        reactorUserId: reactor.userId,
+        reactorDisplayName: reactor.name,
+      });
+    } catch (err) {
+      const dup = await db
+        .select({ id: brainstormReactions.id })
+        .from(brainstormReactions)
+        .where(
+          and(
+            eq(brainstormReactions.brainstormId, brainstormId),
+            eq(brainstormReactions.emoji, emoji),
+            eq(brainstormReactions.reactorUserId, reactor.userId),
+          ),
+        )
+        .limit(1);
+      if (dup.length === 0) throw err;
+    }
+  }
+
+  return getBrainstormReactionSummary(db, brainstormId, reactor);
+}

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,6 +1,7 @@
 import { and, count, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { Database } from "../db";
-import { projects, videos } from "../db/schema";
+import { folders, projects, scripts, videos } from "../db/schema";
+import { logProjectActivity } from "./activity";
 
 export type ProjectRow = typeof projects.$inferSelect;
 export type VideoRow = typeof videos.$inferSelect;
@@ -217,3 +218,93 @@ export async function getProjectForVideoId(
 }
 
 export type { ProjectRow as Project };
+
+interface CreateProjectInSpaceInput {
+  spaceId: string;
+  folderId?: string | null;
+  title: string;
+  description?: string | null;
+  user: { id: string; name: string };
+}
+
+export interface CreateProjectInSpaceResult {
+  videoId: string;
+  projectId: string;
+}
+
+/**
+ * Creates a project + initial video version + empty script row in one
+ * logical operation. Validates that `folderId`, when set, belongs to the
+ * target space. Throws on validation failures so callers can convert to
+ * the appropriate user-facing error.
+ */
+export async function createProjectInSpace(
+  db: Database,
+  input: CreateProjectInSpaceInput,
+): Promise<CreateProjectInSpaceResult> {
+  const { spaceId, title, user } = input;
+  const folderId = input.folderId ?? null;
+  const description = input.description?.trim() || null;
+
+  if (folderId) {
+    const folder = await db
+      .select({ id: folders.id })
+      .from(folders)
+      .where(and(eq(folders.id, folderId), eq(folders.spaceId, spaceId)))
+      .limit(1);
+    if (folder.length === 0) {
+      throw new Error("FOLDER_NOT_FOUND");
+    }
+  }
+
+  const videoId = crypto.randomUUID();
+  const projectId = videoId;
+  const now = new Date().toISOString();
+
+  await db.insert(projects).values({
+    id: projectId,
+    spaceId,
+    uploadedBy: user.id,
+    folderId,
+    title,
+    description,
+    phase: "creating_script",
+    targetDate: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  await db.insert(videos).values({
+    id: videoId,
+    spaceId,
+    uploadedBy: user.id,
+    projectId,
+    status: "draft",
+    versionNumber: 1,
+    isCurrentVersion: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  await db.insert(scripts).values({
+    id: crypto.randomUUID(),
+    videoId,
+    content: "",
+    plainText: "",
+    status: "writing",
+    createdBy: user.id,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  await logProjectActivity(db, {
+    videoId,
+    actorUserId: user.id,
+    actorDisplayName: user.name,
+    type: "project.created",
+    data: { title },
+    createdAt: now,
+  });
+
+  return { videoId, projectId };
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -174,3 +174,36 @@ export const notificationsMarkReadByContextSchema = z.object({
   videoId: z.string().min(1),
   tab: z.enum(["video", "script"]),
 });
+
+// ---------------------------------------------------------------------------
+// Brainstorms
+// ---------------------------------------------------------------------------
+
+export const BRAINSTORM_REACTION_EMOJIS = ["👍", "❤️", "🚀", "💡", "🎬"] as const;
+export const brainstormReactionEmojiSchema = z.enum(BRAINSTORM_REACTION_EMOJIS);
+
+export const brainstormCreateSchema = z.object({
+  spaceId: z.string().uuid(),
+  title: z.string().trim().min(1, "Title is required").max(200),
+  notes: z.string().max(5000).optional().default(""),
+});
+
+export const brainstormUpdateSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().trim().min(1).max(200).optional(),
+  notes: z.string().max(5000).optional(),
+});
+
+export const brainstormStatusUpdateSchema = z.object({
+  id: z.string().min(1),
+});
+
+export const brainstormReactionToggleSchema = z.object({
+  brainstormId: z.string().min(1),
+  emoji: brainstormReactionEmojiSchema,
+});
+
+export const brainstormMarkPromotedSchema = z.object({
+  id: z.string().min(1),
+  videoId: z.string().min(1),
+});

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -197,10 +197,10 @@ const videoItems: VideoCardItemData[] = userVideos.map((video) => ({
 }));
 ---
 
-<Layout title={currentFolderRecord ? currentFolderRecord.name : selectedSpace.name} user={user} selectedSpaceId={selectedSpaceId}>
+<Layout title={currentFolderRecord ? currentFolderRecord.name : selectedSpace.name} user={user} selectedSpaceId={selectedSpaceId} spaceView="projects">
   <PendingToast client:load />
   <div class="mx-auto max-w-[1280px] px-4 py-8 sm:px-8">
-    <div class="mb-2">
+    <div class="mb-6">
       <Breadcrumbs path={folderPath} />
       <h1 class="text-2xl font-bold text-text-primary">
         {currentFolderRecord ? currentFolderRecord.name : selectedSpace.name}

--- a/src/pages/spaces/[id]/brainstorm.astro
+++ b/src/pages/spaces/[id]/brainstorm.astro
@@ -1,0 +1,60 @@
+---
+import Layout from "../../../layouts/Layout.astro";
+import { BrainstormBoard } from "../../../components/BrainstormBoard";
+import { createDb } from "../../../db";
+import { folders, spaces } from "../../../db/schema";
+import { asc, eq } from "drizzle-orm";
+import { env } from "cloudflare:workers";
+import { verifySpaceAccess } from "../../../lib/spaces";
+import { getBrainstormsForSpace } from "../../../lib/brainstorms";
+import type { FolderTreeOption } from "../../../types";
+
+const user = Astro.locals.user;
+if (!user) return Astro.redirect("/login");
+
+const { id } = Astro.params;
+if (!id) return Astro.redirect("/dashboard");
+
+const db = createDb(env.DB);
+
+const role = await verifySpaceAccess(db, user.id, id);
+if (!role) return Astro.redirect("/dashboard");
+
+const space = await db.select().from(spaces).where(eq(spaces.id, id)).limit(1);
+if (space.length === 0) return Astro.redirect("/dashboard");
+
+const brainstorms = await getBrainstormsForSpace(db, id, {
+  userId: user.id,
+  name: user.name,
+});
+
+const allFolders = await db
+  .select()
+  .from(folders)
+  .where(eq(folders.spaceId, id))
+  .orderBy(asc(folders.name));
+
+const folderOptions: FolderTreeOption[] = allFolders.map((folder) => ({
+  id: folder.id,
+  name: folder.name,
+  parentId: folder.parentId,
+}));
+---
+
+<Layout title={`${space[0].name} Brainstorm`} user={user} selectedSpaceId={id} spaceView="brainstorm">
+  <div class="mx-auto max-w-[1280px] px-4 py-8 sm:px-8">
+    <div class="mb-6">
+      <h1 class="text-2xl font-bold text-text-primary">Brainstorm</h1>
+      <p class="text-sm text-text-secondary">{space[0].name}</p>
+    </div>
+
+    <BrainstormBoard
+      client:load
+      spaceId={id}
+      currentUserId={user.id}
+      isOwner={role === "owner"}
+      initialBrainstorms={brainstorms}
+      folders={folderOptions}
+    />
+  </div>
+</Layout>

--- a/src/pages/spaces/[id]/calendar.astro
+++ b/src/pages/spaces/[id]/calendar.astro
@@ -64,22 +64,11 @@ const calendarVideos: DashboardVideo[] = rows.map((row) => ({
 }));
 ---
 
-<Layout title={`${space[0].name} Launch Calendar`} user={user} selectedSpaceId={id}>
+<Layout title={`${space[0].name} Launch Calendar`} user={user} selectedSpaceId={id} spaceView="calendar">
   <div class="mx-auto max-w-[1280px] px-4 py-8 sm:px-8">
-    <div class="mb-6 flex flex-wrap items-center justify-between gap-3">
-      <div>
-        <a
-          href={`/dashboard?space=${id}`}
-          class="inline-flex items-center gap-1 text-sm text-text-secondary transition-colors hover:text-text-primary"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <polyline points="15 18 9 12 15 6" />
-          </svg>
-          Back to Dashboard
-        </a>
-        <h1 class="mt-2 text-2xl font-bold text-text-primary">Launch Calendar</h1>
-        <p class="text-sm text-text-secondary">{space[0].name}</p>
-      </div>
+    <div class="mb-6">
+      <h1 class="text-2xl font-bold text-text-primary">Launch Calendar</h1>
+      <p class="text-sm text-text-secondary">{space[0].name}</p>
     </div>
 
     <CalendarView client:load spaceId={id} initialVideos={calendarVideos} />

--- a/src/pages/spaces/[id]/settings.astro
+++ b/src/pages/spaces/[id]/settings.astro
@@ -57,7 +57,7 @@ const firstOwned = await db
 const isDefaultSpace = firstOwned.length > 0 && firstOwned[0].id === id;
 ---
 
-<Layout title={`${space[0].name} Settings`} user={user} selectedSpaceId={id}>
+<Layout title={`${space[0].name} Settings`} user={user} selectedSpaceId={id} spaceView="settings">
   <div class="mx-auto max-w-[1280px] px-4 py-8 sm:px-8">
     <div class="mb-6">
       <a

--- a/src/pages/videos/[id]/index.astro
+++ b/src/pages/videos/[id]/index.astro
@@ -78,7 +78,7 @@ const tabHref = (tab: "script" | "video" | "details") => {
 };
 ---
 
-<Layout title={video.title} user={user} selectedSpaceId={video.spaceId}>
+<Layout title={video.title} user={user} selectedSpaceId={video.spaceId} spaceView="none">
   {hasVideo && <script src="https://embed.cloudflarestream.com/embed/sdk.latest.js" is:inline></script>}
   <div class="mx-auto max-w-[1180px] px-4 py-6 sm:px-8 sm:py-8">
     <VideoHeader

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,3 +101,37 @@ export function normalizeVideoPhase(phase: string | null | undefined): VideoPhas
   if (PROJECT_STATUSES.includes(phase as ProjectStatus)) return phase as ProjectStatus;
   return "reviewing_video";
 }
+
+export const BRAINSTORM_REACTION_EMOJIS = ["👍", "❤️", "🚀", "💡", "🎬"] as const;
+export type BrainstormReactionEmoji = (typeof BRAINSTORM_REACTION_EMOJIS)[number];
+
+export const BRAINSTORM_STATUSES = ["open", "promoted", "archived"] as const;
+export type BrainstormStatus = (typeof BRAINSTORM_STATUSES)[number];
+
+export interface BrainstormReactionSummary {
+  emoji: BrainstormReactionEmoji;
+  count: number;
+  reactedByMe: boolean;
+}
+
+export interface BrainstormItem {
+  id: string;
+  spaceId: string;
+  authorUserId: string | null;
+  authorDisplayName: string;
+  title: string;
+  notes: string;
+  status: BrainstormStatus;
+  promotedProjectId: string | null;
+  promotedProjectTitle: string | null;
+  createdAt: string;
+  updatedAt: string;
+  reactionCount: number;
+  reactions: BrainstormReactionSummary[];
+}
+
+export interface FolderTreeOption {
+  id: string;
+  name: string;
+  parentId: string | null;
+}


### PR DESCRIPTION
## Summary

Adds a **Brainstormer** so any space member can capture video ideas in a shared backlog and promote them into real video projects. Also restructures space-scoped navigation as a left sidebar.

### Brainstormer

- New `brainstorms` and `brainstorm_reactions` tables (migration `0026_create_brainstorms.sql`)
- `brainstorm` action group: `create`, `update`, `archive`, `unarchive`, `delete`, `toggleReaction`, `markPromoted`
- Once an idea is promoted to a project it's locked — `markPromoted` rejects further attempts
- Reactions: `👍 ❤️ 🚀 💡 🎬` (server-side allowlist)
- Sort order within each filter: reaction count DESC, tiebroken by `createdAt` DESC
- Permissions: any member can create / react / promote; author or space owner can edit / archive / delete

### Promote-to-project flow

- `NewProjectDialog` reused for promotion with `initialTitle` / `initialDescription` / `brainstormId` props
- After successful project creation, the dialog calls `brainstorm.markPromoted` (best-effort) and navigates to the new video
- `NewProjectDialog` now always shows a folder picker; default is contextual (URL `folderId` on dashboard, space root on brainstorm)
- `video.createProject` and the brainstorm flow share a new `createProjectInSpace` helper in `src/lib/projects.ts`

### Sidebar navigation

- New `SpaceSidebar.astro` rendered by `Layout.astro` whenever a `spaceView` prop is passed
- Items: **Projects**, **Calendar**, **Brainstorm**, with **Settings** at the bottom
- Sticky on desktop, animated slide-in drawer on mobile (sits below the 56px header so the nav bar stays usable)
- Visible on `videos/:id` (Projects/Calendar/Brainstorm none-active) so users can hop back in one click
- "Videos" / "All Videos" copy renamed to **Projects** in breadcrumbs, move-to-folder, and folder-delete dialog
- Comments columns on the video and script pages now wrap underneath at `2xl:` (was `lg:` / `xl:`) so the 240px sidebar doesn't squeeze them on typical laptop widths

## Test plan

1. Two-member space (owner A, member B). A goes to `/dashboard?space=…` — sidebar visible with Projects active.
2. Click **Brainstorm** in the sidebar → empty state.
3. A creates idea X (with notes), B creates idea Y. Y is above X (newer, both 0 reactions).
4. B reacts 👍 + 🚀 on X (count 2). X moves above Y.
5. A reacts 👍 on Y. Both at count 2 → tiebreak by createdAt → Y above X.
6. A reacts 🎬 on X (count 3) → X above Y. Toggle 👍 off again → X drops to 2.
7. B's ⋯ menu on X (A's idea) hides Edit/Archive/Delete; A (owner) sees the full menu on Y.
8. Click **Create Project** on Y. Dialog opens prefilled with title + notes, folder picker defaulted to "Space root". Pick a sub-folder → lands on `/videos/:id?space=…` and the project is in that folder.
9. Back on Brainstorm: Y has **Promoted** pill, "View project" link, **Create Project** action gone. Calling `brainstorm.markPromoted` again is rejected by the server.
10. Filter to **Promoted** → Y appears. Archive X → moves to **Archived**. Unarchive → back to **Open**.
11. Delete an idea with reactions → cascade-deletes the reaction rows (verify in D1 shell).
12. Non-member visits `/spaces/:id/brainstorm` → redirected to `/dashboard`.
13. Server checks: notes >5000 chars rejected; emoji outside the allowlist rejected; `folderId` from a different space rejected.
14. Mobile: hamburger button opens animated drawer below the header; ESC closes it; backdrop click closes it.
15. Desktop: visit `/videos/:id` — sidebar still visible with no item highlighted.
16. `pnpm build` clean.