### PR TITLE
docs: add DESIGN.md, PRODUCT.md, and .impeccable/design.json

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,189 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-05-12T00:00:00.000Z",
+  "title": "Design System: QuickCut",
+  "extensions": {
+    "colorMeta": {
+      "signal-violet": {
+        "role": "primary",
+        "displayName": "Signal Violet",
+        "canonical": "#6c5ce7",
+        "tonalRamp": ["#1a1547", "#2b2272", "#3d319e", "#4e3fc0", "#6c5ce7", "#8a7cee", "#b1a8f3", "#d7d3f9"]
+      },
+      "bg-primary-dark": {
+        "role": "neutral",
+        "displayName": "Surface Page (Dark)",
+        "canonical": "#0d0d0f",
+        "tonalRamp": ["#050506", "#0d0d0f", "#161619", "#1e1e22", "#2a2a2f", "#3a3a42", "#5a5a66", "#a0a0ab"]
+      },
+      "bg-primary-light": {
+        "role": "neutral",
+        "displayName": "Surface Page (Light)",
+        "canonical": "#ffffff",
+        "tonalRamp": ["#0d0d0f", "#1e1e22", "#3a3a42", "#5a5a66", "#8a8a94", "#c8c8d0", "#e3e3e8", "#ffffff"]
+      },
+      "accent-secondary-dark": {
+        "role": "secondary",
+        "displayName": "Approval Teal",
+        "canonical": "#00b894",
+        "tonalRamp": ["#002b22", "#004a3a", "#006652", "#00866b", "#00a383", "#00b894", "#4dd0b1", "#a8e8d5"]
+      },
+      "accent-warning-dark": {
+        "role": "tertiary",
+        "displayName": "Caution Amber",
+        "canonical": "#f39c12",
+        "tonalRamp": ["#3a2300", "#5e3a00", "#7d4f00", "#a06800", "#d97706", "#f39c12", "#f7b955", "#fbdba6"]
+      },
+      "accent-danger-dark": {
+        "role": "tertiary",
+        "displayName": "Halt Red",
+        "canonical": "#e74c3c",
+        "tonalRamp": ["#3a0e08", "#591611", "#7b1f17", "#a02b20", "#dc2626", "#e74c3c", "#f0827a", "#fac4bf"]
+      },
+      "accent-info-dark": {
+        "role": "tertiary",
+        "displayName": "Reference Blue",
+        "canonical": "#3498db",
+        "tonalRamp": ["#072034", "#0e3a5c", "#155080", "#1d6aa6", "#2980b9", "#3498db", "#76b6e6", "#c2dff3"]
+      }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Display", "purpose": "Hero headlines on the landing page only. Never inside the app." },
+      "headline": { "displayName": "Headline", "purpose": "Page titles. Dashboard / Settings / Notifications page headings." },
+      "title": { "displayName": "Title", "purpose": "Card titles, modal titles, section titles inside a page." },
+      "body": { "displayName": "Body", "purpose": "The default voice. Comments, helper text, form labels, button labels, nav." },
+      "label": { "displayName": "Label", "purpose": "Status pill text, chip text, table column headers, eyebrow labels." },
+      "mono": { "displayName": "Mono", "purpose": "Timecodes, upload percentages, share-link tokens, numeric columns." }
+    },
+    "shadows": [
+      { "name": "overlay-subtle", "value": "0 4px 12px rgba(0,0,0,0.15)", "purpose": "Dropdown menus, comment-marker tooltip, small popovers." },
+      { "name": "overlay-lifted", "value": "0 10px 25px rgba(0,0,0,0.2)", "purpose": "User menu, space switcher, version switcher, target-date editor." },
+      { "name": "overlay-modal", "value": "0 25px 50px rgba(0,0,0,0.3)", "purpose": "Modals. Paired with bg-black/85 backdrop." }
+    ],
+    "motion": [
+      { "name": "ease-default", "value": "cubic-bezier(0.4, 0, 0.2, 1)", "purpose": "Default easing for hover, focus, and state transitions. Ease-out, no bounce." },
+      { "name": "duration-fast", "value": "150ms", "purpose": "Default transition duration for buttons, inputs, hovers." },
+      { "name": "duration-medium", "value": "300ms", "purpose": "Progress bar fills, modal entrances, sidebar slide-in." }
+    ],
+    "breakpoints": [
+      { "name": "sm", "value": "640px" },
+      { "name": "md", "value": "768px" },
+      { "name": "lg", "value": "1024px" },
+      { "name": "xl", "value": "1280px" },
+      { "name": "2xl", "value": "1536px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The path forward. One per screen. No shadow on hover.",
+      "html": "<button class=\"ds-btn-primary\">Upload a cut</button>",
+      "css": ".ds-btn-primary { display: inline-flex; align-items: center; justify-content: center; gap: 8px; background: #6c5ce7; color: #ffffff; padding: 10px 20px; border: none; border-radius: 8px; font-family: Inter, ui-sans-serif, system-ui, sans-serif; font-size: 14px; font-weight: 500; line-height: 1.5; cursor: pointer; transition: background 150ms cubic-bezier(0.4,0,0.2,1); } .ds-btn-primary:hover { background: #7c6ff0; } .ds-btn-primary:focus-visible { outline: none; box-shadow: 0 0 0 2px #0d0d0f, 0 0 0 4px #6c5ce7; } .ds-btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }"
+    },
+    {
+      "name": "Secondary Button",
+      "kind": "button",
+      "refersTo": "button-secondary",
+      "description": "Second-tier actions. Always paired with a primary; never the only CTA.",
+      "html": "<button class=\"ds-btn-secondary\">Cancel</button>",
+      "css": ".ds-btn-secondary { display: inline-flex; align-items: center; justify-content: center; gap: 8px; background: #161619; color: #f0f0f3; padding: 10px 20px; border: 1px solid #2a2a2f; border-radius: 8px; font-family: Inter, ui-sans-serif, system-ui, sans-serif; font-size: 14px; font-weight: 500; cursor: pointer; transition: background 150ms cubic-bezier(0.4,0,0.2,1); } .ds-btn-secondary:hover { background: #1e1e22; }"
+    },
+    {
+      "name": "Ghost Button",
+      "kind": "button",
+      "refersTo": "button-ghost",
+      "description": "Inline action verbs: 'Mark read', 'Use a different email'. No background at rest.",
+      "html": "<button class=\"ds-btn-ghost\">Mark read</button>",
+      "css": ".ds-btn-ghost { display: inline-flex; align-items: center; gap: 8px; background: transparent; color: #a0a0ab; padding: 8px 12px; border: none; border-radius: 8px; font-family: Inter, ui-sans-serif, system-ui, sans-serif; font-size: 14px; font-weight: 500; cursor: pointer; transition: background 150ms, color 150ms; } .ds-btn-ghost:hover { background: #1e1e22; color: #f0f0f3; }"
+    },
+    {
+      "name": "Text Input",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "Default input. Border shifts to Signal Violet on focus; no ring, no glow.",
+      "html": "<input class=\"ds-input\" type=\"text\" placeholder=\"name@studio.com\" />",
+      "css": ".ds-input { display: block; width: 100%; background: #232328; color: #f0f0f3; padding: 10px 16px; border: 1px solid #2a2a2f; border-radius: 8px; font-family: Inter, ui-sans-serif, system-ui, sans-serif; font-size: 14px; outline: none; transition: border-color 150ms; } .ds-input::placeholder { color: #6b6b76; } .ds-input:focus { border-color: #6c5ce7; }"
+    },
+    {
+      "name": "Status Pill (Processing)",
+      "kind": "chip",
+      "refersTo": "chip-status",
+      "description": "Status badge. Tinted bg at /15 alpha + colored text + pulsing dot for active states.",
+      "html": "<span class=\"ds-chip-processing\"><span class=\"ds-chip-dot\"></span>Processing</span>",
+      "css": ".ds-chip-processing { display: inline-flex; align-items: center; padding: 2px 10px; background: rgba(243, 156, 18, 0.15); color: #f39c12; border-radius: 9999px; font-family: Inter, ui-sans-serif, system-ui, sans-serif; font-size: 12px; font-weight: 500; letter-spacing: 0.02em; } .ds-chip-dot { width: 6px; height: 6px; margin-right: 6px; background: #f39c12; border-radius: 9999px; animation: ds-pulse 2s ease-in-out infinite; } @keyframes ds-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }"
+    },
+    {
+      "name": "Card",
+      "kind": "card",
+      "refersTo": "card",
+      "description": "Flat surface at rest. 1px border, tinted fill, 20px internal padding. No shadow.",
+      "html": "<article class=\"ds-card\"><h3 class=\"ds-card-title\">Reel cut v3</h3><p class=\"ds-card-meta\">Uploaded 2d ago by Jamie</p></article>",
+      "css": ".ds-card { background: #161619; border: 1px solid #2a2a2f; border-radius: 12px; padding: 20px; transition: border-color 150ms; } .ds-card:hover { border-color: #3a3a42; } .ds-card-title { margin: 0 0 4px; color: #f0f0f3; font-family: Inter, ui-sans-serif, system-ui, sans-serif; font-size: 18px; font-weight: 600; } .ds-card-meta { margin: 0; color: #a0a0ab; font-family: Inter, ui-sans-serif, system-ui, sans-serif; font-size: 14px; }"
+    },
+    {
+      "name": "Dropdown Menu",
+      "kind": "nav",
+      "refersTo": "modal",
+      "description": "Lifted overlay. Subtle shadow. Rounded-lg with a 1px border and tinted panel fill.",
+      "html": "<div class=\"ds-menu\"><button class=\"ds-menu-item\">Share link</button><button class=\"ds-menu-item\">Rename</button><button class=\"ds-menu-item ds-menu-item-danger\">Delete</button></div>",
+      "css": ".ds-menu { display: flex; flex-direction: column; min-width: 176px; background: #161619; border: 1px solid #2a2a2f; border-radius: 8px; padding: 4px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); } .ds-menu-item { display: flex; align-items: center; padding: 8px 12px; background: transparent; color: #f0f0f3; border: none; border-radius: 6px; font-family: Inter, ui-sans-serif, system-ui, sans-serif; font-size: 14px; text-align: left; cursor: pointer; transition: background 150ms; } .ds-menu-item:hover { background: #1e1e22; } .ds-menu-item-danger { color: #e74c3c; } .ds-menu-item-danger:hover { background: rgba(231, 76, 60, 0.15); }"
+    },
+    {
+      "name": "Timeline Marker",
+      "kind": "custom",
+      "refersTo": null,
+      "description": "Signature component. Colored dot positioned on a horizontal track at a comment's timestamp. Hover reveals tooltip with avatar initial, mono timecode, and excerpt. Click seeks the player.",
+      "html": "<div class=\"ds-timeline\"><button class=\"ds-marker\" style=\"left: 32%;\"><span class=\"ds-marker-dot\"></span><span class=\"ds-marker-tooltip\"><span class=\"ds-marker-avatar\">JQ</span><span class=\"ds-marker-time\">0:42</span><span class=\"ds-marker-excerpt\">Tighten this cut</span></span></button></div>",
+      "css": ".ds-timeline { position: relative; height: 24px; background: #1e1e22; border-radius: 12px; } .ds-marker { position: absolute; top: 4px; transform: translateX(-50%); background: transparent; border: none; padding: 0; cursor: pointer; } .ds-marker-dot { display: block; width: 12px; height: 12px; background: #6c5ce7; border-radius: 9999px; transition: transform 150ms; } .ds-marker:hover .ds-marker-dot { transform: scale(1.25); } .ds-marker-tooltip { position: absolute; bottom: calc(100% + 8px); left: 50%; transform: translateX(-50%); display: none; align-items: center; gap: 8px; padding: 8px 12px; background: #161619; border: 1px solid #2a2a2f; border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); white-space: nowrap; } .ds-marker:hover .ds-marker-tooltip { display: inline-flex; } .ds-marker-avatar { display: inline-flex; align-items: center; justify-content: center; width: 20px; height: 20px; background: #6c5ce7; color: #fff; border-radius: 9999px; font-family: Inter, ui-sans-serif, system-ui, sans-serif; font-size: 10px; font-weight: 600; } .ds-marker-time { color: #f0f0f3; font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 12px; } .ds-marker-excerpt { color: #a0a0ab; font-family: Inter, ui-sans-serif, system-ui, sans-serif; font-size: 12px; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Edit Room",
+    "overview": "QuickCut is an edit room rendered as software. A post-production suite at night: low light, a single bright frame in the center, instruments arranged around it. The interface is the room, not the showroom. The video is the only thing the eye should fight for; everything else is the panel around the panel. The system runs in both dark and light, but dark is the home register. Surfaces are flat at rest. Depth is reserved for things that genuinely float. Inter is the only voice. JetBrains Mono is the timecode voice. The single accent, Signal Violet, is rationed.",
+    "keyCharacteristics": [
+      "Flat surfaces, lifted overlays. Pages don't have shadows; popovers do.",
+      "One accent, rationed. Signal Violet occupies less than or equal to 10% of any screen.",
+      "Frame is the largest mass. Anywhere the video appears, it owns the optical center.",
+      "Inter for everything; JetBrains Mono for timecodes. No third font.",
+      "No pure black, no pure white. Every neutral is tinted toward a cool axis."
+    ],
+    "rules": [
+      { "name": "The One Voice Rule", "body": "Signal Violet appears on less than or equal to 10% of any screen. If two violet things are within 100px of each other, kill one.", "section": "colors" },
+      { "name": "The No-Pure-Surface Rule", "body": "No pure black, no pure white. Every background, every panel, every text color is tinted. The player surface must be a dedicated near-black token, not bg-black.", "section": "colors" },
+      { "name": "The Color-Plus-Glyph Rule", "body": "Status, urgency, and severity are never communicated by color alone. Always pair color with a glyph, label, or shape.", "section": "colors" },
+      { "name": "The Two-Voice Rule", "body": "Inter and JetBrains Mono. No third font. Differentiation comes from weight and size, not from family.", "section": "typography" },
+      { "name": "The Numerals-Are-Mono-When-Aligned Rule", "body": "Numerals that appear in a column use JetBrains Mono. Numerals in prose use Inter.", "section": "typography" },
+      { "name": "The 65ch Rule", "body": "Body copy is capped at 65-75ch.", "section": "typography" },
+      { "name": "The Flat-By-Default Rule", "body": "Surfaces at rest have no shadow. Cards, sections, panels, side rails, sidebars are flat.", "section": "elevation" },
+      { "name": "The Floating-Means-Detached Rule", "body": "Shadows mean 'I'm not part of the layer behind me.' Menus, popovers, modals. That is the complete list. Buttons do not float.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do keep Signal Violet to less than or equal to 10% of any screen.",
+      "Do pair color with a glyph, label, or shape for every status, severity, and urgency signal.",
+      "Do use Inter for everything visible and JetBrains Mono for timecodes, upload percentages, and any numeric column.",
+      "Do keep surfaces flat at rest. Reserve shadows for menus, popovers, modals, and the timeline-marker tooltip.",
+      "Do tint every neutral. Page-light should be off-white (#fafafb), page-dark near-black (#0d0d0f), the player surface #0a0a0c.",
+      "Do size cards' internal padding at 20px by default. Modals at 24px.",
+      "Do use the shadow-lg / shadow-xl / shadow-2xl triad for the three depth roles. Don't invent new shadow values.",
+      "Do make the video the largest visual mass on any screen it appears in.",
+      "Do keep transitions at 150ms with an ease-out curve. No bounce, no elastic."
+    ],
+    "donts": [
+      "Don't use SaaS-template gradients. No bg-gradient on text. No background-clip: text with a gradient fill.",
+      "Don't add the purple-glow shadow on buttons. Buttons don't float.",
+      "Don't use side-stripe borders (border-l-2 colored stripes) on cards, list items, comment items, or alerts.",
+      "Don't use glassmorphism decoratively. The only permitted blur is the modal backdrop scrim.",
+      "Don't use pure #000 or pure #fff.",
+      "Don't build identical card grids of 'icon + heading + paragraph' repeated 3-6 times.",
+      "Don't use radial purple glow backgrounds for atmosphere.",
+      "Don't invent new fonts. Inter and JetBrains Mono. That's it.",
+      "Don't put the same CTA in the header, the hero, and the final-CTA section. Once per surface.",
+      "Don't use em dashes in JSX/Astro user-facing copy.",
+      "Don't use modals for routine actions. Inline-edit, popovers, and progressive disclosure exhaust first.",
+      "Don't use alert(). Route through Toast or keep an open ConfirmDialog.",
+      "Don't nest cards."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,326 @@
+---
+name: QuickCut
+description: Video review tool, edge-native. The Edit Room as an interface.
+colors:
+  bg-primary-light: "#ffffff"
+  bg-primary-dark: "#0d0d0f"
+  bg-secondary-light: "#f7f7f8"
+  bg-secondary-dark: "#161619"
+  bg-tertiary-light: "#eeeef1"
+  bg-tertiary-dark: "#1e1e22"
+  bg-input-light: "#ffffff"
+  bg-input-dark: "#232328"
+  border-default-light: "#e3e3e8"
+  border-default-dark: "#2a2a2f"
+  border-hover-light: "#c8c8d0"
+  border-hover-dark: "#3a3a42"
+  text-primary-light: "#0d0d0f"
+  text-primary-dark: "#f0f0f3"
+  text-secondary-light: "#5a5a66"
+  text-secondary-dark: "#a0a0ab"
+  text-tertiary-light: "#8a8a94"
+  text-tertiary-dark: "#6b6b76"
+  signal-violet: "#6c5ce7"
+  signal-violet-hover-light: "#5848d4"
+  signal-violet-hover-dark: "#7c6ff0"
+  accent-secondary-light: "#00a383"
+  accent-secondary-dark: "#00b894"
+  accent-warning-light: "#d97706"
+  accent-warning-dark: "#f39c12"
+  accent-danger-light: "#dc2626"
+  accent-danger-dark: "#e74c3c"
+  accent-info-light: "#2980b9"
+  accent-info-dark: "#3498db"
+typography:
+  display:
+    fontFamily: "Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "clamp(2.25rem, 5vw, 3.5rem)"
+    fontWeight: 700
+    lineHeight: 1.05
+    letterSpacing: "-0.02em"
+  headline:
+    fontFamily: "Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "1.5rem"
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: "-0.01em"
+  title:
+    fontFamily: "Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "1.125rem"
+    fontWeight: 600
+    lineHeight: 1.3
+    letterSpacing: "normal"
+  body:
+    fontFamily: "Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "0.875rem"
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: "normal"
+  label:
+    fontFamily: "Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "0.75rem"
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: "0.02em"
+  mono:
+    fontFamily: "JetBrains Mono, ui-monospace, monospace"
+    fontSize: "0.8125rem"
+    fontWeight: 400
+    lineHeight: 1.4
+    letterSpacing: "normal"
+rounded:
+  sm: "6px"
+  md: "8px"
+  lg: "12px"
+  xl: "16px"
+  full: "9999px"
+spacing:
+  xs: "4px"
+  sm: "8px"
+  md: "16px"
+  lg: "20px"
+  xl: "24px"
+  2xl: "32px"
+components:
+  button-primary:
+    backgroundColor: "{colors.signal-violet}"
+    textColor: "#ffffff"
+    rounded: "{rounded.md}"
+    padding: "10px 20px"
+    typography: "{typography.body}"
+  button-primary-hover:
+    backgroundColor: "{colors.signal-violet-hover-light}"
+  button-secondary:
+    backgroundColor: "{colors.bg-secondary-light}"
+    textColor: "{colors.text-primary-light}"
+    rounded: "{rounded.md}"
+    padding: "10px 20px"
+    typography: "{typography.body}"
+  button-danger:
+    backgroundColor: "{colors.accent-danger-light}"
+    textColor: "#ffffff"
+    rounded: "{rounded.md}"
+    padding: "10px 20px"
+    typography: "{typography.body}"
+  button-ghost:
+    backgroundColor: "transparent"
+    textColor: "{colors.text-secondary-light}"
+    rounded: "{rounded.md}"
+    padding: "10px 20px"
+    typography: "{typography.body}"
+  input:
+    backgroundColor: "{colors.bg-input-light}"
+    textColor: "{colors.text-primary-light}"
+    rounded: "{rounded.md}"
+    padding: "10px 16px"
+    typography: "{typography.body}"
+  card:
+    backgroundColor: "{colors.bg-secondary-light}"
+    rounded: "{rounded.lg}"
+    padding: "20px"
+  chip-status:
+    backgroundColor: "transparent"
+    textColor: "{colors.text-primary-light}"
+    rounded: "{rounded.full}"
+    padding: "2px 10px"
+    typography: "{typography.label}"
+  modal:
+    backgroundColor: "{colors.bg-secondary-light}"
+    rounded: "{rounded.xl}"
+    padding: "24px"
+---
+
+# Design System: QuickCut
+
+## 1. Overview
+
+**Creative North Star: "The Edit Room"**
+
+QuickCut is an edit room rendered as software. A post-production suite at night: low light, a single bright frame in the center, instruments arranged around it. The interface is the room, not the showroom. The video is the only thing the eye should fight for; everything else is the panel around the panel.
+
+The system runs in both dark and light, but dark is the home register. Dark mode is the "lights down to watch a cut" state; light mode is the "lights up to read the brief" state. Both modes tint every neutral toward a faint cool axis (no pure black, no pure white) so the frame has a perimeter the eye can locate. Surfaces are flat at rest. Depth is reserved for things that genuinely float — menus, popovers, modals, the timeline tooltip — not for buttons, not for cards, not for decoration.
+
+Density is deliberate but never crowded. Inter is the only voice. JetBrains Mono is the timecode voice. The single accent — Signal Violet (`#6c5ce7`) — is rationed: it marks the path forward (primary CTA), the focus ring, the speaker initial avatar, the timeline scrub head. When it appears, it means something. When it appears next to itself, one of them is wrong.
+
+This system explicitly rejects: SaaS-template gradients, glassmorphism-as-default, hero-metric card grids, side-stripe alert borders, identical icon-tile feature rows, gradient text, neon decorative glows, and any chrome that calls attention to itself while a video is playing. We are not Frame.io's enterprise weight, and we are not the AI-landing-page reflex.
+
+**Key Characteristics:**
+- **Flat surfaces, lifted overlays.** Pages don't have shadows; popovers do.
+- **One accent, rationed.** Signal Violet occupies ≤10% of any screen.
+- **Frame is the largest mass.** Anywhere the video appears, it owns the optical center.
+- **Inter for everything; JetBrains Mono for timecodes.** No third font.
+- **No pure black, no pure white.** Every neutral is tinted toward a cool axis.
+
+## 2. Colors
+
+The palette is a tinted dark/light dual system organized around one accent. Signal Violet does identity work; the secondary teal does success work; warning amber and danger red do their literal jobs. Info blue exists for share-link / share-state copy. Everything else is grayscale — but never grayscale-with-no-hue. Each neutral leans slightly cool.
+
+### Primary
+
+- **Signal Violet** (`#6c5ce7`): the one accent that earns its place. Primary buttons, focus rings, the timeline scrub head, the speaker initial in the comment compose, the brand wordmark accent. Hover: `#5848d4` (light) / `#7c6ff0` (dark). Used at ≤10% surface coverage per screen.
+
+### Secondary
+
+- **Approval Teal** (`#00a383` light / `#00b894` dark): the success voice. Approved states, "ready" status, accept-invite affordance, version-uploaded toasts. Never used decoratively.
+- **Caution Amber** (`#d97706` light / `#f39c12` dark): the processing voice. The pulsing dot on Processing status badges, "uploading" indicators, target-date-near-now hints. Note: the light/dark variants differ in saturation more than ideal; treat as a known inconsistency until resolved.
+- **Halt Red** (`#dc2626` light / `#e74c3c` dark): the destructive voice. Delete, revoke, error inline, "failed" badge.
+- **Reference Blue** (`#2980b9` light / `#3498db` dark): the share-link voice. External link affordances, "active share" pill.
+
+### Neutral
+
+The neutral stack is six surface tones plus three text tones, all faintly cool-tinted. Light and dark mirror each other; the same role-name in both themes carries the same job.
+
+- **Surface — Page** (`#ffffff` light / `#0d0d0f` dark): the page background. The light value is functionally white but the dark is near-black, not pure black. *Known issue: the light value should move to a tinted off-white like `#fafafb` per the no-pure-white rule.*
+- **Surface — Panel** (`#f7f7f8` light / `#161619` dark): the secondary fill. Cards, sections, side panels, modal bodies, the comment column.
+- **Surface — Recess** (`#eeeef1` light / `#1e1e22` dark): the tertiary fill. Inset chips, file-info recesses inside the upload modal, low-contrast pills.
+- **Surface — Input** (`#ffffff` light / `#232328` dark): input fields. Slightly lighter than Panel in dark mode so fields read as openings, not as raised surfaces.
+- **Stroke — Default** (`#e3e3e8` light / `#2a2a2f` dark): the resting border for cards, inputs, sections, modal frames.
+- **Stroke — Hover** (`#c8c8d0` light / `#3a3a42` dark): the hover border for cards and interactive containers. Never used at rest.
+- **Ink — Primary** (`#0d0d0f` light / `#f0f0f3` dark): body text. Headlines. Anything load-bearing.
+- **Ink — Secondary** (`#5a5a66` light / `#a0a0ab` dark): meta text. Timestamps, helper text, "uploaded 2d ago."
+- **Ink — Tertiary** (`#8a8a94` light / `#6b6b76` dark): de-emphasized text. Placeholders, disabled labels, resolved-comment body.
+
+### Named Rules
+
+**The One Voice Rule.** Signal Violet appears on ≤10% of any screen. If two violet things are within 100px of each other, kill one. The primary CTA, the focus ring, the timeline scrub head, the comment-compose avatar — these are the only canonical homes. Adding a fifth job dilutes all four.
+
+**The No-Pure-Surface Rule.** No `#000`, no `#fff`. Every background, every panel, every text color is tinted. The player iframe currently uses `bg-black` (`#000`); that is a violation and needs a tinted player surface (`#0a0a0c`) introduced as its own token.
+
+**The Color-Plus-Glyph Rule.** Status, urgency, and severity are never communicated by color alone. Always pair color with a glyph, label, or shape. Critical and Idea cannot look identical at a glance.
+
+## 3. Typography
+
+**Display Font:** Inter (fallback: `ui-sans-serif, system-ui, sans-serif`)
+**Body Font:** Inter (same family, different weights)
+**Label/Mono Font:** JetBrains Mono (fallback: `ui-monospace, monospace`)
+
+**Character:** Inter does everything visible to a reviewer except numbers that need to align. JetBrains Mono is reserved for timecodes, upload percentages, share-link tokens, and any monospaced data the editor needs to scan in a column. The system has exactly two voices.
+
+### Hierarchy
+
+- **Display** (700, `clamp(2.25rem, 5vw, 3.5rem)`, line-height 1.05, letter-spacing `-0.02em`): hero headlines on the landing page only. Tight tracking pulls the form together at large sizes. Never used inside the app.
+- **Headline** (700, `1.5rem`/24px, line-height 1.2, letter-spacing `-0.01em`): page titles. Dashboard `Projects` heading, settings page headings, notifications page heading.
+- **Title** (600, `1.125rem`/18px, line-height 1.3): section titles inside a page. Card titles. Modal titles.
+- **Body** (400, `0.875rem`/14px, line-height 1.5): the default. Comment text, helper text, form labels, button labels, navigation. Maximum line length 65–75ch.
+- **Label** (500, `0.75rem`/12px, line-height 1.4, letter-spacing `0.02em`): status pill labels, chip text, table column headers, the eyebrow above a section heading.
+- **Mono** (400, `0.8125rem`/13px, JetBrains Mono): timecodes (`0:12`, `01:23:45`), upload progress percentages (`42%`), share tokens.
+
+### Named Rules
+
+**The Two-Voice Rule.** Inter and JetBrains Mono. No third font. No display serif, no rounded variant, no condensed cut. If a screen needs more typographic differentiation, use weight (400 / 500 / 600 / 700) and size, not a new family.
+
+**The Numerals-Are-Mono-When-Aligned Rule.** Numerals that appear in a column (durations, file sizes, upload percentages, comment counts in a list) use JetBrains Mono. Numerals that appear in prose (`2 days ago`, `3 unresolved`) use Inter.
+
+**The 65ch Rule.** Body copy is capped at 65–75ch. The comment column is sized for this. The brief panel is sized for this. The script editor is sized for this. Wider columns betray a layout decision, not a typography one.
+
+## 4. Elevation
+
+The system is **flat surfaces, lifted overlays**. The page itself has no shadows. Cards have a 1px border and a tinted fill; that's the whole vocabulary of a surface at rest. Depth only appears on things that genuinely float above the page: dropdown menus, popovers, modals, the timeline-marker hover tooltip, the share-link copy popover. When you see a shadow, something is supposed to feel detached from the layer behind it.
+
+The current codebase has a known anti-pattern that violates this: the primary button uses `hover:shadow-[0_2px_8px_rgba(108,92,231,0.3)]` (a purple glow). Buttons do not float. Remove. The card-hover shadow `hover:shadow-[0_4px_16px_rgba(0,0,0,0.3)]` is also a violation; if a card needs hover feedback, use a border darkening (`border-hover` token) instead.
+
+### Shadow Vocabulary
+
+- **Overlay — Subtle** (`box-shadow: 0 4px 12px rgba(0,0,0,0.15)`; Tailwind `shadow-lg`): dropdown menus, the comment-marker tooltip, small popovers. The "I'm close to the page but not on it" lift.
+- **Overlay — Lifted** (`box-shadow: 0 10px 25px rgba(0,0,0,0.2)`; Tailwind `shadow-xl`): the user menu, space switcher, version switcher, target-date editor. The "I'm a real panel above the page" lift.
+- **Overlay — Modal** (`box-shadow: 0 25px 50px rgba(0,0,0,0.3)`; Tailwind `shadow-2xl`): modals only. The "I'm blocking the page" lift, paired with the `bg-black/85` backdrop.
+
+### Named Rules
+
+**The Flat-By-Default Rule.** Surfaces at rest have no shadow. Ever. Cards, sections, panels, side rails, sidebars — flat. If a card has a shadow, you've borrowed a Material-3 reflex.
+
+**The Floating-Means-Detached Rule.** Shadows mean "I'm not part of the layer behind me." Menus, popovers, modals. That is the complete list. Buttons aren't floating. Cards aren't floating. The CTA glow is not depth — it's decoration, and it's prohibited.
+
+## 5. Components
+
+### Buttons
+
+- **Shape:** Gentle radius (`rounded-lg` / 8px). Consistent across sizes; we don't change radii by button size.
+- **Primary:** Signal Violet background, white text, `px-5 py-2.5` / `px-4 py-2` (md / sm). Hover: violet shifts to hover-tone (`#5848d4` light / `#7c6ff0` dark). **No shadow on hover.** Disabled: `opacity-50` + cursor `not-allowed`.
+- **Secondary:** `bg-secondary` fill, default-stroke border, primary ink. Hover: `bg-tertiary` fill. Use for second-tier actions on the same row as a primary.
+- **Danger:** Halt Red fill, white text. Reserved for destructive confirms. Never a default action.
+- **Ghost:** No background, secondary ink, optional icon. Hover: `bg-tertiary` fill + primary ink. Use for inline action verbs ("Mark read", "Use a different email").
+- **Focus:** 2px Signal Violet ring with 2px page-color offset (`focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2`). Visible on keyboard focus only.
+- **Transition:** `150ms` on all-properties. No bounce, no elastic.
+
+### Chips & Status Pills
+
+- **Shape:** Full-radius (`rounded-full`).
+- **Style:** Tinted color background at `/15` alpha + colored text at full opacity. Pattern: `bg-accent-X/15 text-accent-X`.
+- **Sizes:** Status badges use `px-2.5 py-0.5 text-xs font-medium`. Inline tag chips slightly larger (`px-3 py-1 text-xs`).
+- **State (processing):** Color text + a small pulsing colored dot (`h-1.5 w-1.5 animate-pulse`) inset 6px from the text. The animation IS the affordance for "actively happening."
+- **Color-plus-glyph rule:** Every status pill carries text. Pills are never color-only.
+
+### Cards / Containers
+
+- **Corner Style:** Soft radius. Card-as-content uses `rounded-xl` (12px); modals and very large panels use `rounded-2xl` (16px).
+- **Background:** `bg-secondary` (`#f7f7f8` light / `#161619` dark).
+- **Shadow Strategy:** None. Flat. See Elevation section.
+- **Border:** 1px `border-default`. Hover (interactive cards only): border shifts to `border-hover`. No shadow on hover.
+- **Internal Padding:** `p-5` (20px) is canonical. Smaller cards inside a list use `p-4`. Dialog content uses `p-6`.
+- **Nesting:** Avoid. Cards inside cards is a slop pattern; if you need internal grouping, use a divider or a `bg-tertiary` recess instead.
+
+### Inputs / Fields
+
+- **Style:** `bg-input` fill, `border-default` border, `rounded-lg` (8px), `px-4 py-2.5` for default md size.
+- **Typography:** Body (Inter 400, 14px). Placeholder uses `text-tertiary`.
+- **Focus:** Border shifts to Signal Violet (`focus:border-accent-primary focus:outline-none`). No glow, no ring on inputs (the border shift is the affordance).
+- **Disabled:** `opacity-50`.
+- **Error:** Inline message in `bg-accent-danger/15 text-accent-danger` chip below the field. The input border itself does not change color on error — the message does the work. This avoids screaming-red field outlines.
+
+### Modals
+
+- **Size:** `sm` (max-w-sm), `md` (max-w-md), `lg` (max-w-lg). Most product modals are `sm`.
+- **Frame:** `rounded-2xl` (16px), 1px `border-default`, `bg-secondary`, `p-6`, `shadow-2xl`.
+- **Backdrop:** `bg-black/85 backdrop-blur-sm`. The backdrop blur is *only* permitted on the modal scrim, not as a decorative effect anywhere else in the system.
+- **Close affordance:** Top-right `h-8 w-8` icon button, ghost styling, only when `showCloseButton` is true.
+- **Default behavior:** `closeOnBackdropClick` and `closeOnEscape` are true unless the modal blocks a destructive choice. Forced-modal patterns are prohibited (see the share-page name modal in the open critique).
+
+### Dropdowns / Menus
+
+- **Width:** `w-44` to `w-72` depending on content. Avoid fixed widths beyond `w-80`.
+- **Style:** `rounded-lg` or `rounded-xl`, 1px `border-default`, `bg-secondary`, `shadow-lg` (small menus) or `shadow-xl` (user menus, switchers).
+- **Item rows:** `px-3 py-2 text-sm` body, ghost hover (`bg-tertiary` fill).
+- **Group divider:** 1px `border-default` row, no labels except where the menu spans multiple roles.
+
+### Navigation
+
+- **Header:** `Header.astro` for app, `GuestHeader.astro` for share-link viewers. Sticky `top-0`, `bg-primary`, 1px bottom border, `h-14`.
+- **Sidebar (Spaces):** Sticky `top-14`, `w-60`, 1px right border, `bg-primary`. Active route uses `bg-tertiary` fill + primary ink + small Signal Violet leading dot or icon-only highlight.
+- **Mobile:** Sidebar slides in from left via `data-[state=open]:translate-x-0`, with `shadow-xl` while floating.
+
+### Signature: Timeline Marker
+
+The single most distinctive component. A horizontal track below the player with colored dots positioned at the exact second of each comment. Hover reveals a `shadow-lg` tooltip with the commenter's avatar initial, the timestamp in JetBrains Mono, and a 1-2 line excerpt. Click seeks the player. Marker color encodes urgency, but per the Color-Plus-Glyph Rule, marker *shape* must also vary by urgency (currently it doesn't — open issue).
+
+### Signature: Annotation Overlay
+
+The Pin tool drops a Signal Violet circle on the video frame at click coordinates. The Rectangle tool drags a Signal Violet-stroked rectangle. Both are anchored to the timestamp and shown in the comment list as a small icon next to the timecode. The overlay disappears when the comment is resolved.
+
+## 6. Do's and Don'ts
+
+### Do:
+- **Do** keep Signal Violet to ≤10% of any screen. If you can see two violet things on one screen, one of them is wrong.
+- **Do** pair color with a glyph, label, or shape for every status, severity, and urgency signal. Critical and Idea should never look identical at a glance.
+- **Do** use Inter for everything visible and JetBrains Mono for timecodes, upload percentages, and any numeric column.
+- **Do** keep surfaces flat at rest. Reserve shadows for menus, popovers, modals, and the timeline-marker tooltip.
+- **Do** tint every neutral. Page-light should be off-white (`#fafafb`), page-dark should be near-black (`#0d0d0f`), the player surface should be `#0a0a0c`.
+- **Do** size cards' internal padding at `p-5` (20px) by default. Modals at `p-6`.
+- **Do** use the `shadow-lg` / `shadow-xl` / `shadow-2xl` triad for the three depth roles (subtle, lifted, modal). Don't invent new shadow values.
+- **Do** make the video the largest visual mass on any screen it appears in. Shrink the chrome around it; never grow chrome at the frame's expense.
+- **Do** keep transitions at 150ms with an ease-out curve. No bounce, no elastic.
+
+### Don't:
+- **Don't** use SaaS-template gradients. No `bg-gradient-to-r` on text. No `background-clip: text` with a gradient fill. The current landing page is a violation and the gradient hero text needs to go.
+- **Don't** add the purple-glow shadow on buttons (`shadow-[0_2px_8px_rgba(108,92,231,0.3)]`). Buttons don't float. The glow is a SaaS-landing-page reflex and is prohibited everywhere, including the landing CTAs and login submit.
+- **Don't** use side-stripe borders (`border-l-2` colored stripes) on cards, list items, comment items, or alerts. The current resolved-comment treatment violates this and needs replacement (strikethrough timecode + "Resolved" pill + `text-tertiary` body).
+- **Don't** use glassmorphism (`backdrop-filter: blur`) decoratively. The only permitted blur is the modal backdrop scrim.
+- **Don't** use pure `#000` or pure `#fff`. The current `VideoPlayer` `bg-black` and the light theme `--color-bg-primary: #ffffff` are violations and need tinted replacements.
+- **Don't** build identical card grids of "icon + heading + paragraph" repeated 3–6 times. The landing page features section is a textbook violation.
+- **Don't** use radial purple glow backgrounds for atmosphere. The landing page has two; both should go.
+- **Don't** invent new fonts. Inter and JetBrains Mono. That's it.
+- **Don't** put the same CTA in the header, the hero, and the final-CTA section. Once per surface.
+- **Don't** use em dashes in JSX/Astro user-facing copy. Use periods, colons, semicolons, or parentheses.
+- **Don't** use modals for routine actions. Inline-edit, popovers, and progressive disclosure exhaust first. Modals are for genuinely destructive or genuinely-must-block choices.
+- **Don't** use `alert()` ever. Route through Toast or keep an open ConfirmDialog.
+- **Don't** nest cards. If you reach for a card inside a card, replace the inner one with a divider or a `bg-tertiary` recess.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,47 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Two user types share the same surface:
+
+1. **Creators / video teams** (authenticated) — upload cuts, organize work into spaces, manage members and approvals, review their own and teammates' versions. Power users who return daily; they value speed and keyboard-friendly flows over hand-holding.
+2. **External reviewers / clients** (unauthenticated, share-link only) — open a link, identify themselves with a display name, scrub through a video, drop timestamped comments, optionally resolve threads. One-shot users; they should never feel like they've stumbled into "an app."
+
+Job to be done: "Get a cut in front of the right people, collect specific feedback at specific timecodes, and know when it's approved." The product replaces a chain of email + Drive links + Slack pings.
+
+## Product Purpose
+
+A focused video review tool — Frame.io's core loop without the enterprise weight. Spaces, version stacks, timestamped comments, approvals, and public share links, running entirely on Cloudflare's edge. Success looks like: a creator uploads a new cut, drops a link in Slack, and gets actionable timestamped feedback inside 10 minutes — with zero account friction for the reviewer.
+
+## Brand Personality
+
+Fast, focused, confident.
+
+- **Voice:** direct, terse, builder-to-builder. No fluff, no marketing softness, no apologetic copy. "Upload a cut" not "Let's get started by uploading your first amazing video!"
+- **Tone:** quiet competence. The product should feel like it was made by people who actually review video, not people selling a "video review platform."
+- **Emotional goal:** the relief of a tool that just does the thing. The opposite of "what does this button do."
+
+## Anti-references
+
+- **Generic SaaS template look.** Hero-metric cards, identical icon-heading-text card grids, gradient text, side-stripe alert borders, three-column "Why us" landing sections. The obvious AI/template reflex. If a screen looks like it could be from any B2B SaaS, it's wrong.
+- **Frame.io's enterprise heaviness** (implied by category positioning). Dense toolbars stacked three deep, nested panels, modal-on-modal. We're the small, focused alternative — the chrome should reflect that.
+
+## Design Principles
+
+1. **Small product, large craft.** We don't compete on feature count. Every screen we ship has to feel deliberate — typography, spacing, motion, microcopy — because there are fewer screens carrying the weight.
+2. **Two audiences, one surface.** The same UI serves a power user who's here 20 times a week and a one-shot reviewer who's here for 90 seconds. Default to the reviewer's clarity; let the creator's speed surface through density, shortcuts, and progressive disclosure — not by simplifying things away.
+3. **The video is the product.** The player and the timeline are the center of gravity. Chrome shrinks; the frame grows. If a UI element competes with the video for attention without earning it, cut it.
+4. **Edge-native, not edge-themed.** Cloudflare is the runtime, not the aesthetic. No neon "powered by the edge" decoration. The speed should be felt, not announced.
+5. **Quiet confidence, not loud reassurance.** No celebratory toasts for routine actions, no "Great job!" copy, no progress bars where instant feedback would do. The tool earns trust by getting out of the way.
+
+## Accessibility & Inclusion
+
+- **WCAG AA** as the baseline target across the app.
+- Keyboard navigation through the review surface (play/pause, scrub, comment focus, thread navigation) — power users will expect it.
+- Respect `prefers-reduced-motion` for the timeline scrubbing, comment-pin animations, and any panel transitions.
+- Color is never the only signal for status (approved / processing / failed). Pair color with icon or text.
+- Contrast: the dark, purple-accented theme must clear AA for body text and interactive controls in both default and hover states.


### PR DESCRIPTION
## Summary

Checks in three design/product reference documents that have been living as untracked files in the main checkout:

- **`DESIGN.md`** — design system reference (color tokens, typography, elevation, motion, anti-patterns). Already referenced by the homepage audit issues (#157, #158, #159) as the source of truth for what counts as "AI-slop".
- **`PRODUCT.md`** — product reference (user flows, terminology).
- **`.impeccable/design.json`** — generated design-token export from the `impeccable` skill, the machine-readable counterpart to `DESIGN.md`.

## Why

These docs are already cited in active GitHub issues but were sitting untracked locally. Checking them in lets:

- Reviewers verify audit findings against the canonical design rules.
- Future homepage / design polish PRs reference stable file paths instead of "the design doc I have locally".
- The `impeccable` skill regenerate `design.json` against a tracked baseline.

## Changes

- `DESIGN.md` (+326 lines)
- `PRODUCT.md` (+47 lines)
- `.impeccable/design.json` (+189 lines)

No code changes. No build artifacts.