### PR TITLE
chore(homepage): polish hero, Spaces mock, and copy

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -55,7 +55,7 @@ if (user) {
         </h1>
         <p class="mx-auto mt-6 max-w-2xl text-lg text-text-secondary">
           Create spaces for each team or client, invite collaborators, upload up to 5GB, stack new cuts as
-          versions, and collect timestamped feedback — no account required for external reviewers.
+          versions, and collect timestamped feedback. No account required for external reviewers.
         </p>
         <div class="mt-10 flex flex-wrap items-center justify-center gap-3">
           <a
@@ -78,13 +78,7 @@ if (user) {
         <div
           class="rounded-2xl border border-border-default bg-bg-secondary p-3 shadow-[0_24px_64px_rgba(0,0,0,0.5)]"
         >
-          <!-- Mock window chrome -->
-            <div class="mb-3 flex items-center justify-between px-2">
-              <div class="flex items-center gap-1.5">
-                <span class="size-2.5 rounded-full bg-accent-danger/60"></span>
-                <span class="size-2.5 rounded-full bg-accent-warning/60"></span>
-                <span class="size-2.5 rounded-full bg-accent-secondary/60"></span>
-              </div>
+            <div class="mb-3 flex items-center justify-end px-2">
               <div class="flex items-center gap-2">
                 <span class="rounded-full bg-accent-primary/15 px-2.5 py-0.5 text-xs font-medium text-accent-primary">
                   Acme Launch Space
@@ -211,7 +205,7 @@ if (user) {
           </div>
           <h3 class="font-semibold text-text-primary">Timestamped comments</h3>
           <p class="mt-2 text-sm text-text-secondary">
-            Pin feedback to the exact frame. No more "around the 30 second mark…" — reviewers click and comment.
+            Pin feedback to the exact frame. No more "around the 30 second mark." Reviewers click and comment.
           </p>
         </div>
 
@@ -355,17 +349,6 @@ if (user) {
               <span class="rounded-full bg-accent-warning/15 px-2.5 py-0.5 text-xs font-medium text-accent-warning">
                 Pending
               </span>
-            </div>
-
-            <div class="grid gap-3 sm:grid-cols-2">
-              <div class="rounded-lg border border-border-default bg-bg-tertiary/60 p-3">
-                <p class="text-xs font-medium text-text-tertiary">Required approvals</p>
-                <p class="mt-2 text-2xl font-bold text-text-primary">2</p>
-              </div>
-              <div class="rounded-lg border border-border-default bg-bg-tertiary/60 p-3">
-                <p class="text-xs font-medium text-text-tertiary">Videos in review</p>
-                <p class="mt-2 text-2xl font-bold text-text-primary">12</p>
-              </div>
             </div>
           </div>
         </div>
@@ -528,8 +511,8 @@ if (user) {
           Globally distributed by default
         </h2>
         <p class="mt-4 text-text-secondary">
-          Every part of Quick Cuts runs on Cloudflare's network. Fast for every reviewer, anywhere — with
-          serverless economics that scale to zero.
+          Every part of Quick Cuts runs on Cloudflare's network. Fast for every reviewer, anywhere. Serverless
+          economics that scale to zero.
         </p>
       </div>
 
@@ -554,7 +537,7 @@ if (user) {
             <a href="https://developers.cloudflare.com/workers/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-accent-primary">Workers</a>
           </h3>
           <p class="mt-2 text-sm text-text-secondary">
-            The entire Astro app runs at the edge — auth, API routes, page rendering. Sub-50ms cold starts
+            The entire Astro app runs at the edge: auth, API routes, page rendering. Sub-50ms cold starts
             in 300+ cities means reviewers never wait on the network.
           </p>
           <p class="mt-3 text-sm font-medium text-accent-primary">
@@ -584,7 +567,7 @@ if (user) {
             <a href="https://developers.cloudflare.com/d1/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-accent-info">D1</a>
           </h3>
           <p class="mt-2 text-sm text-text-secondary">
-            Users, sessions, videos, version groups, comments, share links — all in serverless SQLite.
+            Users, sessions, videos, version groups, comments, share links. All in serverless SQLite.
             We use Drizzle ORM for type-safe queries with zero infrastructure to manage.
           </p>
           <p class="mt-3 text-sm font-medium text-accent-info">
@@ -647,7 +630,7 @@ if (user) {
             for instant page loads worldwide.
           </p>
           <p class="mt-3 text-sm font-medium text-accent-secondary">
-            Why it matters: free, fast, automatic — no separate CDN to wire up.
+            Why it matters: free, fast, automatic. No separate CDN to wire up.
           </p>
         </div>
       </div>
@@ -685,7 +668,7 @@ if (user) {
           </summary>
           <p class="mt-3 text-sm text-text-secondary">
             No. Anyone with a share link can leave timestamped comments after entering a display name. You
-            stay in control — revoke any link at any time.
+            stay in control: revoke any link at any time.
           </p>
         </details>
 
@@ -726,7 +709,7 @@ if (user) {
             </svg>
           </summary>
           <p class="mt-3 text-sm text-text-secondary">
-            MP4, MOV, WebM, AVI, and MKV up to 5GB per file. Uploads are resumable — close your laptop,
+            MP4, MOV, WebM, AVI, and MKV up to 5GB per file. Uploads are resumable. Close your laptop,
             come back later, and pick up where you left off.
           </p>
         </details>
@@ -790,7 +773,7 @@ if (user) {
             </svg>
           </summary>
           <p class="mt-3 text-sm text-text-secondary">
-            Entirely on Cloudflare's global network — <a href="https://developers.cloudflare.com/workers/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-text-primary">Workers</a> for compute, <a href="https://developers.cloudflare.com/d1/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-text-primary">D1</a> for data, <a href="https://developers.cloudflare.com/stream/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-text-primary">Stream</a> for video,
+            Entirely on Cloudflare's global network: <a href="https://developers.cloudflare.com/workers/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-text-primary">Workers</a> for compute, <a href="https://developers.cloudflare.com/d1/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-text-primary">D1</a> for data, <a href="https://developers.cloudflare.com/stream/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-text-primary">Stream</a> for video,
             <a href="https://developers.cloudflare.com/workers/static-assets/" target="_blank" rel="noopener noreferrer" class="underline decoration-text-tertiary underline-offset-2 transition-colors hover:decoration-text-primary">Workers Assets</a> for the static frontend. No origin servers, no separate CDN.
           </p>
         </details>


### PR DESCRIPTION
## Summary

Three small homepage polish issues from the impeccable audit, bundled together because they all touch `src/pages/index.astro`:

- Remove the macOS traffic-light dots from the hero mockup
- Remove the giant `2` / `12` hero-metric tiles inside the Spaces mock
- Sweep em dashes from user-facing copy and replace with periods/colons

## Changes

- `src/pages/index.astro` (hero mockup): deleted the red/yellow/green dot wrapper. The window-chrome row now contains only the right-side `Acme Launch Space` + `Approved` pills, top-aligned via `justify-end`.
- `src/pages/index.astro` (Spaces mock): deleted the two-column stat grid containing the oversized `2` (Required approvals) and `12` (Videos in review). The existing pending-invite row + `4 members` pill in the divider header already communicate "this is what a space looks like".
- `src/pages/index.astro` (copy): replaced 9 em dashes (`—`) in user-facing strings with periods or colons per `AGENTS.md` / `DESIGN.md` §6. Hero subhead, Feature 3 copy, Stack section intro + Workers / D1 / Workers Assets cards, and three FAQ entries.

## Testing

`pnpm build` passes (Wrangler types + Astro build, exit 0).

Acceptance checks:
- `grep -n '—' src/pages/index.astro` returns zero matches.
- No red/yellow/green dot decoration anywhere in the hero mockup.
- No oversized bold numerals with small label captions inside the Spaces mock.

See the test plan I'll post separately for the manual review steps.

Closes #160
Closes #165
Closes #166