### PR TITLE
feat(security): origin-check middleware for cookie-authed mutations

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import { defineMiddleware } from "astro:middleware";
 import { env } from "cloudflare:workers";
 import { createAuth } from "./lib/auth";
-import { getSafeReturnUrl } from "./lib/urls";
+import { getCanonicalBaseUrl, getSafeReturnUrl } from "./lib/urls";
 
 // Extend Astro locals type
 declare global {
@@ -15,8 +15,37 @@ declare global {
 const protectedRoutes = ["/dashboard", "/notifications", "/settings", "/videos/", "/spaces/"];
 const authApiRoutes = ["/api/videos", "/api/comments", "/api/spaces", "/api/invites", "/api/notifications", "/_actions/"];
 
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+const ORIGIN_CHECK_SKIP_PATTERNS: RegExp[] = [
+  /^\/api\/auth\//,
+  /^\/api\/webhooks\/stream\/?$/,
+  /^\/api\/share\/[^/]+\/comments\/?$/,
+  /^\/api\/share\/[^/]+\/view\/?$/,
+];
+
+function shouldEnforceOriginCheck(method: string, pathname: string): boolean {
+  if (SAFE_METHODS.has(method)) return false;
+  const isProtectedScope =
+    pathname.startsWith("/api/") || pathname.startsWith("/_actions/");
+  if (!isProtectedScope) return false;
+  return !ORIGIN_CHECK_SKIP_PATTERNS.some((pattern) => pattern.test(pathname));
+}
+
 export const onRequest = defineMiddleware(async (context, next) => {
   context.locals.user = null;
+
+  const pathname = context.url.pathname;
+
+  if (shouldEnforceOriginCheck(context.request.method, pathname)) {
+    const origin = context.request.headers.get("Origin");
+    if (origin && origin !== getCanonicalBaseUrl(env)) {
+      return new Response(JSON.stringify({ error: "Cross-origin request blocked" }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+  }
 
   const auth = createAuth(env.DB, {
     BETTER_AUTH_SECRET: env.BETTER_AUTH_SECRET,
@@ -41,8 +70,6 @@ export const onRequest = defineMiddleware(async (context, next) => {
   } catch {
     // Auth error, continue unauthenticated
   }
-
-  const pathname = context.url.pathname;
 
   // Let Better Auth handle its own routes
   if (pathname.startsWith("/api/auth/")) {


### PR DESCRIPTION
## Summary

**Final PR for the security hardening bundle in #138.** Augments better-auth's \`SameSite=Lax\` cookie behavior with an explicit Origin allowlist on cookie-authenticated mutations.

For non-GET requests under \`/api/\` and \`/_actions/\`, the middleware now requires the \`Origin\` header to match \`env.BETTER_AUTH_URL\`. Requests with no \`Origin\` header are allowed (SSR-internal calls, non-browser clients like \`curl\` without a referrer); requests with a mismatching \`Origin\` are rejected with \`403\`.

## Changes

\`src/middleware.ts\`:

- New \`shouldEnforceOriginCheck(method, pathname)\` helper. Returns \`false\` for safe methods (\`GET\`, \`HEAD\`, \`OPTIONS\`) and for paths in the skip list. Otherwise enforces.
- The check runs **before** auth, so cross-origin requests don't even spend a session lookup before being rejected.
- Uses \`getCanonicalBaseUrl(env)\` (added in PR #147) so the allowed origin is sourced from \`env.BETTER_AUTH_URL\` and immune to \`Host\` header spoofing.

## Skip list

Four patterns skip the Origin check, each for a deliberate reason:

| Path | Why |
|---|---|
| \`/api/auth/*\` | better-auth performs its own origin check |
| \`/api/webhooks/stream\` | HMAC-signed (PR #146), no cookie auth, callers don't set \`Origin\` |
| \`/api/share/[token]/comments\` | Public anonymous endpoint (also dual-mode authenticated; trade noted below) |
| \`/api/share/[token]/view\` | Public anonymous endpoint, already rate-limited (PR #148) |

## Trade-off worth flagging

\`/api/share/[token]/comments\` POST is **dual-mode**: anonymous callers and authenticated callers both go through the same handler. Skipping it preserves the public-share flow but means an authenticated user could be CSRF'd into posting a comment via this endpoint.

The issue body explicitly calls for skipping this endpoint, so we honor that. The blast radius is small (an attacker can already post comments via routes the user has access to), and a follow-up could split this into two routes if needed.

## Out of scope (per issue)

- \`src/lib/auth.ts\` duplicate cookie-parser unification — separate follow-up.
- WebSocket Origin checks — separate PR with realtime work.
- Rate-limit binding for share comments — issue defers this to once the binding pattern is in place; PR #148 added it for OTP and view-count first.

## Testing

\`pnpm build\` passes (typecheck + Astro build).

Closes #138