### PR TITLE
feat(email): add SEND_REAL_EMAILS flag to log emails to console

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -73,6 +73,7 @@ import {
   markNotificationsReadByVideoTab,
 } from "../lib/notifications";
 import { buildInviteAuthPath, buildInviteEmail } from "../lib/email";
+import { sendEmail } from "../lib/send-email";
 
 // Re-export ActionError for convenience
 export { ActionError } from "astro:actions";
@@ -746,7 +747,7 @@ export const server = {
               actorDisplayName: user.name,
             },
             {
-              send: (msg) => env.EMAIL.send(msg),
+              send: (msg) => sendEmail(env, msg),
               from: env.OTP_EMAIL_FROM,
               baseUrl: getCanonicalBaseUrl(env),
             },
@@ -1365,7 +1366,7 @@ export const server = {
               phase,
             },
             {
-              send: (msg) => env.EMAIL.send(msg),
+              send: (msg) => sendEmail(env, msg),
               from: env.OTP_EMAIL_FROM,
               baseUrl: getCanonicalBaseUrl(env),
             },
@@ -1593,7 +1594,7 @@ export const server = {
               phase: parent[0].phase,
             },
             {
-              send: (msg) => env.EMAIL.send(msg),
+              send: (msg) => sendEmail(env, msg),
               from: env.OTP_EMAIL_FROM,
               baseUrl: getCanonicalBaseUrl(env),
             },
@@ -1933,7 +1934,7 @@ export const server = {
         });
 
         try {
-          await env.EMAIL.send({
+          await sendEmail(env, {
             to: input.email,
             from: env.OTP_EMAIL_FROM,
             subject: email.subject,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,12 +6,16 @@ import { eq, and } from "drizzle-orm";
 import { sessions, videos, shareLinks, spaceMembers } from "../db/schema";
 import * as schema from "../db/schema";
 import type { Database } from "../db";
+import { sendEmail } from "./send-email";
 
 export type VideoAccess =
   | { ok: true; videoId: string; spaceId: string; identity: { type: "user"; userId: string } | { type: "anonymous" } }
   | { ok: false; status: number; error: string };
 
-type AuthEnv = Pick<Cloudflare.Env, "BETTER_AUTH_SECRET" | "BETTER_AUTH_URL" | "EMAIL" | "OTP_EMAIL_FROM">;
+type AuthEnv = Pick<
+  Cloudflare.Env,
+  "BETTER_AUTH_SECRET" | "BETTER_AUTH_URL" | "EMAIL" | "OTP_EMAIL_FROM" | "SEND_REAL_EMAILS"
+>;
 
 function getOtpEmailSubject(type: "sign-in" | "email-verification" | "forget-password" | "change-email"): string {
   switch (type) {
@@ -59,7 +63,7 @@ export function createAuth(d1: D1Database, env: AuthEnv) {
           const normalizedEmail = email.trim().toLowerCase();
           const { subject, text, html } = getOtpEmailBody(otp, type);
 
-          await env.EMAIL.send({
+          await sendEmail(env, {
             to: normalizedEmail,
             from: env.OTP_EMAIL_FROM,
             subject,

--- a/src/lib/send-email.ts
+++ b/src/lib/send-email.ts
@@ -1,0 +1,36 @@
+export interface EmailMessagePayload {
+  to: string;
+  from: string;
+  subject: string;
+  text: string;
+  html: string;
+}
+
+type SendEmailEnv = Pick<Cloudflare.Env, "EMAIL" | "SEND_REAL_EMAILS">;
+
+function shouldSendRealEmails(env: SendEmailEnv): boolean {
+  return (env.SEND_REAL_EMAILS as string | undefined) !== "false";
+}
+
+export async function sendEmail(
+  env: SendEmailEnv,
+  message: EmailMessagePayload,
+): Promise<void> {
+  if (shouldSendRealEmails(env)) {
+    await env.EMAIL.send(message);
+    return;
+  }
+
+  const divider = "─".repeat(60);
+  console.log(`[email:dry-run] ${divider}`);
+  console.log(`[email:dry-run] to:      ${message.to}`);
+  console.log(`[email:dry-run] from:    ${message.from}`);
+  console.log(`[email:dry-run] subject: ${message.subject}`);
+  console.log(`[email:dry-run] ${divider}`);
+  console.log(`[email:dry-run] text:`);
+  console.log(message.text);
+  console.log(`[email:dry-run] ${divider}`);
+  console.log(`[email:dry-run] html:`);
+  console.log(message.html);
+  console.log(`[email:dry-run] ${divider}`);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -52,6 +52,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
     BETTER_AUTH_URL: env.BETTER_AUTH_URL,
     EMAIL: env.EMAIL,
     OTP_EMAIL_FROM: env.OTP_EMAIL_FROM,
+    SEND_REAL_EMAILS: env.SEND_REAL_EMAILS,
   });
 
   try {

--- a/src/pages/api/auth/[...all].ts
+++ b/src/pages/api/auth/[...all].ts
@@ -8,6 +8,7 @@ export const ALL: APIRoute = async ({ request }) => {
     BETTER_AUTH_URL: env.BETTER_AUTH_URL,
     EMAIL: env.EMAIL,
     OTP_EMAIL_FROM: env.OTP_EMAIL_FROM,
+    SEND_REAL_EMAILS: env.SEND_REAL_EMAILS,
   });
 
   return auth.handler(request);

--- a/src/pages/api/otp/send.ts
+++ b/src/pages/api/otp/send.ts
@@ -73,6 +73,7 @@ export const POST: APIRoute = async ({ request }) => {
     BETTER_AUTH_URL: env.BETTER_AUTH_URL,
     EMAIL: env.EMAIL,
     OTP_EMAIL_FROM: env.OTP_EMAIL_FROM,
+    SEND_REAL_EMAILS: env.SEND_REAL_EMAILS,
   });
 
   try {

--- a/src/pages/api/otp/verify.ts
+++ b/src/pages/api/otp/verify.ts
@@ -55,6 +55,7 @@ export const POST: APIRoute = async ({ request }) => {
     BETTER_AUTH_URL: env.BETTER_AUTH_URL,
     EMAIL: env.EMAIL,
     OTP_EMAIL_FROM: env.OTP_EMAIL_FROM,
+    SEND_REAL_EMAILS: env.SEND_REAL_EMAILS,
   });
 
   return auth.api.signInEmailOTP({

--- a/src/pages/api/share/[token]/comments.ts
+++ b/src/pages/api/share/[token]/comments.ts
@@ -6,6 +6,7 @@ import { eq, asc, gt, and, inArray } from "drizzle-orm";
 import { broadcastNewComment } from "../../../../lib/broadcast";
 import { addReactionSummaries } from "../../../../lib/comments";
 import { createCommentNotifications } from "../../../../lib/notifications";
+import { sendEmail } from "../../../../lib/send-email";
 import { anonymousCommentSchema, commentSchema } from "../../../../lib/validation";
 import { getCanonicalBaseUrl } from "../../../../lib/urls";
 import { z } from "zod";
@@ -231,7 +232,7 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
       parentCommentId: newComment.parentId,
       phase: newComment.phase,
     }, {
-      send: (msg) => env.EMAIL.send(msg),
+      send: (msg) => sendEmail(env, msg),
       from: env.OTP_EMAIL_FROM,
       baseUrl: getCanonicalBaseUrl(env),
     }, env);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -69,6 +69,7 @@
     "TRANSCRIPT_CLEANUP_MODEL": "@cf/meta/llama-3.1-8b-instruct",
     "BETTER_AUTH_URL": "http://localhost:4321",
     "OTP_EMAIL_FROM": "noreply@quickcuts.app",
+    "SEND_REAL_EMAILS": "true",
   },
   "ratelimits": [
     {


### PR DESCRIPTION
## Summary

Adds an optional `SEND_REAL_EMAILS` env var (defaults to `"true"`) that controls whether outbound emails are actually sent via the Cloudflare `EMAIL` binding or logged to the console for inspection.

## Changes

- **New helper** `src/lib/send-email.ts` exporting `sendEmail(env, message)`. When `env.SEND_REAL_EMAILS === "false"`, the helper pretty-prints the full payload (`to`, `from`, `subject`, `text`, `html`) to the console with an `[email:dry-run]` prefix. Otherwise it calls `env.EMAIL.send(message)`.
- **`wrangler.jsonc`**: adds `SEND_REAL_EMAILS: "true"` to `vars` (production-safe default).
- **All 6 `env.EMAIL.send` call sites** now route through the helper:
  - `src/lib/auth.ts` — OTP sign-in / verification emails (better-auth plugin)
  - `src/actions/index.ts` — targeted approval requests, script comments, review comments, replies, space invites
  - `src/pages/api/share/[token]/comments.ts` — anonymous share-link comment notifications
- **`AuthEnv`** in `src/lib/auth.ts` now includes `SEND_REAL_EMAILS`; the four `createAuth(...)` callers (`middleware.ts`, `api/otp/send.ts`, `api/otp/verify.ts`, `api/auth/[...all].ts`) pass it through.

## Behavior

| \`SEND_REAL_EMAILS\` | Result |
|---|---|
| missing / unset / \`"true"\` / anything else | Real email sent via \`env.EMAIL.send\` |
| \`"false"\` (literal string) | Email logged to console with \`[email:dry-run]\` prefix; nothing sent |

## Verification

- \`pnpm build\` passes (types + Astro server build).
- All previous \`env.EMAIL.send\` references replaced; only \`src/lib/send-email.ts\` retains the direct binding call.

## Manual test plan

1. With \`SEND_REAL_EMAILS\` unset (or \`"true"\`): trigger any email path (e.g. send an OTP, invite a user) and confirm a real email is sent — unchanged from main.
2. Set \`SEND_REAL_EMAILS=false\` in \`.dev.vars\` (or override \`wrangler.jsonc\`), restart dev server, and trigger the same path. No email should be sent; the worker logs should show:
   \`\`\`
   [email:dry-run] ────────────────────────────────────────────────────────────
   [email:dry-run] to:      ...
   [email:dry-run] from:    ...
   [email:dry-run] subject: ...
   ...
   \`\`\`
3. Remove the override and confirm normal sending resumes.