### PR TITLE
feat(script): improve comment selection and highlight UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@astrojs/react": "^5.0.4",
     "@tiptap/core": "^3.22.5",
     "@tiptap/extension-placeholder": "^3.22.5",
+    "@tiptap/pm": "^3.22.5",
     "@tiptap/react": "^3.22.5",
     "@tiptap/starter-kit": "^3.22.5",
     "astro": "^6.1.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@tiptap/extension-placeholder':
         specifier: ^3.22.5
         version: 3.22.5(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/pm':
+        specifier: ^3.22.5
+        version: 3.22.5
       '@tiptap/react':
         specifier: ^3.22.5
         version: 3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)

--- a/src/components/ScriptWorkspace.tsx
+++ b/src/components/ScriptWorkspace.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
 import { actions } from "astro:actions";
 import { Mark } from "@tiptap/core";
 import Placeholder from "@tiptap/extension-placeholder";
@@ -9,6 +9,8 @@ import type { Comment, CommentUrgency, TextRange } from "../types";
 import { relativeTime } from "../lib/time";
 import { connectVideoRoom, type Viewer } from "../lib/realtime";
 import { PresenceBar } from "./PresenceBar";
+import { PendingCommentHighlight } from "./pendingCommentHighlight";
+import { CommentHighlightDecorations } from "./commentHighlightDecorations";
 
 const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] };
 
@@ -169,14 +171,7 @@ const CommentHighlight = Mark.create({
     return [{ tag: "mark[data-comment-id]" }];
   },
   renderHTML({ HTMLAttributes }) {
-    return [
-      "mark",
-      {
-        ...HTMLAttributes,
-        class: "rounded bg-accent-warning/25 px-0.5 text-text-primary decoration-accent-warning underline decoration-2 underline-offset-2",
-      },
-      0,
-    ];
+    return ["span", { ...HTMLAttributes }, 0];
   },
 });
 
@@ -258,7 +253,9 @@ export function ScriptWorkspace({
   const [viewers, setViewers] = useState<Viewer[]>([]);
   const [presenceLoading, setPresenceLoading] = useState(false);
   const [filter, setFilter] = useState<FilterType>("all");
+  const [activeCommentId, setActiveCommentId] = useState<string | null>(null);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const commentRowRefs = useRef<Map<string, HTMLElement>>(new Map());
   const isReviewMode = true;
   const isReviewModeRef = useRef(isReviewMode);
 
@@ -350,6 +347,8 @@ export function ScriptWorkspace({
       StarterKit.configure({ heading: { levels: [1, 2, 3] } }),
       Placeholder.configure({ placeholder: "Write the hook, outline, or full script here..." }),
       CommentHighlight,
+      PendingCommentHighlight,
+      CommentHighlightDecorations,
     ],
     content: parseInitialContent(initialContent),
     editorProps: {
@@ -381,6 +380,34 @@ export function ScriptWorkspace({
   useEffect(() => {
     if (editor) editor.setEditable(canEditScript);
   }, [editor, canEditScript]);
+
+  useEffect(() => {
+    if (!editor) return;
+    editor.commands.setPendingCommentRange(
+      selectedRange ? { from: selectedRange.from, to: selectedRange.to } : null,
+    );
+  }, [editor, selectedRange]);
+
+  useEffect(() => {
+    if (!editor) return;
+    const items = comments
+      .filter((c) => c.phase === "script" && !c.isResolved && c.textRange && !c.parentId)
+      .map((c) => ({
+        id: c.id,
+        from: c.textRange!.from,
+        to: c.textRange!.to,
+        quote: c.textRange!.quote,
+      }));
+    editor.commands.setCommentHighlights(items);
+  }, [editor, comments]);
+
+  useEffect(() => {
+    if (!activeCommentId) return;
+    const stillActive = comments.some(
+      (c) => c.id === activeCommentId && !c.isResolved && !c.parentId,
+    );
+    if (!stillActive) setActiveCommentId(null);
+  }, [activeCommentId, comments]);
 
   useEffect(() => () => {
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
@@ -449,16 +476,6 @@ export function ScriptWorkspace({
         });
         if (error || !data) throw new Error(error?.message || "Failed to create comment");
         comment = data.comment as Comment;
-      }
-
-      if (canEditScript && comment) {
-        editor
-          .chain()
-          .focus()
-          .setTextSelection({ from: selectedRange.from, to: selectedRange.to })
-          .setMark("commentHighlight", { commentId: comment.id })
-          .run();
-        await saveScript(JSON.stringify(editor.getJSON()), editor.getText());
       }
 
       if (comment) {
@@ -536,9 +553,32 @@ export function ScriptWorkspace({
     }
   };
 
+  const activateComment = (commentId: string) => {
+    const comment = comments.find((c) => c.id === commentId);
+    if (!comment) return;
+    setActiveCommentId(commentId);
+    const row = commentRowRefs.current.get(commentId);
+    if (row) row.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    if (editor && comment.textRange) {
+      editor
+        .chain()
+        .focus()
+        .setTextSelection({ from: comment.textRange.from, to: comment.textRange.to })
+        .run();
+    }
+  };
+
   const focusComment = (comment: Comment) => {
-    if (!editor || !comment.textRange) return;
-    editor.chain().focus().setTextSelection({ from: comment.textRange.from, to: comment.textRange.to }).run();
+    activateComment(comment.id);
+  };
+
+  const handleEditorClick = (event: ReactMouseEvent<HTMLDivElement>) => {
+    const target = event.target as HTMLElement | null;
+    if (!target) return;
+    const hit = target.closest<HTMLElement>("[data-comment-id]");
+    if (!hit) return;
+    const id = hit.getAttribute("data-comment-id");
+    if (id) activateComment(id);
   };
 
   return (
@@ -564,7 +604,11 @@ export function ScriptWorkspace({
               )}
             </div>
           </div>
-          <EditorContent editor={editor} className="script-editor max-h-[560px] overflow-y-auto bg-bg-input" />
+          <EditorContent
+            editor={editor}
+            onClick={handleEditorClick}
+            className="script-editor max-h-[560px] overflow-y-auto bg-bg-input"
+          />
         </div>
 
       </div>
@@ -617,12 +661,17 @@ export function ScriptWorkspace({
               const meta = URGENCY_META[comment.urgency];
               const displayName = comment.name || viewerName;
               const replies = getReplies(comment.id);
+              const isActive = activeCommentId === comment.id;
               return (
                 <article
                   key={comment.id}
-                  className={`space-y-3 rounded-lg p-2 -m-2 transition-shadow duration-500 ${
-                    comment.isResolved ? "border-l-2 border-accent-secondary pl-3 opacity-50" : ""
-                  }`}
+                  ref={(el) => {
+                    if (el) commentRowRefs.current.set(comment.id, el);
+                    else commentRowRefs.current.delete(comment.id);
+                  }}
+                  className={`space-y-3 rounded-lg p-2 -m-2 transition-all duration-200 ${
+                    isActive ? "bg-accent-warning/10 ring-1 ring-accent-warning/60" : ""
+                  } ${comment.isResolved ? "border-l-2 border-accent-secondary pl-3 opacity-50" : ""}`}
                 >
                   <div className="flex gap-3">
                     <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent-primary text-xs font-medium text-white">

--- a/src/components/commentHighlightDecorations.ts
+++ b/src/components/commentHighlightDecorations.ts
@@ -1,0 +1,158 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import type { Node as PMNode } from "@tiptap/pm/model";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+const SAVED_HIGHLIGHT_CLASS =
+  "rounded bg-accent-warning/25 px-0.5 text-text-primary decoration-accent-warning underline decoration-2 underline-offset-2";
+
+export interface CommentHighlightItem {
+  id: string;
+  from: number;
+  to: number;
+  quote: string;
+}
+
+interface CommentHighlightMeta {
+  items: CommentHighlightItem[];
+}
+
+export const commentHighlightDecorationsKey = new PluginKey<DecorationSet>("commentHighlightDecorations");
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    commentHighlightDecorations: {
+      setCommentHighlights: (items: CommentHighlightItem[]) => ReturnType;
+    };
+  }
+}
+
+function normalize(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function findQuoteRange(doc: PMNode, quote: string): { from: number; to: number } | null {
+  const target = normalize(quote);
+  if (!target) return null;
+
+  let found: { from: number; to: number } | null = null;
+
+  doc.descendants((node, pos) => {
+    if (found) return false;
+    if (!node.isText || !node.text) return true;
+
+    const text = node.text;
+    const normalizedText = normalize(text);
+    const idx = normalizedText.indexOf(target);
+    if (idx === -1) return true;
+
+    let consumed = 0;
+    let rawStart = -1;
+    let rawEnd = -1;
+    let prevWasSpace = true;
+    for (let i = 0; i < text.length; i++) {
+      const ch = text[i]!;
+      const isSpace = /\s/.test(ch);
+      const normalizedChar = isSpace ? (prevWasSpace ? "" : " ") : ch;
+      if (normalizedChar) {
+        if (consumed === idx && rawStart === -1) rawStart = i;
+        consumed++;
+        if (consumed === idx + target.length) {
+          rawEnd = i + 1;
+          break;
+        }
+      }
+      prevWasSpace = isSpace;
+    }
+
+    if (rawStart === -1 || rawEnd === -1) return true;
+    found = { from: pos + rawStart, to: pos + rawEnd };
+    return false;
+  });
+
+  return found;
+}
+
+function buildDecorations(doc: PMNode, items: CommentHighlightItem[]): DecorationSet {
+  const decorations: Decoration[] = [];
+
+  for (const item of items) {
+    const docSize = doc.content.size;
+    let from = item.from;
+    let to = item.to;
+
+    const inBounds = from >= 0 && to <= docSize && from < to;
+    const matches =
+      inBounds && normalize(doc.textBetween(from, to, " ")) === normalize(item.quote);
+
+    if (!matches) {
+      const recovered = findQuoteRange(doc, item.quote);
+      if (!recovered) continue;
+      from = recovered.from;
+      to = recovered.to;
+    }
+
+    decorations.push(
+      Decoration.inline(from, to, {
+        class: SAVED_HIGHLIGHT_CLASS,
+        "data-comment-id": item.id,
+      }),
+    );
+  }
+
+  return decorations.length ? DecorationSet.create(doc, decorations) : DecorationSet.empty;
+}
+
+export const CommentHighlightDecorations = Extension.create({
+  name: "commentHighlightDecorations",
+
+  addStorage() {
+    return {
+      items: [] as CommentHighlightItem[],
+    };
+  },
+
+  addCommands() {
+    return {
+      setCommentHighlights:
+        (items) =>
+        ({ tr, dispatch, editor }) => {
+          const storage = (editor.storage as unknown as Record<string, { items: CommentHighlightItem[] } | undefined>)[
+            "commentHighlightDecorations"
+          ];
+          if (storage) storage.items = items;
+          if (dispatch) {
+            const meta: CommentHighlightMeta = { items };
+            dispatch(tr.setMeta(commentHighlightDecorationsKey, meta));
+          }
+          return true;
+        },
+    };
+  },
+
+  addProseMirrorPlugins() {
+    const storage = this.storage as { items: CommentHighlightItem[] };
+    return [
+      new Plugin<DecorationSet>({
+        key: commentHighlightDecorationsKey,
+        state: {
+          init: (_, state) => buildDecorations(state.doc, storage.items),
+          apply(tr, current) {
+            const meta = tr.getMeta(commentHighlightDecorationsKey) as
+              | CommentHighlightMeta
+              | undefined;
+
+            if (meta) return buildDecorations(tr.doc, meta.items);
+            if (!tr.docChanged) return current;
+            return current.map(tr.mapping, tr.doc);
+          },
+        },
+        props: {
+          decorations(state) {
+            return this.getState(state) ?? DecorationSet.empty;
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/src/components/pendingCommentHighlight.ts
+++ b/src/components/pendingCommentHighlight.ts
@@ -1,0 +1,75 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+const PENDING_HIGHLIGHT_CLASS =
+  "rounded bg-accent-warning/15 px-0.5 text-text-primary decoration-accent-warning/70 underline decoration-dashed decoration-2 underline-offset-2";
+
+export interface PendingRange {
+  from: number;
+  to: number;
+}
+
+interface PendingMeta {
+  range: PendingRange | null;
+}
+
+export const pendingCommentHighlightKey = new PluginKey<DecorationSet>("pendingCommentHighlight");
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    pendingCommentHighlight: {
+      setPendingCommentRange: (range: PendingRange | null) => ReturnType;
+    };
+  }
+}
+
+export const PendingCommentHighlight = Extension.create({
+  name: "pendingCommentHighlight",
+
+  addCommands() {
+    return {
+      setPendingCommentRange:
+        (range) =>
+        ({ tr, dispatch }) => {
+          if (dispatch) {
+            const meta: PendingMeta = { range };
+            dispatch(tr.setMeta(pendingCommentHighlightKey, meta));
+          }
+          return true;
+        },
+    };
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin<DecorationSet>({
+        key: pendingCommentHighlightKey,
+        state: {
+          init: () => DecorationSet.empty,
+          apply(tr, current) {
+            const meta = tr.getMeta(pendingCommentHighlightKey) as PendingMeta | undefined;
+
+            if (meta) {
+              if (!meta.range) return DecorationSet.empty;
+              const { from, to } = meta.range;
+              if (from === to) return DecorationSet.empty;
+              const decoration = Decoration.inline(from, to, {
+                class: PENDING_HIGHLIGHT_CLASS,
+              });
+              return DecorationSet.create(tr.doc, [decoration]);
+            }
+
+            if (!tr.docChanged) return current;
+            return current.map(tr.mapping, tr.doc);
+          },
+        },
+        props: {
+          decorations(state) {
+            return this.getState(state) ?? DecorationSet.empty;
+          },
+        },
+      }),
+    ];
+  },
+});


### PR DESCRIPTION
## Summary

Improves three connected problems with script commenting:

- **Selection disappeared on compose.** Selecting text and clicking into the comment input made the editor's native selection vanish, so users couldn't tell what their comment was attached to.
- **Highlights only worked for one role.** The saved `<mark>` was only written when `canEditScript` was true, meaning anonymous share-mode commenters and logged-in share-link viewers never got a persistent highlight at all. Even the author's highlight was tied to a doc-write side effect rather than to the comment itself.
- **No editor → sidebar binding.** Clicking a highlighted phrase in the script did nothing.

## Changes

- New `PendingCommentHighlight` Tiptap extension: dashed-underline decoration that stays on the selected range while the user composes a comment, surviving focus loss to the sidebar input.
- New `CommentHighlightDecorations` Tiptap extension: derives persistent highlights from the React `comments` array. Renders for every unresolved script-phase comment regardless of who created it or what role the viewer has. Highlights survive page reloads because they're rebuilt from comment rows on load.
- Stale-anchor recovery: each decoration validates `doc.textBetween(from, to)` against `comment.textRange.quote` and falls back to a whitespace-tolerant plain-text search if positions drifted after another user's edit.
- `createScriptComment` no longer writes a `commentHighlight` mark into the saved doc or triggers an extra `script.update` for highlight purposes. The Mark schema stays registered with a no-op `renderHTML` so any preexisting saved JSON still parses cleanly without contributing styling.
- Two-way binding: clicking a highlight in the editor scrolls the matching comment into view in the sidebar and applies an active ring on the card; clicking a sidebar row keeps the existing range-selection behavior and now also activates the card. Active state persists until a different comment/highlight is clicked or the active comment is resolved.

## Behavior matrix after the change

| User | Highlight after reload |
|---|---|
| Owner / member at `/videos/[id]` | yes (was yes) |
| Logged-in user via `/s/[token]` | **yes** (was no) |
| Anonymous via `/s/[token]` | **yes** (was no) |
| Resolved comments | no highlight (intentional) |

## Manual test plan

1. As owner at `/videos/[id]`: select script text, type a comment, submit. Highlight appears. Reload. Highlight still there.
2. In an incognito tab as anonymous via `/s/[token]`: same flow. Highlight appears. Reload. Highlight still there.
3. Click a highlighted phrase in the editor: the matching comment scrolls into view in the sidebar and gets a yellow ring. Click a different highlight: ring moves.
4. Click a comment row in the sidebar: editor selects the underlying range, card gets the ring.
5. Resolve a comment: highlight disappears and the active ring clears.
6. Open two tabs (owner + share viewer). Owner edits text adjacent to a highlight: share viewer's decoration tracks the edit via `tr.mapping`. Owner deletes the quoted text entirely: server auto-resolves on the next save, share viewer's decoration disappears.