### PR TITLE
fix(privacy): scope users queries, gate member emails, cascade reaction delete

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -15,6 +15,7 @@ import {
   approvalRequests,
   brainstorms,
   comments,
+  commentReactions,
   projects,
   scripts,
   shareLinks,
@@ -1429,11 +1430,27 @@ export const server = {
           });
         }
 
-        // Delete replies if this is a root comment
         if (!comment[0].parentId) {
-          await db.delete(comments).where(eq(comments.parentId, commentId));
+          const replyIds = await db
+            .select({ id: comments.id })
+            .from(comments)
+            .where(eq(comments.parentId, commentId));
+          if (replyIds.length > 0) {
+            await db
+              .delete(commentReactions)
+              .where(
+                inArray(
+                  commentReactions.commentId,
+                  replyIds.map((r) => r.id),
+                ),
+              );
+            await db.delete(comments).where(eq(comments.parentId, commentId));
+          }
         }
 
+        await db
+          .delete(commentReactions)
+          .where(eq(commentReactions.commentId, commentId));
         await db.delete(comments).where(eq(comments.id, commentId));
 
         return { success: true };

--- a/src/components/RequestApprovalDialog.tsx
+++ b/src/components/RequestApprovalDialog.tsx
@@ -5,7 +5,7 @@ import { Modal } from "./Modal";
 interface SpaceMemberOption {
   userId: string;
   name: string;
-  email: string;
+  email?: string;
   role: "owner" | "member";
 }
 
@@ -87,7 +87,7 @@ export function RequestApprovalDialog({
     return eligibleMembers.filter(
       (m) =>
         m.name.toLowerCase().includes(q) ||
-        m.email.toLowerCase().includes(q),
+        (m.email?.toLowerCase().includes(q) ?? false),
     );
   }, [eligibleMembers, filter]);
 
@@ -204,9 +204,11 @@ export function RequestApprovalDialog({
                             </span>
                           )}
                         </span>
-                        <span className="block truncate text-xs text-text-tertiary">
-                          {member.email}
-                        </span>
+                        {member.email && (
+                          <span className="block truncate text-xs text-text-tertiary">
+                            {member.email}
+                          </span>
+                        )}
                       </span>
                     </label>
                   </li>

--- a/src/components/SpaceSettings.tsx
+++ b/src/components/SpaceSettings.tsx
@@ -19,7 +19,7 @@ interface Member {
   role: string;
   createdAt: string;
   name: string;
-  email: string;
+  email?: string;
 }
 
 interface Invite {
@@ -279,7 +279,9 @@ export function SpaceSettings({
                     <span className="ml-2 text-xs text-text-tertiary">(you)</span>
                   )}
                 </p>
-                <p className="text-xs text-text-tertiary">{member.email}</p>
+                {member.email && (
+                  <p className="text-xs text-text-tertiary">{member.email}</p>
+                )}
               </div>
               <div className="flex items-center gap-3">
                 <span

--- a/src/pages/api/share/[token]/comments.ts
+++ b/src/pages/api/share/[token]/comments.ts
@@ -2,7 +2,7 @@ import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
 import { createDb } from "../../../../db";
 import { shareLinks, comments, projects, users, videos } from "../../../../db/schema";
-import { eq, asc, gt, and } from "drizzle-orm";
+import { eq, asc, gt, and, inArray } from "drizzle-orm";
 import { broadcastNewComment } from "../../../../lib/broadcast";
 import { addReactionSummaries } from "../../../../lib/comments";
 import { createCommentNotifications } from "../../../../lib/notifications";
@@ -58,7 +58,8 @@ export const GET: APIRoute = async ({ params, url }) => {
   if (userIds.length > 0) {
     const usersResult = await db
       .select({ id: users.id, name: users.name })
-      .from(users);
+      .from(users)
+      .where(inArray(users.id, userIds));
     userMap = Object.fromEntries(usersResult.map((u) => [u.id, u.name]));
   }
 

--- a/src/pages/api/share/[token]/index.ts
+++ b/src/pages/api/share/[token]/index.ts
@@ -2,7 +2,7 @@ import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
 import { createDb } from "../../../../db";
 import { shareLinks, videos, comments, users } from "../../../../db/schema";
-import { eq, asc } from "drizzle-orm";
+import { eq, asc, inArray } from "drizzle-orm";
 
 export const GET: APIRoute = async ({ params }) => {
   const { token } = params;
@@ -69,7 +69,8 @@ export const GET: APIRoute = async ({ params }) => {
   if (userIds.length > 0) {
     const usersResult = await db
       .select({ id: users.id, name: users.name })
-      .from(users);
+      .from(users)
+      .where(inArray(users.id, userIds));
     userMap = Object.fromEntries(usersResult.map((u) => [u.id, u.name]));
   }
 

--- a/src/pages/api/spaces/[id]/members/index.ts
+++ b/src/pages/api/spaces/[id]/members/index.ts
@@ -31,7 +31,7 @@ export const GET: APIRoute = async ({ params, locals }) => {
     });
   }
 
-  const members = await db
+  const rows = await db
     .select({
       id: spaceMembers.id,
       userId: spaceMembers.userId,
@@ -43,6 +43,11 @@ export const GET: APIRoute = async ({ params, locals }) => {
     .from(spaceMembers)
     .innerJoin(users, eq(spaceMembers.userId, users.id))
     .where(eq(spaceMembers.spaceId, id));
+
+  const members =
+    role === "owner"
+      ? rows
+      : rows.map(({ email: _email, ...rest }) => rest);
 
   return new Response(JSON.stringify({ members }), {
     headers: { "Content-Type": "application/json" },

--- a/src/pages/api/videos/[id]/comments.ts
+++ b/src/pages/api/videos/[id]/comments.ts
@@ -2,7 +2,7 @@ import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
 import { createDb } from "../../../../db";
 import { comments, users, videos } from "../../../../db/schema";
-import { eq, asc, gt, and } from "drizzle-orm";
+import { eq, asc, gt, and, inArray } from "drizzle-orm";
 import { verifySpaceAccess } from "../../../../lib/spaces";
 import { addReactionSummaries } from "../../../../lib/comments";
 
@@ -69,7 +69,8 @@ export const GET: APIRoute = async ({ params, locals, url }) => {
   if (userIds.length > 0) {
     const usersResult = await db
       .select({ id: users.id, name: users.name })
-      .from(users);
+      .from(users)
+      .where(inArray(users.id, userIds));
     userMap = Object.fromEntries(usersResult.map((u) => [u.id, u.name]));
   }
 

--- a/src/pages/spaces/[id]/settings.astro
+++ b/src/pages/spaces/[id]/settings.astro
@@ -26,7 +26,7 @@ const space = await db
 
 if (space.length === 0) return Astro.redirect("/dashboard");
 
-const members = await db
+const memberRows = await db
   .select({
     id: spaceMembers.id,
     userId: spaceMembers.userId,
@@ -38,6 +38,11 @@ const members = await db
   .from(spaceMembers)
   .innerJoin(users, eq(spaceMembers.userId, users.id))
   .where(eq(spaceMembers.spaceId, id));
+
+const members =
+  role === "owner"
+    ? memberRows
+    : memberRows.map(({ email: _email, ...rest }) => rest);
 
 const pendingInvites = role === "owner"
   ? await db


### PR DESCRIPTION
## Summary

- Three privacy/IDOR fixes from the security audit, bundled into one reviewable PR.
- Stops every comment-list endpoint from selecting the entire `users` table to resolve commenter names.
- Stops non-owner space members from seeing other members' emails.
- Stops `commentReactions` rows from being orphaned when a comment (or its replies) is deleted.

## Changes

- `src/pages/api/share/[token]/comments.ts`, `src/pages/api/share/[token]/index.ts`, `src/pages/api/videos/[id]/comments.ts`: filter the `users` lookup with `where(inArray(users.id, userIds))` after collecting comment author ids.
- `src/pages/api/spaces/[id]/members/index.ts`: keep returning the member list to all space members, but omit `email` for non-owner callers (option (b) from the issue).
- `src/pages/spaces/[id]/settings.astro`: same gating applied to the SSR data passed to `<SpaceSettings>` — this is the actual UI that was rendering emails to non-owners.
- `src/components/SpaceSettings.tsx`, `src/components/RequestApprovalDialog.tsx`: make `email` optional on the member type, only render it when present, and let the search filter handle a missing email.
- `src/actions/index.ts` (`comment.delete`): explicitly delete `commentReactions` for the comment and any replies before deleting the comments themselves. Schema-level cascade is deferred to #142 per the issue.

## Testing

`pnpm build` passes locally. See the manual test plan in the next comment for end-to-end scenarios.

## Out of scope

- Schema-level `ON DELETE CASCADE` on `commentReactions` — handled in #142.
- Other unfiltered `users` selects (e.g., notification fan-out keyed by membership) — not in scope.

Closes #139