### PR TITLE
fix(security): validate share comments + canonical base URL for emails

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -41,6 +41,7 @@ import {
 } from "../lib/validation";
 import { verifySpaceAccess, getDefaultSpaceForUser } from "../lib/spaces";
 import { generateShareToken, generateInviteToken } from "../lib/share";
+import { getCanonicalBaseUrl } from "../lib/urls";
 import { getApprovalStatus } from "../lib/approvals";
 import { createDirectUpload, deleteVideo as deleteStreamVideo } from "../lib/stream";
 import { isTranscriptGenerationEnabled } from "../lib/flags";
@@ -746,7 +747,7 @@ export const server = {
             {
               send: (msg) => env.EMAIL.send(msg),
               from: env.OTP_EMAIL_FROM,
-              baseUrl: new URL(context.request.url).origin,
+              baseUrl: getCanonicalBaseUrl(env),
             },
             env,
           );
@@ -1365,7 +1366,7 @@ export const server = {
             {
               send: (msg) => env.EMAIL.send(msg),
               from: env.OTP_EMAIL_FROM,
-              baseUrl: new URL(context.request.url).origin,
+              baseUrl: getCanonicalBaseUrl(env),
             },
             env,
           );
@@ -1577,7 +1578,7 @@ export const server = {
             {
               send: (msg) => env.EMAIL.send(msg),
               from: env.OTP_EMAIL_FROM,
-              baseUrl: new URL(context.request.url).origin,
+              baseUrl: getCanonicalBaseUrl(env),
             },
             env,
           );
@@ -1907,7 +1908,7 @@ export const server = {
           hasAccount: existingUser.length > 0,
           token: invite.token,
         });
-        const inviteUrl = new URL(invitePath, new URL(context.request.url).origin).toString();
+        const inviteUrl = new URL(invitePath, getCanonicalBaseUrl(env)).toString();
         const email = buildInviteEmail({
           inviteUrl,
           inviterName: user.name,

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -8,3 +8,7 @@ export function getSafeReturnUrl(returnUrl: string | null | undefined): string |
 
   return `${url.pathname}${url.search}${url.hash}`;
 }
+
+export function getCanonicalBaseUrl(env: Pick<Cloudflare.Env, "BETTER_AUTH_URL">): string {
+  return new URL(env.BETTER_AUTH_URL).origin;
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -54,12 +54,18 @@ export const commentSchema = z.object({
 });
 
 export const anonymousCommentSchema = z.object({
-  text: z.string().min(1, "Comment text is required").max(5000),
-  timestamp: z.number().nullable().optional(),
-  name: z.string().min(1, "Name is required").max(100),
-  parentId: z.string().optional(),
+  text: z.string().trim().min(1, "Comment text is required").max(5000),
+  timestamp: z
+    .number()
+    .finite("Invalid timestamp")
+    .nullable()
+    .optional(),
+  name: z.string().trim().min(1, "Name is required").max(100),
+  parentId: z.string().min(1).max(100).optional(),
   annotation: annotationSchema.nullable().optional(),
   urgency: urgencySchema.optional().default("suggestion"),
+  phase: z.enum(["script", "review"]).optional().default("review"),
+  textRange: textRangeSchema.nullable().optional(),
 });
 
 // Project-level update payload. After issue #121 these fields all live

--- a/src/pages/api/share/[token]/comments.ts
+++ b/src/pages/api/share/[token]/comments.ts
@@ -6,6 +6,9 @@ import { eq, asc, gt, and } from "drizzle-orm";
 import { broadcastNewComment } from "../../../../lib/broadcast";
 import { addReactionSummaries } from "../../../../lib/comments";
 import { createCommentNotifications } from "../../../../lib/notifications";
+import { anonymousCommentSchema, commentSchema } from "../../../../lib/validation";
+import { getCanonicalBaseUrl } from "../../../../lib/urls";
+import { z } from "zod";
 
 export const GET: APIRoute = async ({ params, url }) => {
   const { token } = params;
@@ -103,8 +106,30 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 
   const sessionUser = locals.user;
   const videoId = shareLinkResult[0].videoId;
-  const body = await request.json();
-  const { text, timestamp, name, parentId, annotation, urgency, phase, textRange } = body;
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const schema = sessionUser ? commentSchema : anonymousCommentSchema;
+  const parsed = schema.safeParse(rawBody);
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "Invalid request";
+    return new Response(JSON.stringify({ error: message }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  const input = parsed.data;
+  const anonymousName = !sessionUser
+    ? (input as z.infer<typeof anonymousCommentSchema>).name
+    : null;
 
   const videoResult = await db
     .select({ phase: projects.phase })
@@ -127,48 +152,17 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
     });
   }
 
-  if (!text || !text.trim()) {
-    return new Response(JSON.stringify({ error: "Comment text is required" }), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    });
-  }
-
-  if (!sessionUser && (!name || !name.trim())) {
-    return new Response(
-      JSON.stringify({ error: "Name is required" }),
-      { status: 400, headers: { "Content-Type": "application/json" } },
-    );
-  }
-
-  // Replies don't carry urgency; force "suggestion" for them. Validate input
-  // for top-level comments and fall back to "suggestion" if missing/invalid.
-  const allowedUrgencies = [
-    "idea",
-    "suggestion",
-    "important",
-    "critical",
-  ] as const;
-  type Urgency = (typeof allowedUrgencies)[number];
-  const isReply = !!parentId;
-  const commentUrgency: Urgency = isReply
-    ? "suggestion"
-    : allowedUrgencies.includes(urgency as Urgency)
-      ? (urgency as Urgency)
-      : "suggestion";
+  const isReply = !!input.parentId;
+  const commentUrgency = isReply ? "suggestion" : input.urgency;
 
   const commentId = crypto.randomUUID();
 
-  // Determine the comment phase:
-  // - Replies inherit the parent comment's phase.
-  // - Top-level comments use the explicit `phase` field if provided.
-  // - Default to "review" for backward compatibility.
-  let commentPhase: "script" | "review" = phase === "script" ? "script" : "review";
-  if (isReply && parentId) {
+  let commentPhase: "script" | "review" = input.phase;
+  if (isReply && input.parentId) {
     const parentRows = await db
       .select({ phase: comments.phase })
       .from(comments)
-      .where(and(eq(comments.id, parentId), eq(comments.videoId, videoId)))
+      .where(and(eq(comments.id, input.parentId), eq(comments.videoId, videoId)))
       .limit(1);
 
     if (parentRows.length === 0) {
@@ -180,6 +174,10 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
     commentPhase = parentRows[0].phase;
   }
 
+  const annotation = input.annotation ?? null;
+  const textRange = input.textRange ?? null;
+  const timestampValue = input.timestamp ?? null;
+
   const newComment = sessionUser
     ? {
         id: commentId,
@@ -187,9 +185,9 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
         authorType: "user" as const,
         authorUserId: sessionUser.id,
         authorDisplayName: null,
-        timestamp: timestamp != null ? Number(timestamp) : null,
-        text: text.trim(),
-        parentId: parentId || null,
+        timestamp: timestampValue,
+        text: input.text,
+        parentId: input.parentId ?? null,
         isResolved: false,
         resolvedBy: null,
         resolvedAt: null,
@@ -204,10 +202,10 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
         videoId,
         authorType: "anonymous" as const,
         authorUserId: null,
-        authorDisplayName: name.trim(),
-        timestamp: timestamp != null ? Number(timestamp) : null,
-        text: text.trim(),
-        parentId: parentId || null,
+        authorDisplayName: anonymousName!,
+        timestamp: timestampValue,
+        text: input.text,
+        parentId: input.parentId ?? null,
         isResolved: false,
         resolvedBy: null,
         resolvedAt: null,
@@ -234,7 +232,7 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
     }, {
       send: (msg) => env.EMAIL.send(msg),
       from: env.OTP_EMAIL_FROM,
-      baseUrl: new URL(request.url).origin,
+      baseUrl: getCanonicalBaseUrl(env),
     }, env);
   } catch (err) {
     console.error("Failed to create share comment notification", err);


### PR DESCRIPTION
## Summary

Second of four planned PRs for the security hardening bundle in #138. Both items are pure code, no new bindings.

- **Validate anonymous share comments with Zod** (Item 2). The handler used to destructure `request.json()` directly. There was already an `anonymousCommentSchema` in `src/lib/validation.ts` that wasn't wired up. This PR plugs it in, strengthens the schema, and removes the manual ad-hoc validation that lived in the route.
- **Eliminate host-header injection in outbound email links** (Item 4). All five call sites that built `baseUrl` from `new URL(request.url).origin` now go through `getCanonicalBaseUrl(env)`, which sources the origin from `env.BETTER_AUTH_URL`.

## Changes

### Validation
- `src/lib/validation.ts`: `anonymousCommentSchema` now trims `text` and `name`, requires `timestamp` to be finite (rejects `NaN` / `Infinity`), bounds `parentId` length, and accepts the `phase` and `textRange` fields the endpoint already produced. Existing `pointAnnotationSchema` / `rectAnnotationSchema` (via the discriminated `annotationSchema`) continue to validate annotations.
- `src/pages/api/share/[token]/comments.ts`: POST handler now `safeParse`s the body. Authenticated callers validate against `commentSchema`; anonymous callers validate against the stricter `anonymousCommentSchema` (which additionally requires a name). Removed ~50 lines of manual urgency/phase/text/name validation that the schemas now cover. Errors return a sanitized first-issue message — no raw Zod stacks.

### Canonical base URL
- `src/lib/urls.ts`: New `getCanonicalBaseUrl(env)` helper.
- `src/pages/api/share/[token]/comments.ts:234`: replaced.
- `src/actions/index.ts:749` (mention notifications): replaced.
- `src/actions/index.ts:1366` (reply notifications): replaced.
- `src/actions/index.ts:1578` (approval-request notifications): replaced.
- `src/actions/index.ts:1908` (invite URL builder): replaced.

## Out of scope (follow-up PRs for #138)

- PR 3: \`RATE_LIMITER\` binding + OTP neutral response/rate limit + share view-count rate limit
- PR 4: Origin-check middleware

## Testing

\`pnpm build\` passes (typecheck + Astro build).

Refs #138