### PR TITLE
chore(wrangler): mark FLAGS binding as remote

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -16,6 +16,7 @@
     {
       "binding": "FLAGS",
       "app_id": "0e0911ff-8d97-4af0-a6cb-95093b8b045e",
+      "remote": true,
     },
   ],
   "ai": {


### PR DESCRIPTION
## Summary

Sets `remote: true` on the Flagship `FLAGS` binding in `wrangler.jsonc` so local dev reads feature flags from the deployed Flagship app instead of an empty local stub.

## Context

This was a long-standing local-only edit on the `main` checkout that hadn't been committed. Surfacing it as its own PR.

## Verification

Single-line config change. No code paths to test; confirmed via `git diff` that only the `FLAGS` binding gains `"remote": true`.