### PR TITLE
fix(workflow): harden TranscriptWorkflow reliability

### DIFF
--- a/src/workflows/TranscriptWorkflow.ts
+++ b/src/workflows/TranscriptWorkflow.ts
@@ -36,122 +36,140 @@ export class TranscriptWorkflow extends WorkflowEntrypoint<Env, TranscriptWorkfl
     const { transcriptId, videoId } = event.payload;
     const db = createDb(this.env.DB);
 
-    const video = await step.do("load video", async () => {
-      const result = await db.select().from(videos).where(eq(videos.id, videoId)).limit(1);
-      if (!result[0]) throw new Error("Video not found");
-      if (!result[0].streamVideoId) throw new Error("Video is missing Stream ID");
-      return result[0];
-    });
+    try {
+      const video = await step.do("load video", async () => {
+        const result = await db.select().from(videos).where(eq(videos.id, videoId)).limit(1);
+        if (!result[0]) throw new Error("Video not found");
+        if (!result[0].streamVideoId) throw new Error("Video is missing Stream ID");
+        return result[0];
+      });
 
-    await step.do("mark exporting audio", async () => {
-      await db
-        .update(transcripts)
-        .set({ status: "exporting_audio", startedAt: now(), updatedAt: now() })
-        .where(eq(transcripts.id, transcriptId));
-    });
-
-    await step.do("request audio download", async () => {
-      await requestAudioDownload(
-        this.env.STREAM_ACCOUNT_ID,
-        this.env.STREAM_API_TOKEN,
-        video.streamVideoId!,
-      );
-    });
-
-    const audioUrl = await step.do(
-      "wait for audio download",
-      { retries: { limit: 20, delay: "15 seconds", backoff: "linear" }, timeout: "2 minutes" },
-      async () => {
+      await step.do("mark exporting audio", async () => {
         await db
           .update(transcripts)
-          .set({ status: "waiting_for_audio", updatedAt: now() })
+          .set({ status: "exporting_audio", startedAt: now(), updatedAt: now() })
           .where(eq(transcripts.id, transcriptId));
+      });
 
-        const audio = await getAudioDownload(
+      await step.do("request audio download", async () => {
+        await requestAudioDownload(
           this.env.STREAM_ACCOUNT_ID,
           this.env.STREAM_API_TOKEN,
           video.streamVideoId!,
         );
+      });
 
-        if (!audio || audio.status === "inprogress") {
-          throw new Error("Audio download is not ready yet");
-        }
-        if (audio.status !== "ready" || !audio.url) {
-          throw new Error(`Audio download failed with status ${audio.status}`);
-        }
-
+      await step.do("mark waiting for audio", async () => {
         await db
           .update(transcripts)
-          .set({ audioDownloadUrl: audio.url, updatedAt: now() })
+          .set({ status: "waiting_for_audio", updatedAt: now() })
+          .where(eq(transcripts.id, transcriptId));
+      });
+
+      const audioUrl = await step.do(
+        "wait for audio download",
+        { retries: { limit: 20, delay: "15 seconds", backoff: "linear" }, timeout: "2 minutes" },
+        async () => {
+          const audio = await getAudioDownload(
+            this.env.STREAM_ACCOUNT_ID,
+            this.env.STREAM_API_TOKEN,
+            video.streamVideoId!,
+          );
+
+          if (!audio || audio.status === "inprogress") {
+            throw new Error("Audio download is not ready yet");
+          }
+          if (audio.status !== "ready" || !audio.url) {
+            throw new Error(`Audio download failed with status ${audio.status}`);
+          }
+
+          await db
+            .update(transcripts)
+            .set({ audioDownloadUrl: audio.url, updatedAt: now() })
+            .where(eq(transcripts.id, transcriptId));
+
+          return audio.url;
+        },
+      );
+
+      const transcribed = await step.do("transcribe audio", { timeout: "10 minutes" }, async () => {
+        await db
+          .update(transcripts)
+          .set({ status: "transcribing", updatedAt: now() })
           .where(eq(transcripts.id, transcriptId));
 
-        return audio.url;
-      },
-    );
+        const audioResponse = await fetch(audioUrl);
+        if (!audioResponse.ok) throw new Error(`Audio fetch failed: ${audioResponse.status}`);
 
-    const whisper = await step.do("transcribe audio", { timeout: "10 minutes" }, async () => {
-      await db
-        .update(transcripts)
-        .set({ status: "transcribing", updatedAt: now() })
-        .where(eq(transcripts.id, transcriptId));
+        const audioBuffer = await audioResponse.arrayBuffer();
+        const audioBytes = new Uint8Array(audioBuffer);
+        const response = await this.env.AI.run("@cf/openai/whisper", {
+          audio: Array.from(audioBytes),
+        }) as WhisperResponse;
 
-      const audioResponse = await fetch(audioUrl);
-      if (!audioResponse.ok) throw new Error(`Audio fetch failed: ${audioResponse.status}`);
+        if (!response.text) throw new Error("Workers AI did not return transcript text");
 
-      const audioBytes = new Uint8Array(await audioResponse.arrayBuffer());
-      const response = await this.env.AI.run("@cf/openai/whisper", {
-        audio: [...audioBytes],
-      }) as WhisperResponse;
-
-      if (!response.text) throw new Error("Workers AI did not return transcript text");
-
-      await db
-        .update(transcripts)
-        .set({
-          rawText: response.text,
-          vtt: response.vtt || null,
-          wordCount: response.word_count || null,
-          status: "ready_raw_only",
-          updatedAt: now(),
-        })
-        .where(eq(transcripts.id, transcriptId));
-
-      return response;
-    });
-
-    await step.do("clean transcript", { timeout: "5 minutes" }, async () => {
-      await db
-        .update(transcripts)
-        .set({ status: "cleaning", updatedAt: now() })
-        .where(eq(transcripts.id, transcriptId));
-
-      try {
-        const response = await this.env.AI.run(this.env.TRANSCRIPT_CLEANUP_MODEL, {
-          messages: [{ role: "user", content: getCleanupPrompt(whisper.text!) }],
-        }) as TextGenerationResponse;
-
-        const cleaned = response.response?.trim();
         await db
           .update(transcripts)
           .set({
-            cleanedText: cleaned || null,
-            status: cleaned ? "ready" : "ready_raw_only",
-            completedAt: now(),
-            updatedAt: now(),
-          })
-          .where(eq(transcripts.id, transcriptId));
-      } catch (cleanupError) {
-        // Cleanup failure is non-fatal -- raw transcript is still usable.
-        await db
-          .update(transcripts)
-          .set({
+            rawText: response.text,
+            vtt: response.vtt || null,
+            wordCount: response.word_count || null,
             status: "ready_raw_only",
-            errorMessage: cleanupError instanceof Error ? cleanupError.message : "Transcript cleanup failed",
+            updatedAt: now(),
+          })
+          .where(eq(transcripts.id, transcriptId));
+
+        return { text: response.text };
+      });
+
+      await step.do("clean transcript", { timeout: "5 minutes" }, async () => {
+        await db
+          .update(transcripts)
+          .set({ status: "cleaning", updatedAt: now() })
+          .where(eq(transcripts.id, transcriptId));
+
+        try {
+          const response = await this.env.AI.run(this.env.TRANSCRIPT_CLEANUP_MODEL, {
+            messages: [{ role: "user", content: getCleanupPrompt(transcribed.text) }],
+          }) as TextGenerationResponse;
+
+          const cleaned = response.response?.trim();
+          await db
+            .update(transcripts)
+            .set({
+              cleanedText: cleaned || null,
+              status: cleaned ? "ready" : "ready_raw_only",
+              completedAt: now(),
+              updatedAt: now(),
+            })
+            .where(eq(transcripts.id, transcriptId));
+        } catch (cleanupError) {
+          // Cleanup failure is non-fatal -- raw transcript is still usable.
+          await db
+            .update(transcripts)
+            .set({
+              status: "ready_raw_only",
+              errorMessage: cleanupError instanceof Error ? cleanupError.message : "Transcript cleanup failed",
+              completedAt: now(),
+              updatedAt: now(),
+            })
+            .where(eq(transcripts.id, transcriptId));
+        }
+      });
+    } catch (err) {
+      await step.do("mark failed", async () => {
+        await db
+          .update(transcripts)
+          .set({
+            status: "failed",
+            errorMessage: err instanceof Error ? err.message : "Unknown workflow error",
             completedAt: now(),
             updatedAt: now(),
           })
           .where(eq(transcripts.id, transcriptId));
-      }
-    });
+      });
+      throw err;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Three small but high-confidence reliability fixes to `TranscriptWorkflow`:

- **Global error handler** so workflow failures land the transcript row in `failed` with an `errorMessage` instead of silently stuck in an intermediate status.
- **Move the `waiting_for_audio` status write out of the retried polling step** so it doesn't fire up to 20 times per transcript.
- **Replace `[...audioBytes]` spread with `Array.from(audioBytes)`** when handing audio to `env.AI.run('@cf/openai/whisper')`. The Whisper binding officially requires `number[]` (per [Cloudflare docs](https://developers.cloudflare.com/workers-ai/models/whisper/)), so we still pay the array conversion, but `Array.from` skips the spread iterator's intermediate allocation. Audio buffer references are now narrowly scoped inside the step closure so they can be GC'd as soon as the step returns.

Also slimmed the `transcribe audio` step return value to `{ text }` only — the raw text is the sole field consumed downstream, so persisting the full Whisper response in Workflow durable state was redundant with what already gets written to D1.

## Why

- Without a global catch, retries-exhausted failures stick the transcript row in `exporting_audio` / `waiting_for_audio` / `transcribing` with no `errorMessage`, and users get no feedback that something went wrong.
- The `waiting_for_audio` status write was inside the retried polling step's closure, so each retry attempt re-issued the same UPDATE. For a video where audio download takes the full 5 minutes (20 attempts at 15s), that's 20 redundant writes.
- The spread `[...audioBytes]` pattern walks the `Uint8Array` via its iterator before allocating a `number[]` of equal length. `Array.from` does the same allocation in a single pass without the iterator step.

## Closes

- Closes #24 (global error handler)
- Closes #25 (redundant DB writes in retried steps)
- Closes #26 (audio byte array spread)

## Verification

- `pnpm build` passes.
- File-level diff is mostly indentation (try/catch wrapper) plus the three targeted fixes.
- No schema changes.

## Manual test plan

1. Upload a new video and confirm transcript generation reaches `status='ready'` end-to-end (happy path).
2. Force a failure during transcription (e.g. by temporarily corrupting the `STREAM_ACCOUNT_ID` so `requestAudioDownload` 401s) and confirm the transcript row ends up with `status='failed'` and a populated `errorMessage`. Restore the env var and verify a fresh transcript succeeds.
3. Watch D1 logs / `wrangler tail` while a transcript is waiting on audio export — confirm only **one** `UPDATE transcripts SET status='waiting_for_audio'` per workflow run, regardless of how many retry attempts happen.

## Out of scope

- Per-step retry config for `transcribe audio` and `clean transcript` (issue #28).
- Splitting the cleanup step into AI-call vs persist (covered in #140).