### PR TITLE
refactor(upload): extract shared tus upload logic into lib + hook

### DIFF
--- a/src/components/UploadVersionModal.tsx
+++ b/src/components/UploadVersionModal.tsx
@@ -1,15 +1,9 @@
 import { useId, useRef, useState } from "react";
 import { actions } from "astro:actions";
-import * as tus from "tus-js-client";
 import { friendlyActionErrorMessage } from "../lib/errors";
+import { ALLOWED_EXTENSIONS_ACCEPT, formatFileSize } from "../lib/upload";
+import { useTusUpload } from "../hooks/useTusUpload";
 import { Modal } from "./Modal";
-
-const ALLOWED_EXTENSIONS = ["mp4", "mov", "webm", "avi", "mkv"];
-const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024;
-const TUS_CHUNK_SIZE = 52_428_800;
-const TUS_RETRY_DELAYS = [0, 3000, 5000, 10000, 20000];
-
-type UploadState = "idle" | "selected" | "uploading" | "processing" | "error";
 
 interface UploadVersionModalProps {
   videoId: string;
@@ -19,12 +13,6 @@ interface UploadVersionModalProps {
   // trigger is hidden in this mode.
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
-}
-
-function formatFileSize(bytes: number): string {
-  if (bytes >= 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
-  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / 1024).toFixed(1)} KB`;
 }
 
 export function UploadVersionModal({
@@ -42,109 +30,49 @@ export function UploadVersionModal({
     if (!isControlled) setInternalOpen(next);
     onOpenChange?.(next);
   };
-  const [state, setState] = useState<UploadState>("idle");
-  const [file, setFile] = useState<File | null>(null);
   const [versionNotes, setVersionNotes] = useState("");
   const [generateTranscript, setGenerateTranscript] = useState(false);
-  const [progress, setProgress] = useState(0);
-  const [error, setError] = useState("");
   const [dragOver, setDragOver] = useState(false);
-
-  const reset = () => {
-    setState("idle");
-    setFile(null);
-    setVersionNotes("");
-    setGenerateTranscript(false);
-    setProgress(0);
-    setError("");
-    setDragOver(false);
-  };
+  const { state, file, progress, error, selectFile, startUpload, reset } = useTusUpload();
 
   const close = () => {
     if (state === "uploading") return;
     setOpen(false);
+    setVersionNotes("");
+    setGenerateTranscript(false);
+    setDragOver(false);
     reset();
   };
 
-  const validateFile = (selectedFile: File): string | null => {
-    const ext = selectedFile.name.split(".").pop()?.toLowerCase();
-    if (!ext || !ALLOWED_EXTENSIONS.includes(ext)) {
-      return "Unsupported file type. Please upload MP4, MOV, WebM, AVI, or MKV.";
-    }
-    if (selectedFile.size > MAX_FILE_SIZE) return "File exceeds the 5GB limit.";
-    return null;
-  };
+  const upload = () => {
+    void startUpload({
+      resolveUploadTarget: async () => {
+        if (!file) {
+          throw new Error("No file selected.");
+        }
+        const { data, error: actionError } = await actions.video.uploadVersion({
+          id: videoId,
+          fileName: file.name,
+          fileSize: file.size,
+          generateTranscript: transcriptsEnabled ? generateTranscript : false,
+          versionNotes: versionNotes.trim() || undefined,
+        });
 
-  const selectFile = (selectedFile: File) => {
-    const validationError = validateFile(selectedFile);
-    if (validationError) {
-      setError(validationError);
-      setState("error");
-      return;
-    }
-    setFile(selectedFile);
-    setError("");
-    setState("selected");
-  };
+        if (actionError || !data?.videoId || !data.uploadUrl) {
+          throw new Error(
+            friendlyActionErrorMessage(
+              actionError?.message,
+              "We couldn't start the upload. Please try again.",
+            ),
+          );
+        }
 
-  const upload = async () => {
-    if (!file) return;
-
-    setState("uploading");
-    setError("");
-    setProgress(0);
-
-    try {
-      const { data, error: actionError } = await actions.video.uploadVersion({
-        id: videoId,
-        fileName: file.name,
-        fileSize: file.size,
-        generateTranscript: transcriptsEnabled ? generateTranscript : false,
-        versionNotes: versionNotes.trim() || undefined,
-      });
-
-      if (actionError || !data?.videoId || !data.uploadUrl) {
-        throw new Error(
-          friendlyActionErrorMessage(
-            actionError?.message,
-            "We couldn't start the upload. Please try again.",
-          ),
-        );
-      }
-
-      const newVideoId = data.videoId;
-      const upload = new tus.Upload(file, {
-        uploadUrl: data.uploadUrl,
-        chunkSize: TUS_CHUNK_SIZE,
-        retryDelays: TUS_RETRY_DELAYS,
-        metadata: {
-          name: file.name,
-          filetype: file.type,
-        },
-        onProgress: (bytesUploaded, bytesTotal) => {
-          if (bytesTotal > 0) {
-            setProgress(Math.round((bytesUploaded / bytesTotal) * 100));
-          }
-        },
-        onSuccess: () => {
-          setState("processing");
-          window.location.href = `/videos/${newVideoId}?tab=video`;
-        },
-        onError: () => {
-          setError("Upload failed. Please try again.");
-          setState("error");
-        },
-      });
-      upload.start();
-    } catch (err) {
-      setError(
-        friendlyActionErrorMessage(
-          err instanceof Error ? err.message : null,
-          "Upload failed. Please try again.",
-        ),
-      );
-      setState("error");
-    }
+        return { uploadUrl: data.uploadUrl, videoId: data.videoId };
+      },
+      onComplete: (newVideoId) => {
+        window.location.href = `/videos/${newVideoId}?tab=video`;
+      },
+    });
   };
 
   return (
@@ -200,7 +128,7 @@ export function UploadVersionModal({
               <input
                 ref={inputRef}
                 type="file"
-                accept=".mp4,.mov,.webm,.avi,.mkv"
+                accept={ALLOWED_EXTENSIONS_ACCEPT}
                 className="hidden"
                 onChange={(event) => {
                   const selectedFile = event.target.files?.[0];

--- a/src/components/UploadView.tsx
+++ b/src/components/UploadView.tsx
@@ -1,25 +1,13 @@
 import { useRef, useState } from "react";
 import { actions } from "astro:actions";
-import * as tus from "tus-js-client";
 import { friendlyActionErrorMessage } from "../lib/errors";
-
-const ALLOWED_EXTENSIONS = ["mp4", "mov", "webm", "avi", "mkv"];
-const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024;
-const TUS_CHUNK_SIZE = 52_428_800;
-const TUS_RETRY_DELAYS = [0, 3000, 5000, 10000, 20000];
-
-type UploadState = "idle" | "selected" | "uploading" | "processing" | "error";
+import { ALLOWED_EXTENSIONS_ACCEPT, formatFileSize } from "../lib/upload";
+import { useTusUpload } from "../hooks/useTusUpload";
 
 interface UploadViewProps {
   videoId: string;
   isFirstCut: boolean;
   transcriptsEnabled: boolean;
-}
-
-function formatFileSize(bytes: number): string {
-  if (bytes >= 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
-  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / 1024).toFixed(1)} KB`;
 }
 
 export function UploadView({
@@ -28,100 +16,50 @@ export function UploadView({
   transcriptsEnabled,
 }: UploadViewProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [state, setState] = useState<UploadState>("idle");
-  const [file, setFile] = useState<File | null>(null);
   const [versionNotes, setVersionNotes] = useState("");
   const [generateTranscript, setGenerateTranscript] = useState(false);
-  const [progress, setProgress] = useState(0);
-  const [error, setError] = useState("");
   const [dragOver, setDragOver] = useState(false);
+  const { state, file, progress, error, selectFile, startUpload } = useTusUpload();
 
-  const validateFile = (selectedFile: File): string | null => {
-    const ext = selectedFile.name.split(".").pop()?.toLowerCase();
-    if (!ext || !ALLOWED_EXTENSIONS.includes(ext)) {
-      return "Unsupported file type. Please upload MP4, MOV, WebM, AVI, or MKV.";
-    }
-    if (selectedFile.size > MAX_FILE_SIZE) return "File exceeds the 5GB limit.";
-    return null;
-  };
+  const upload = () => {
+    void startUpload({
+      resolveUploadTarget: async () => {
+        if (!file) {
+          throw new Error("No file selected.");
+        }
+        const { data, error: actionError } = isFirstCut
+          ? await actions.video.uploadFirstCut({
+              id: videoId,
+              fileName: file.name,
+              fileSize: file.size,
+              generateTranscript: transcriptsEnabled ? generateTranscript : false,
+            })
+          : await actions.video.uploadVersion({
+              id: videoId,
+              fileName: file.name,
+              fileSize: file.size,
+              generateTranscript: transcriptsEnabled ? generateTranscript : false,
+              versionNotes: versionNotes.trim() || undefined,
+            });
 
-  const selectFile = (selectedFile: File) => {
-    const validationError = validateFile(selectedFile);
-    if (validationError) {
-      setError(validationError);
-      setState("error");
-      return;
-    }
-    setFile(selectedFile);
-    setError("");
-    setState("selected");
-  };
+        if (actionError || !data?.uploadUrl) {
+          throw new Error(
+            friendlyActionErrorMessage(
+              actionError?.message,
+              "We couldn't start the upload. Please try again.",
+            ),
+          );
+        }
 
-  const upload = async () => {
-    if (!file) return;
-
-    setState("uploading");
-    setError("");
-    setProgress(0);
-
-    try {
-      const { data, error: actionError } = isFirstCut
-        ? await actions.video.uploadFirstCut({
-            id: videoId,
-            fileName: file.name,
-            fileSize: file.size,
-            generateTranscript: transcriptsEnabled ? generateTranscript : false,
-          })
-        : await actions.video.uploadVersion({
-            id: videoId,
-            fileName: file.name,
-            fileSize: file.size,
-            generateTranscript: transcriptsEnabled ? generateTranscript : false,
-            versionNotes: versionNotes.trim() || undefined,
-          });
-
-      if (actionError || !data?.uploadUrl) {
-        throw new Error(
-          friendlyActionErrorMessage(
-            actionError?.message,
-            "We couldn't start the upload. Please try again.",
-          ),
-        );
-      }
-
-      const targetVideoId = data.videoId || videoId;
-      const upload = new tus.Upload(file, {
-        uploadUrl: data.uploadUrl,
-        chunkSize: TUS_CHUNK_SIZE,
-        retryDelays: TUS_RETRY_DELAYS,
-        metadata: {
-          name: file.name,
-          filetype: file.type,
-        },
-        onProgress: (bytesUploaded, bytesTotal) => {
-          if (bytesTotal > 0) {
-            setProgress(Math.round((bytesUploaded / bytesTotal) * 100));
-          }
-        },
-        onSuccess: () => {
-          setState("processing");
-          window.location.href = `/videos/${targetVideoId}?tab=video`;
-        },
-        onError: () => {
-          setError("Upload failed. Please try again.");
-          setState("error");
-        },
-      });
-      upload.start();
-    } catch (err) {
-      setError(
-        friendlyActionErrorMessage(
-          err instanceof Error ? err.message : null,
-          "Upload failed. Please try again.",
-        ),
-      );
-      setState("error");
-    }
+        return {
+          uploadUrl: data.uploadUrl,
+          videoId: data.videoId || videoId,
+        };
+      },
+      onComplete: (targetVideoId) => {
+        window.location.href = `/videos/${targetVideoId}?tab=video`;
+      },
+    });
   };
 
   return (
@@ -159,7 +97,7 @@ export function UploadView({
             <input
               ref={inputRef}
               type="file"
-              accept=".mp4,.mov,.webm,.avi,.mkv"
+              accept={ALLOWED_EXTENSIONS_ACCEPT}
               className="hidden"
               onChange={(event) => {
                 const selectedFile = event.target.files?.[0];

--- a/src/hooks/useTusUpload.ts
+++ b/src/hooks/useTusUpload.ts
@@ -1,0 +1,92 @@
+import { useCallback, useRef, useState } from "react";
+import type * as tus from "tus-js-client";
+import { friendlyActionErrorMessage } from "../lib/errors";
+import { startTusUpload, validateFile } from "../lib/upload";
+
+export type UploadState = "idle" | "selected" | "uploading" | "processing" | "error";
+
+export interface ResolvedUploadTarget {
+  uploadUrl: string;
+  videoId: string;
+}
+
+export interface StartUploadArgs {
+  resolveUploadTarget: () => Promise<ResolvedUploadTarget>;
+  onComplete: (videoId: string) => void;
+}
+
+export interface UseTusUploadResult {
+  state: UploadState;
+  file: File | null;
+  progress: number;
+  error: string;
+  selectFile: (file: File) => void;
+  startUpload: (args: StartUploadArgs) => Promise<void>;
+  reset: () => void;
+}
+
+export function useTusUpload(): UseTusUploadResult {
+  const [state, setState] = useState<UploadState>("idle");
+  const [file, setFile] = useState<File | null>(null);
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState("");
+  const uploadRef = useRef<tus.Upload | null>(null);
+
+  const selectFile = useCallback((selectedFile: File) => {
+    const validationError = validateFile(selectedFile);
+    if (validationError) {
+      setError(validationError);
+      setState("error");
+      return;
+    }
+    setFile(selectedFile);
+    setError("");
+    setState("selected");
+  }, []);
+
+  const reset = useCallback(() => {
+    uploadRef.current = null;
+    setState("idle");
+    setFile(null);
+    setProgress(0);
+    setError("");
+  }, []);
+
+  const startUpload = useCallback(
+    async ({ resolveUploadTarget, onComplete }: StartUploadArgs) => {
+      if (!file) return;
+
+      setState("uploading");
+      setError("");
+      setProgress(0);
+
+      try {
+        const { uploadUrl, videoId } = await resolveUploadTarget();
+        uploadRef.current = startTusUpload({
+          file,
+          uploadUrl,
+          onProgress: setProgress,
+          onSuccess: () => {
+            setState("processing");
+            onComplete(videoId);
+          },
+          onError: () => {
+            setError("Upload failed. Please try again.");
+            setState("error");
+          },
+        });
+      } catch (err) {
+        setError(
+          friendlyActionErrorMessage(
+            err instanceof Error ? err.message : null,
+            "Upload failed. Please try again.",
+          ),
+        );
+        setState("error");
+      }
+    },
+    [file],
+  );
+
+  return { state, file, progress, error, selectFile, startUpload, reset };
+}

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -1,0 +1,57 @@
+import * as tus from "tus-js-client";
+
+export const ALLOWED_EXTENSIONS = ["mp4", "mov", "webm", "avi", "mkv"] as const;
+export const ALLOWED_EXTENSIONS_ACCEPT = ".mp4,.mov,.webm,.avi,.mkv";
+export const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024;
+export const TUS_CHUNK_SIZE = 52_428_800;
+export const TUS_RETRY_DELAYS = [0, 3000, 5000, 10000, 20000];
+
+export function formatFileSize(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+export function validateFile(file: File): string | null {
+  const ext = file.name.split(".").pop()?.toLowerCase();
+  if (!ext || !ALLOWED_EXTENSIONS.includes(ext as (typeof ALLOWED_EXTENSIONS)[number])) {
+    return "Unsupported file type. Please upload MP4, MOV, WebM, AVI, or MKV.";
+  }
+  if (file.size > MAX_FILE_SIZE) return "File exceeds the 5GB limit.";
+  return null;
+}
+
+export interface StartTusUploadOptions {
+  file: File;
+  uploadUrl: string;
+  onProgress: (percent: number) => void;
+  onSuccess: () => void;
+  onError: (err: Error) => void;
+}
+
+export function startTusUpload({
+  file,
+  uploadUrl,
+  onProgress,
+  onSuccess,
+  onError,
+}: StartTusUploadOptions): tus.Upload {
+  const upload = new tus.Upload(file, {
+    uploadUrl,
+    chunkSize: TUS_CHUNK_SIZE,
+    retryDelays: TUS_RETRY_DELAYS,
+    metadata: {
+      name: file.name,
+      filetype: file.type,
+    },
+    onProgress: (bytesUploaded, bytesTotal) => {
+      if (bytesTotal > 0) {
+        onProgress(Math.round((bytesUploaded / bytesTotal) * 100));
+      }
+    },
+    onSuccess,
+    onError,
+  });
+  upload.start();
+  return upload;
+}


### PR DESCRIPTION
## Summary

- Pull the duplicated upload code out of `UploadView` and `UploadVersionModal` into a shared `src/lib/upload.ts` (pure logic) and `src/hooks/useTusUpload.ts` (React state machine).
- Single source of truth for allowed extensions, max file size, tus chunk size, tus retry delays, and the `tus.Upload` configuration.
- Each component still owns its own form UI and decides which action to call (`uploadFirstCut` vs `uploadVersion`); the hook drives `state`, `progress`, and `error`.

## Changes

- `src/lib/upload.ts` (new): `ALLOWED_EXTENSIONS`, `ALLOWED_EXTENSIONS_ACCEPT`, `MAX_FILE_SIZE`, `TUS_CHUNK_SIZE`, `TUS_RETRY_DELAYS`, `formatFileSize`, `validateFile`, `startTusUpload`.
- `src/hooks/useTusUpload.ts` (new): owns `state` / `file` / `progress` / `error`; exposes `selectFile`, `startUpload({ resolveUploadTarget, onComplete })`, `reset`.
- `src/components/UploadView.tsx`: 246 → 184 lines; removed inline constants, helpers, and `new tus.Upload(...)` block; consumes the hook.
- `src/components/UploadVersionModal.tsx`: 288 → 216 lines; same treatment, plus the modal's own reset path now calls `reset()` from the hook.

## Verification

- `pnpm build` passes (typecheck + Astro build, exit 0).
- `grep` confirms no inline copies remain of `ALLOWED_EXTENSIONS`, `MAX_FILE_SIZE`, `TUS_CHUNK_SIZE`, `TUS_RETRY_DELAYS`, `formatFileSize`, `validateFile`, `selectFile`, or `new tus.Upload(...)` in either component.

## Testing

See test plan in the next comment.

Closes #145