### PR TITLE
fix(wrangler): stop overwriting BETTER_AUTH_URL on deploy

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -68,9 +68,7 @@
     "STREAM_ACCOUNT_ID": "4426cbeacb457b1ca1b865d6c36ced0d",
     "TRANSCRIPTS_ENABLED": "true",
     "TRANSCRIPT_CLEANUP_MODEL": "@cf/meta/llama-3.1-8b-instruct",
-    "BETTER_AUTH_URL": "http://localhost:4321",
     "OTP_EMAIL_FROM": "noreply@quickcuts.app",
-    "SEND_REAL_EMAILS": "true",
   },
   "ratelimits": [
     {


### PR DESCRIPTION
## Summary

`wrangler.jsonc` defined `BETTER_AUTH_URL` and `SEND_REAL_EMAILS` in the top-level `vars` block. Wrangler treats `vars` as the source of truth and rewrites those values on every `wrangler deploy`, which kept resetting production's `BETTER_AUTH_URL` back to `http://localhost:4321`.

That caused the origin/CSRF check in `src/middleware.ts` to compare incoming `Origin: https://quickcuts.app` against `http://localhost:4321` and reject the request with `403`, surfacing in the browser as a CORS-shaped error on `POST /api/otp/send`.

This PR removes both keys from `vars`. They are now configured per environment instead.

## Changes

- `wrangler.jsonc`: remove `BETTER_AUTH_URL` and `SEND_REAL_EMAILS` from `vars`.

No code changes. No new `env.production` block. No binding duplication. The fail-fast behavior is intentional — if `BETTER_AUTH_URL` is missing in production, `new URL(undefined)` in `src/lib/urls.ts` throws on the first request.

## Required follow-up actions

### Production (one-time)

\`\`\`
wrangler secret put BETTER_AUTH_URL
# paste: https://quickcuts.app
\`\`\`

\`SEND_REAL_EMAILS\` is intentionally **not** set in production. \`src/lib/send-email.ts:12\` defaults to sending real emails when the value is unset (only \`\"false\"\` disables it).

### Local development

Add to \`.dev.vars\`:

\`\`\`
BETTER_AUTH_URL=http://localhost:4321
SEND_REAL_EMAILS=false
\`\`\`

The \`worktree-setup\` flow already copies \`.dev.vars\` between worktrees, so this propagates automatically to feature branches.

## Verification

- \`wrangler secret list\` shows \`BETTER_AUTH_URL\` after the secret is set.
- Web sign-in at \`https://quickcuts.app\` works — the middleware origin check now resolves \`getCanonicalBaseUrl(env)\` to \`https://quickcuts.app\`.
- Local \`pnpm dev\`: OTP requests log \`[email:dry-run]\` instead of sending real emails.

## Out of scope

- Android emulator (\`10.0.2.2\`) is still blocked by the origin check because the mobile shell sends a non-matching \`Origin\` header. That's a separate fix and will be handled in a follow-up PR.