### PR TITLE
perf: reduce latency and improve reliability across fan-out paths

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -57,6 +57,7 @@ import {
   broadcastNotification,
   broadcastNotificationsRead,
 } from "../lib/broadcast";
+import { getWaitUntil } from "../lib/ctx";
 import {
   isCommentReactionEmoji,
   toggleCommentReaction,
@@ -398,11 +399,17 @@ export const server = {
           });
         }
 
-        await broadcastPhaseChange(env, id, {
+        const waitUntil = getWaitUntil(context.locals);
+        const broadcastPromise = broadcastPhaseChange(env, id, {
           videoId: id,
           phase,
           changedBy: user.name,
         });
+        if (waitUntil) {
+          waitUntil(broadcastPromise);
+        } else {
+          await broadcastPromise;
+        }
 
         // NOTE: per issue #93 the generic fan-out of approval.requested
         // notifications to every space member has been removed. Approvals
@@ -487,7 +494,13 @@ export const server = {
         }
 
         const status = await getApprovalStatus(db, id, video.spaceId);
-        await broadcastApprovalUpdate(env, id, status);
+        const waitUntil = getWaitUntil(context.locals);
+        const approvalBroadcast = broadcastApprovalUpdate(env, id, status);
+        if (waitUntil) {
+          waitUntil(approvalBroadcast);
+        } else {
+          await approvalBroadcast;
+        }
 
         await logProjectActivity(db, {
           videoId: id,
@@ -524,11 +537,16 @@ export const server = {
               createdAt: now,
             });
 
-            await broadcastPhaseChange(env, id, {
+            const phaseBroadcast = broadcastPhaseChange(env, id, {
               videoId: id,
               phase: "video_approved",
               changedBy: user.name,
             });
+            if (waitUntil) {
+              waitUntil(phaseBroadcast);
+            } else {
+              await phaseBroadcast;
+            }
           }
         }
 
@@ -575,7 +593,13 @@ export const server = {
           .where(and(eq(approvals.videoId, id), eq(approvals.userId, user.id)));
 
         const status = await getApprovalStatus(db, id, video.spaceId);
-        await broadcastApprovalUpdate(env, id, status);
+        const waitUntil = getWaitUntil(context.locals);
+        const approvalBroadcast = broadcastApprovalUpdate(env, id, status);
+        if (waitUntil) {
+          waitUntil(approvalBroadcast);
+        } else {
+          await approvalBroadcast;
+        }
 
         const now = new Date().toISOString();
         await logProjectActivity(db, {
@@ -613,11 +637,16 @@ export const server = {
               createdAt: now,
             });
 
-            await broadcastPhaseChange(env, id, {
+            const phaseBroadcast = broadcastPhaseChange(env, id, {
               videoId: id,
               phase: "reviewing_video",
               changedBy: user.name,
             });
+            if (waitUntil) {
+              waitUntil(phaseBroadcast);
+            } else {
+              await phaseBroadcast;
+            }
           }
         }
 
@@ -737,24 +766,30 @@ export const server = {
 
         await db.insert(approvalRequests).values(newRows);
 
-        try {
-          await createTargetedApprovalRequestNotifications(
-            db,
-            {
-              videoId: id,
-              requestedUserIds: toCreate,
-              actorUserId: user.id,
-              actorDisplayName: user.name,
-            },
-            {
-              send: (msg) => sendEmail(env, msg),
-              from: env.OTP_EMAIL_FROM,
-              baseUrl: getCanonicalBaseUrl(env),
-            },
-            env,
-          );
-        } catch (err) {
+        const waitUntil = getWaitUntil(context.locals);
+        const notificationsPromise = createTargetedApprovalRequestNotifications(
+          db,
+          {
+            videoId: id,
+            requestedUserIds: toCreate,
+            actorUserId: user.id,
+            actorDisplayName: user.name,
+          },
+          {
+            send: (msg) => sendEmail(env, msg),
+            from: env.OTP_EMAIL_FROM,
+            baseUrl: getCanonicalBaseUrl(env),
+          },
+          env,
+          waitUntil,
+        ).catch((err) => {
           console.error("Failed to dispatch targeted approval-request notifications", err);
+        });
+
+        if (waitUntil) {
+          waitUntil(notificationsPromise);
+        } else {
+          await notificationsPromise;
         }
 
         return {
@@ -940,11 +975,17 @@ export const server = {
           createdAt: now,
         });
 
-        await broadcastPhaseChange(env, id, {
+        const waitUntil = getWaitUntil(context.locals);
+        const phaseBroadcast = broadcastPhaseChange(env, id, {
           videoId: id,
           phase: "reviewing_video",
           changedBy: user.name,
         });
+        if (waitUntil) {
+          waitUntil(phaseBroadcast);
+        } else {
+          await phaseBroadcast;
+        }
 
         return { videoId: id, uploadUrl };
       },
@@ -1075,7 +1116,17 @@ export const server = {
                 videoId,
                 baseVideo.spaceId,
               );
-              await broadcastApprovalUpdate(env, videoId, status);
+              const waitUntil = getWaitUntil(context.locals);
+              const approvalBroadcast = broadcastApprovalUpdate(
+                env,
+                videoId,
+                status,
+              );
+              if (waitUntil) {
+                waitUntil(approvalBroadcast);
+              } else {
+                await approvalBroadcast;
+              }
             }
           }
         } catch (err) {
@@ -1353,29 +1404,6 @@ export const server = {
 
         await db.insert(comments).values(newComment);
 
-        try {
-          await createCommentNotifications(
-            db,
-            {
-              commentId,
-              videoId,
-              actorUserId: user.id,
-              actorDisplayName: user.name,
-              text: newComment.text,
-              parentCommentId: null,
-              phase,
-            },
-            {
-              send: (msg) => sendEmail(env, msg),
-              from: env.OTP_EMAIL_FROM,
-              baseUrl: getCanonicalBaseUrl(env),
-            },
-            env,
-          );
-        } catch (err) {
-          console.error("Failed to create comment notification", err);
-        }
-
         const responseComment = {
           ...newComment,
           annotation: annotation ?? null,
@@ -1385,7 +1413,37 @@ export const server = {
           reactions: [],
         };
 
-        await broadcastNewComment(env, videoId, responseComment);
+        const waitUntil = getWaitUntil(context.locals);
+        const notificationsPromise = createCommentNotifications(
+          db,
+          {
+            commentId,
+            videoId,
+            actorUserId: user.id,
+            actorDisplayName: user.name,
+            text: newComment.text,
+            parentCommentId: null,
+            phase,
+          },
+          {
+            send: (msg) => sendEmail(env, msg),
+            from: env.OTP_EMAIL_FROM,
+            baseUrl: getCanonicalBaseUrl(env),
+          },
+          env,
+          waitUntil,
+        ).catch((err) => {
+          console.error("Failed to create comment notification", err);
+        });
+
+        const broadcastPromise = broadcastNewComment(env, videoId, responseComment);
+
+        if (waitUntil) {
+          waitUntil(notificationsPromise);
+          waitUntil(broadcastPromise);
+        } else {
+          await Promise.all([notificationsPromise, broadcastPromise]);
+        }
 
         return { comment: responseComment };
       },
@@ -1581,29 +1639,6 @@ export const server = {
 
         await db.insert(comments).values(newReply);
 
-        try {
-          await createCommentNotifications(
-            db,
-            {
-              commentId,
-              videoId: parent[0].videoId,
-              actorUserId: user.id,
-              actorDisplayName: user.name,
-              text: newReply.text,
-              parentCommentId: parentId,
-              phase: parent[0].phase,
-            },
-            {
-              send: (msg) => sendEmail(env, msg),
-              from: env.OTP_EMAIL_FROM,
-              baseUrl: getCanonicalBaseUrl(env),
-            },
-            env,
-          );
-        } catch (err) {
-          console.error("Failed to create reply notification", err);
-        }
-
         const responseComment = {
           ...newReply,
           createdAt: now,
@@ -1611,7 +1646,41 @@ export const server = {
           reactions: [],
         };
 
-        await broadcastNewComment(env, parent[0].videoId, responseComment);
+        const waitUntil = getWaitUntil(context.locals);
+        const notificationsPromise = createCommentNotifications(
+          db,
+          {
+            commentId,
+            videoId: parent[0].videoId,
+            actorUserId: user.id,
+            actorDisplayName: user.name,
+            text: newReply.text,
+            parentCommentId: parentId,
+            phase: parent[0].phase,
+          },
+          {
+            send: (msg) => sendEmail(env, msg),
+            from: env.OTP_EMAIL_FROM,
+            baseUrl: getCanonicalBaseUrl(env),
+          },
+          env,
+          waitUntil,
+        ).catch((err) => {
+          console.error("Failed to create reply notification", err);
+        });
+
+        const broadcastPromise = broadcastNewComment(
+          env,
+          parent[0].videoId,
+          responseComment,
+        );
+
+        if (waitUntil) {
+          waitUntil(notificationsPromise);
+          waitUntil(broadcastPromise);
+        } else {
+          await Promise.all([notificationsPromise, broadcastPromise]);
+        }
 
         return { comment: responseComment };
       },
@@ -1671,13 +1740,20 @@ export const server = {
           name: user.name,
         });
 
-        await broadcastCommentReactions(env, comment[0].videoId, {
+        const waitUntil = getWaitUntil(context.locals);
+        const broadcastPromise = broadcastCommentReactions(env, comment[0].videoId, {
           commentId,
           reactions: reactions.map((reaction) => ({
             ...reaction,
             reactedByMe: false,
           })),
         });
+
+        if (waitUntil) {
+          waitUntil(broadcastPromise);
+        } else {
+          await broadcastPromise;
+        }
 
         return { commentId, reactions };
       },
@@ -1950,17 +2026,21 @@ export const server = {
           });
         }
 
-        // If the invitee already has an account, push a real-time signal to
-        // their open tabs so the header badge increments — pending invites
-        // count toward the unread badge (see Layout.astro).
         if (existingUser.length > 0) {
-          await broadcastNotification(env, existingUser[0].id, {
+          const waitUntil = getWaitUntil(context.locals);
+          const broadcastPromise = broadcastNotification(env, existingUser[0].id, {
             kind: "invite",
             id: invite.id,
             title: `${user.name} invited you to ${space[0].name}`,
             href: "/notifications",
             createdAt: new Date().toISOString(),
           });
+
+          if (waitUntil) {
+            waitUntil(broadcastPromise);
+          } else {
+            await broadcastPromise;
+          }
         }
 
         const created = await db
@@ -2158,7 +2238,13 @@ export const server = {
         const ids = await markNotificationsReadByVideoTab(db, user.id, videoId, tab);
 
         if (ids.length > 0) {
-          await broadcastNotificationsRead(env, user.id, ids);
+          const waitUntil = getWaitUntil(context.locals);
+          const broadcastPromise = broadcastNotificationsRead(env, user.id, ids);
+          if (waitUntil) {
+            waitUntil(broadcastPromise);
+          } else {
+            await broadcastPromise;
+          }
         }
 
         return { ids, count: ids.length };

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -781,7 +781,6 @@ export const server = {
             baseUrl: getCanonicalBaseUrl(env),
           },
           env,
-          waitUntil,
         ).catch((err) => {
           console.error("Failed to dispatch targeted approval-request notifications", err);
         });
@@ -1431,7 +1430,6 @@ export const server = {
             baseUrl: getCanonicalBaseUrl(env),
           },
           env,
-          waitUntil,
         ).catch((err) => {
           console.error("Failed to create comment notification", err);
         });
@@ -1664,7 +1662,6 @@ export const server = {
             baseUrl: getCanonicalBaseUrl(env),
           },
           env,
-          waitUntil,
         ).catch((err) => {
           console.error("Failed to create reply notification", err);
         });

--- a/src/durable-objects/UserNotifications.ts
+++ b/src/durable-objects/UserNotifications.ts
@@ -46,6 +46,15 @@ type ServerMessage =
  * up the correct count from the SSR'd value.
  */
 export class UserNotifications extends DurableObject<Env> {
+	constructor(ctx: DurableObjectState, env: Env) {
+		super(ctx, env);
+		// Cheap ping/pong handled by the runtime so client heartbeats never
+		// wake a hibernating DO.
+		this.ctx.setWebSocketAutoResponse(
+			new WebSocketRequestResponsePair("ping", "pong"),
+		);
+	}
+
 	/**
 	 * Handle the WebSocket upgrade. The route handler authenticates the
 	 * user, then forwards the upgrade Request to this DO, which accepts

--- a/src/durable-objects/VideoRoom.ts
+++ b/src/durable-objects/VideoRoom.ts
@@ -87,7 +87,18 @@ type ServerMessage =
  * D1 remains the source of truth for comments; this DO is purely a fan-out
  * layer triggered by API write routes after a successful insert.
  */
+const PRESENCE_DEBOUNCE_MS = 100;
+
 export class VideoRoom extends DurableObject<Env> {
+	constructor(ctx: DurableObjectState, env: Env) {
+		super(ctx, env);
+		// Cheap ping/pong handled by the runtime so client heartbeats never
+		// wake a hibernating DO.
+		this.ctx.setWebSocketAutoResponse(
+			new WebSocketRequestResponsePair("ping", "pong"),
+		);
+	}
+
 	/**
 	 * Handle the WebSocket upgrade. The route handler forwards the upgrade
 	 * Request to the DO, which accepts the socket and registers it for
@@ -115,13 +126,29 @@ export class VideoRoom extends DurableObject<Env> {
 		// Attach viewer metadata so we can build the presence list later.
 		server.serializeAttachment({ viewer } satisfies SocketMeta);
 
-		// Broadcast the updated presence list to everyone (including the new joiner).
-		this.broadcastPresence();
+		// Coalesce presence updates across a 100ms quiet window so rapid
+		// reload/refresh cycles produce one broadcast instead of N.
+		await this.schedulePresenceBroadcast();
 
 		return new Response(null, {
 			status: 101,
 			webSocket: client,
 		});
+	}
+
+	/**
+	 * Set an alarm to broadcast presence in the near future, unless one is
+	 * already pending. Coalesces rapid join/leave bursts into a single
+	 * broadcast per quiet window.
+	 */
+	private async schedulePresenceBroadcast(): Promise<void> {
+		const existing = await this.ctx.storage.getAlarm();
+		if (existing !== null) return;
+		await this.ctx.storage.setAlarm(Date.now() + PRESENCE_DEBOUNCE_MS);
+	}
+
+	async alarm(): Promise<void> {
+		this.broadcastPresence();
 	}
 
 	/**
@@ -266,8 +293,7 @@ export class VideoRoom extends DurableObject<Env> {
 		} catch {
 			// ignore
 		}
-		// A viewer left — broadcast updated presence to remaining clients.
-		this.broadcastPresence();
+		await this.schedulePresenceBroadcast();
 	}
 
 	async webSocketError(ws: WebSocket, _error: unknown): Promise<void> {
@@ -276,7 +302,6 @@ export class VideoRoom extends DurableObject<Env> {
 		} catch {
 			// ignore
 		}
-		// A viewer dropped — broadcast updated presence to remaining clients.
-		this.broadcastPresence();
+		await this.schedulePresenceBroadcast();
 	}
 }

--- a/src/hooks/useStreamPlayer.ts
+++ b/src/hooks/useStreamPlayer.ts
@@ -2,20 +2,57 @@ import { useState, useEffect, useRef, useCallback } from "react";
 
 function waitForStream(timeoutMs = 5000): Promise<NonNullable<Window["Stream"]>> {
   return new Promise((resolve, reject) => {
-    if (typeof window !== "undefined" && window.Stream) {
+    if (typeof window === "undefined") {
+      reject(new Error("Stream SDK is only available in the browser"));
+      return;
+    }
+    if (window.Stream) {
       resolve(window.Stream);
       return;
     }
-    const start = Date.now();
-    const interval = setInterval(() => {
-      if (typeof window !== "undefined" && window.Stream) {
-        clearInterval(interval);
+
+    const script = document.querySelector<HTMLScriptElement>(
+      'script[src*="embed.cloudflarestream.com"]',
+    );
+
+    let timeoutId: number | undefined;
+    let cleanup: () => void = () => {};
+
+    const onReady = () => {
+      cleanup();
+      if (window.Stream) {
         resolve(window.Stream);
-      } else if (Date.now() - start > timeoutMs) {
-        clearInterval(interval);
-        reject(new Error("Stream SDK did not load in time"));
+      } else {
+        reject(new Error("Stream SDK loaded but window.Stream is undefined"));
       }
-    }, 50);
+    };
+
+    const onError = () => {
+      cleanup();
+      reject(new Error("Stream SDK failed to load"));
+    };
+
+    cleanup = () => {
+      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+      script?.removeEventListener("load", onReady);
+      script?.removeEventListener("error", onError);
+    };
+
+    timeoutId = window.setTimeout(() => {
+      cleanup();
+      reject(new Error("Stream SDK did not load in time"));
+    }, timeoutMs);
+
+    if (script) {
+      script.addEventListener("load", onReady);
+      script.addEventListener("error", onError);
+    } else {
+      // Script tag isn't in the DOM yet — fall back to a short timeout-only
+      // wait. The Astro page injects the script inline so this branch is rare.
+      window.setTimeout(() => {
+        if (window.Stream) onReady();
+      }, 100);
+    }
   });
 }
 

--- a/src/lib/ctx.ts
+++ b/src/lib/ctx.ts
@@ -1,0 +1,7 @@
+import type { WaitUntil } from "./notifications";
+
+export function getWaitUntil(locals: App.Locals): WaitUntil | undefined {
+  const ctx = locals.cfContext;
+  if (!ctx) return undefined;
+  return (promise) => ctx.waitUntil(promise);
+}

--- a/src/lib/ctx.ts
+++ b/src/lib/ctx.ts
@@ -1,4 +1,4 @@
-import type { WaitUntil } from "./notifications";
+export type WaitUntil = (promise: Promise<unknown>) => void;
 
 export function getWaitUntil(locals: App.Locals): WaitUntil | undefined {
   const ctx = locals.cfContext;

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, isNull } from "drizzle-orm";
+import { and, count, desc, eq, inArray, isNull, lt } from "drizzle-orm";
 import type { Database } from "../db";
 import {
   approvalRequests,
@@ -32,6 +32,8 @@ export interface EmailConfig {
   from: string;
   baseUrl: string;
 }
+
+export type WaitUntil = (promise: Promise<unknown>) => void;
 
 export interface UserNotification {
   id: string;
@@ -88,6 +90,7 @@ export async function createCommentNotifications(
   input: CommentNotificationInput,
   emailConfig?: EmailConfig,
   realtimeEnv?: Env,
+  waitUntil?: WaitUntil,
 ): Promise<void> {
   const videoRows = await db
     .select({
@@ -151,69 +154,75 @@ export async function createCommentNotifications(
 
   await db.insert(notifications).values(rows);
 
-  // Real-time fan-out to each recipient's open tabs. Best-effort; failures
-  // are logged inside broadcastNotification and do not block email delivery.
-  if (realtimeEnv) {
-    const createdAt = new Date().toISOString();
-    await Promise.all(
-      rows.map((row) =>
-        broadcastNotification(realtimeEnv, row.userId, {
-          kind: "notification",
-          id: row.id,
-          type: row.type,
-          title: row.title,
-          href: row.href,
-          createdAt,
-        }),
-      ),
-    );
-  }
+  const fanOut = (async () => {
+    if (realtimeEnv) {
+      const createdAt = new Date().toISOString();
+      await Promise.all(
+        rows.map((row) =>
+          broadcastNotification(realtimeEnv, row.userId, {
+            kind: "notification",
+            id: row.id,
+            type: row.type,
+            title: row.title,
+            href: row.href,
+            createdAt,
+          }),
+        ),
+      );
+    }
 
-  if (!emailConfig) return;
+    if (!emailConfig) return;
 
-  try {
-    const emailRecipients = await db
-      .select({ id: users.id, email: users.email })
-      .from(users)
-      .where(
-        and(
-          inArray(users.id, recipientIds),
-          eq(users.emailNotificationsEnabled, true),
+    try {
+      const emailRecipients = await db
+        .select({ id: users.id, email: users.email })
+        .from(users)
+        .where(
+          and(
+            inArray(users.id, recipientIds),
+            eq(users.emailNotificationsEnabled, true),
+          ),
+        );
+
+      if (emailRecipients.length === 0) return;
+
+      const emailContent = buildCommentNotificationEmail({
+        type,
+        actorDisplayName: input.actorDisplayName,
+        videoTitle: video.title,
+        commentSnippet: body,
+        href,
+        baseUrl: emailConfig.baseUrl,
+      });
+
+      const results = await Promise.allSettled(
+        emailRecipients.map((recipient) =>
+          emailConfig.send({
+            to: recipient.email,
+            from: emailConfig.from,
+            subject: emailContent.subject,
+            text: emailContent.text,
+            html: emailContent.html,
+          }),
         ),
       );
 
-    if (emailRecipients.length === 0) return;
-
-    const emailContent = buildCommentNotificationEmail({
-      type,
-      actorDisplayName: input.actorDisplayName,
-      videoTitle: video.title,
-      commentSnippet: body,
-      href,
-      baseUrl: emailConfig.baseUrl,
-    });
-
-    const results = await Promise.allSettled(
-      emailRecipients.map((recipient) =>
-        emailConfig.send({
-          to: recipient.email,
-          from: emailConfig.from,
-          subject: emailContent.subject,
-          text: emailContent.text,
-          html: emailContent.html,
-        }),
-      ),
-    );
-
-    const failures = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
-    if (failures.length > 0) {
-      console.error(
-        `${failures.length}/${results.length} notification emails failed`,
-        failures.map((f) => f.reason),
-      );
+      const failures = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+      if (failures.length > 0) {
+        console.error(
+          `${failures.length}/${results.length} notification emails failed`,
+          failures.map((f) => f.reason),
+        );
+      }
+    } catch (error) {
+      console.error("Failed to send comment notification emails", error);
     }
-  } catch (error) {
-    console.error("Failed to send comment notification emails", error);
+  })();
+
+  if (waitUntil) {
+    waitUntil(fanOut);
+  } else {
+    await fanOut;
   }
 }
 
@@ -235,6 +244,7 @@ export async function createTargetedApprovalRequestNotifications(
   input: TargetedApprovalRequestInput,
   emailConfig?: EmailConfig,
   realtimeEnv?: Env,
+  waitUntil?: WaitUntil,
 ): Promise<void> {
   if (input.requestedUserIds.length === 0) return;
 
@@ -279,67 +289,75 @@ export async function createTargetedApprovalRequestNotifications(
 
   await db.insert(notifications).values(rows);
 
-  if (realtimeEnv) {
-    const createdAt = new Date().toISOString();
-    await Promise.all(
-      rows.map((row) =>
-        broadcastNotification(realtimeEnv, row.userId, {
-          kind: "notification",
-          id: row.id,
-          type: row.type,
-          title: row.title,
-          href: row.href,
-          createdAt,
-        }),
-      ),
-    );
-  }
+  const fanOut = (async () => {
+    if (realtimeEnv) {
+      const createdAt = new Date().toISOString();
+      await Promise.all(
+        rows.map((row) =>
+          broadcastNotification(realtimeEnv, row.userId, {
+            kind: "notification",
+            id: row.id,
+            type: row.type,
+            title: row.title,
+            href: row.href,
+            createdAt,
+          }),
+        ),
+      );
+    }
 
-  if (!emailConfig) return;
+    if (!emailConfig) return;
 
-  try {
-    const emailRecipients = await db
-      .select({ id: users.id, email: users.email })
-      .from(users)
-      .where(
-        and(
-          inArray(users.id, recipientIds),
-          eq(users.emailNotificationsEnabled, true),
+    try {
+      const emailRecipients = await db
+        .select({ id: users.id, email: users.email })
+        .from(users)
+        .where(
+          and(
+            inArray(users.id, recipientIds),
+            eq(users.emailNotificationsEnabled, true),
+          ),
+        );
+
+      if (emailRecipients.length === 0) return;
+
+      const emailContent = buildApprovalRequestEmail({
+        actorDisplayName: input.actorDisplayName,
+        videoTitle: video.title,
+        href,
+        baseUrl: emailConfig.baseUrl,
+      });
+
+      const results = await Promise.allSettled(
+        emailRecipients.map((recipient) =>
+          emailConfig.send({
+            to: recipient.email,
+            from: emailConfig.from,
+            subject: emailContent.subject,
+            text: emailContent.text,
+            html: emailContent.html,
+          }),
         ),
       );
 
-    if (emailRecipients.length === 0) return;
-
-    const emailContent = buildApprovalRequestEmail({
-      actorDisplayName: input.actorDisplayName,
-      videoTitle: video.title,
-      href,
-      baseUrl: emailConfig.baseUrl,
-    });
-
-    const results = await Promise.allSettled(
-      emailRecipients.map((recipient) =>
-        emailConfig.send({
-          to: recipient.email,
-          from: emailConfig.from,
-          subject: emailContent.subject,
-          text: emailContent.text,
-          html: emailContent.html,
-        }),
-      ),
-    );
-
-    const failures = results.filter(
-      (r): r is PromiseRejectedResult => r.status === "rejected",
-    );
-    if (failures.length > 0) {
-      console.error(
-        `${failures.length}/${results.length} approval-request emails failed`,
-        failures.map((f) => f.reason),
+      const failures = results.filter(
+        (r): r is PromiseRejectedResult => r.status === "rejected",
       );
+      if (failures.length > 0) {
+        console.error(
+          `${failures.length}/${results.length} approval-request emails failed`,
+          failures.map((f) => f.reason),
+        );
+      }
+    } catch (error) {
+      console.error("Failed to send approval-request emails", error);
     }
-  } catch (error) {
-    console.error("Failed to send approval-request emails", error);
+  })();
+
+  if (waitUntil) {
+    waitUntil(fanOut);
+  } else {
+    await fanOut;
   }
 }
 
@@ -399,10 +417,23 @@ export async function resolveApprovalRequestsForApprover(
     );
 }
 
+export const NOTIFICATIONS_DEFAULT_PAGE_SIZE = 50;
+
 export async function getNotificationsForUser(
   db: Database,
   userId: string,
+  options?: { limit?: number; cursor?: string | null },
 ): Promise<UserNotification[]> {
+  const limit = options?.limit ?? NOTIFICATIONS_DEFAULT_PAGE_SIZE;
+  const cursor = options?.cursor ?? null;
+
+  const whereClause = cursor
+    ? and(
+        eq(notifications.userId, userId),
+        lt(notifications.createdAt, cursor),
+      )
+    : eq(notifications.userId, userId);
+
   return db
     .select({
       id: notifications.id,
@@ -419,8 +450,9 @@ export async function getNotificationsForUser(
       createdAt: notifications.createdAt,
     })
     .from(notifications)
-    .where(eq(notifications.userId, userId))
-    .orderBy(desc(notifications.createdAt));
+    .where(whereClause)
+    .orderBy(desc(notifications.createdAt))
+    .limit(limit);
 }
 
 export async function getUnreadNotificationCount(
@@ -428,11 +460,11 @@ export async function getUnreadNotificationCount(
   userId: string,
 ): Promise<number> {
   const rows = await db
-    .select({ id: notifications.id })
+    .select({ value: count() })
     .from(notifications)
     .where(and(eq(notifications.userId, userId), isNull(notifications.readAt)));
 
-  return rows.length;
+  return rows[0]?.value ?? 0;
 }
 
 export async function markNotificationRead(

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -415,12 +415,9 @@ export async function getNotificationsForUser(
   const limit = options?.limit ?? NOTIFICATIONS_DEFAULT_PAGE_SIZE;
   const cursor = options?.cursor ?? null;
 
-  // Cursor is `createdAt` with strict `lt`. Batched inserts (e.g. one
-  // comment notifying multiple recipients) can stamp identical createdAt
-  // values; if such a batch straddles a page boundary, the next page
-  // will skip the duplicate-timestamp rows. Tolerable for now because
-  // pagination beyond the first page is rare and batch sizes are small.
-  // If this becomes a problem, switch to a tuple cursor (createdAt, id).
+  // Batched inserts can share a createdAt, so `lt(createdAt, cursor)`
+  // may skip duplicate-timestamp rows that straddle a page boundary.
+  // Switch to a tuple cursor (createdAt, id) if this becomes hot.
   const whereClause = cursor
     ? and(
         eq(notifications.userId, userId),

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -33,8 +33,6 @@ export interface EmailConfig {
   baseUrl: string;
 }
 
-export type WaitUntil = (promise: Promise<unknown>) => void;
-
 export interface UserNotification {
   id: string;
   actorDisplayName: string;
@@ -90,7 +88,6 @@ export async function createCommentNotifications(
   input: CommentNotificationInput,
   emailConfig?: EmailConfig,
   realtimeEnv?: Env,
-  waitUntil?: WaitUntil,
 ): Promise<void> {
   const videoRows = await db
     .select({
@@ -154,7 +151,7 @@ export async function createCommentNotifications(
 
   await db.insert(notifications).values(rows);
 
-  const fanOut = (async () => {
+  try {
     if (realtimeEnv) {
       const createdAt = new Date().toISOString();
       await Promise.all(
@@ -170,59 +167,55 @@ export async function createCommentNotifications(
         ),
       );
     }
+  } catch (error) {
+    console.error("Failed to broadcast comment notifications", error);
+  }
 
-    if (!emailConfig) return;
+  if (!emailConfig) return;
 
-    try {
-      const emailRecipients = await db
-        .select({ id: users.id, email: users.email })
-        .from(users)
-        .where(
-          and(
-            inArray(users.id, recipientIds),
-            eq(users.emailNotificationsEnabled, true),
-          ),
-        );
-
-      if (emailRecipients.length === 0) return;
-
-      const emailContent = buildCommentNotificationEmail({
-        type,
-        actorDisplayName: input.actorDisplayName,
-        videoTitle: video.title,
-        commentSnippet: body,
-        href,
-        baseUrl: emailConfig.baseUrl,
-      });
-
-      const results = await Promise.allSettled(
-        emailRecipients.map((recipient) =>
-          emailConfig.send({
-            to: recipient.email,
-            from: emailConfig.from,
-            subject: emailContent.subject,
-            text: emailContent.text,
-            html: emailContent.html,
-          }),
+  try {
+    const emailRecipients = await db
+      .select({ id: users.id, email: users.email })
+      .from(users)
+      .where(
+        and(
+          inArray(users.id, recipientIds),
+          eq(users.emailNotificationsEnabled, true),
         ),
       );
 
-      const failures = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
-      if (failures.length > 0) {
-        console.error(
-          `${failures.length}/${results.length} notification emails failed`,
-          failures.map((f) => f.reason),
-        );
-      }
-    } catch (error) {
-      console.error("Failed to send comment notification emails", error);
-    }
-  })();
+    if (emailRecipients.length === 0) return;
 
-  if (waitUntil) {
-    waitUntil(fanOut);
-  } else {
-    await fanOut;
+    const emailContent = buildCommentNotificationEmail({
+      type,
+      actorDisplayName: input.actorDisplayName,
+      videoTitle: video.title,
+      commentSnippet: body,
+      href,
+      baseUrl: emailConfig.baseUrl,
+    });
+
+    const results = await Promise.allSettled(
+      emailRecipients.map((recipient) =>
+        emailConfig.send({
+          to: recipient.email,
+          from: emailConfig.from,
+          subject: emailContent.subject,
+          text: emailContent.text,
+          html: emailContent.html,
+        }),
+      ),
+    );
+
+    const failures = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+    if (failures.length > 0) {
+      console.error(
+        `${failures.length}/${results.length} notification emails failed`,
+        failures.map((f) => f.reason),
+      );
+    }
+  } catch (error) {
+    console.error("Failed to send comment notification emails", error);
   }
 }
 
@@ -244,7 +237,6 @@ export async function createTargetedApprovalRequestNotifications(
   input: TargetedApprovalRequestInput,
   emailConfig?: EmailConfig,
   realtimeEnv?: Env,
-  waitUntil?: WaitUntil,
 ): Promise<void> {
   if (input.requestedUserIds.length === 0) return;
 
@@ -289,7 +281,7 @@ export async function createTargetedApprovalRequestNotifications(
 
   await db.insert(notifications).values(rows);
 
-  const fanOut = (async () => {
+  try {
     if (realtimeEnv) {
       const createdAt = new Date().toISOString();
       await Promise.all(
@@ -305,59 +297,55 @@ export async function createTargetedApprovalRequestNotifications(
         ),
       );
     }
+  } catch (error) {
+    console.error("Failed to broadcast approval-request notifications", error);
+  }
 
-    if (!emailConfig) return;
+  if (!emailConfig) return;
 
-    try {
-      const emailRecipients = await db
-        .select({ id: users.id, email: users.email })
-        .from(users)
-        .where(
-          and(
-            inArray(users.id, recipientIds),
-            eq(users.emailNotificationsEnabled, true),
-          ),
-        );
-
-      if (emailRecipients.length === 0) return;
-
-      const emailContent = buildApprovalRequestEmail({
-        actorDisplayName: input.actorDisplayName,
-        videoTitle: video.title,
-        href,
-        baseUrl: emailConfig.baseUrl,
-      });
-
-      const results = await Promise.allSettled(
-        emailRecipients.map((recipient) =>
-          emailConfig.send({
-            to: recipient.email,
-            from: emailConfig.from,
-            subject: emailContent.subject,
-            text: emailContent.text,
-            html: emailContent.html,
-          }),
+  try {
+    const emailRecipients = await db
+      .select({ id: users.id, email: users.email })
+      .from(users)
+      .where(
+        and(
+          inArray(users.id, recipientIds),
+          eq(users.emailNotificationsEnabled, true),
         ),
       );
 
-      const failures = results.filter(
-        (r): r is PromiseRejectedResult => r.status === "rejected",
-      );
-      if (failures.length > 0) {
-        console.error(
-          `${failures.length}/${results.length} approval-request emails failed`,
-          failures.map((f) => f.reason),
-        );
-      }
-    } catch (error) {
-      console.error("Failed to send approval-request emails", error);
-    }
-  })();
+    if (emailRecipients.length === 0) return;
 
-  if (waitUntil) {
-    waitUntil(fanOut);
-  } else {
-    await fanOut;
+    const emailContent = buildApprovalRequestEmail({
+      actorDisplayName: input.actorDisplayName,
+      videoTitle: video.title,
+      href,
+      baseUrl: emailConfig.baseUrl,
+    });
+
+    const results = await Promise.allSettled(
+      emailRecipients.map((recipient) =>
+        emailConfig.send({
+          to: recipient.email,
+          from: emailConfig.from,
+          subject: emailContent.subject,
+          text: emailContent.text,
+          html: emailContent.html,
+        }),
+      ),
+    );
+
+    const failures = results.filter(
+      (r): r is PromiseRejectedResult => r.status === "rejected",
+    );
+    if (failures.length > 0) {
+      console.error(
+        `${failures.length}/${results.length} approval-request emails failed`,
+        failures.map((f) => f.reason),
+      );
+    }
+  } catch (error) {
+    console.error("Failed to send approval-request emails", error);
   }
 }
 
@@ -427,6 +415,12 @@ export async function getNotificationsForUser(
   const limit = options?.limit ?? NOTIFICATIONS_DEFAULT_PAGE_SIZE;
   const cursor = options?.cursor ?? null;
 
+  // Cursor is `createdAt` with strict `lt`. Batched inserts (e.g. one
+  // comment notifying multiple recipients) can stamp identical createdAt
+  // values; if such a batch straddles a page boundary, the next page
+  // will skip the duplicate-timestamp rows. Tolerable for now because
+  // pagination beyond the first page is rare and batch sizes are small.
+  // If this becomes a problem, switch to a tuple cursor (createdAt, id).
   const whereClause = cursor
     ? and(
         eq(notifications.userId, userId),

--- a/src/lib/stream.ts
+++ b/src/lib/stream.ts
@@ -1,5 +1,50 @@
 const STREAM_API_BASE = "https://api.cloudflare.com/client/v4/accounts";
 
+const STREAM_FETCH_TIMEOUT_MS = 15_000;
+const STREAM_FETCH_MAX_ATTEMPTS = 3;
+const STREAM_FETCH_BACKOFF_MS = 500;
+
+async function streamFetch(url: string, init: RequestInit): Promise<Response> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= STREAM_FETCH_MAX_ATTEMPTS; attempt++) {
+    try {
+      const response = await fetch(url, {
+        ...init,
+        signal: AbortSignal.timeout(STREAM_FETCH_TIMEOUT_MS),
+      });
+
+      if (response.status >= 500 && attempt < STREAM_FETCH_MAX_ATTEMPTS) {
+        console.warn(
+          `Stream API ${response.status} (attempt ${attempt}/${STREAM_FETCH_MAX_ATTEMPTS}); retrying`,
+        );
+        await sleep(STREAM_FETCH_BACKOFF_MS * attempt);
+        continue;
+      }
+
+      return response;
+    } catch (err) {
+      lastError = err;
+      if (attempt < STREAM_FETCH_MAX_ATTEMPTS) {
+        console.warn(
+          `Stream API fetch failed (attempt ${attempt}/${STREAM_FETCH_MAX_ATTEMPTS}); retrying`,
+          err,
+        );
+        await sleep(STREAM_FETCH_BACKOFF_MS * attempt);
+        continue;
+      }
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Stream API fetch failed after retries");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 interface DirectUploadResult {
   uploadUrl: string;
   streamVideoId: string;
@@ -11,7 +56,7 @@ export async function createDirectUpload(
   fileName: string,
   fileSize: number,
 ): Promise<DirectUploadResult> {
-  const response = await fetch(
+  const response = await streamFetch(
     `${STREAM_API_BASE}/${accountId}/stream?direct_user=true`,
     {
       method: "POST",
@@ -52,7 +97,7 @@ export async function getVideoInfo(
   apiToken: string,
   streamVideoId: string,
 ): Promise<StreamVideoInfo> {
-  const response = await fetch(
+  const response = await streamFetch(
     `${STREAM_API_BASE}/${accountId}/stream/${streamVideoId}`,
     {
       headers: {
@@ -74,7 +119,7 @@ export async function deleteVideo(
   apiToken: string,
   streamVideoId: string,
 ): Promise<void> {
-  const response = await fetch(
+  const response = await streamFetch(
     `${STREAM_API_BASE}/${accountId}/stream/${streamVideoId}`,
     {
       method: "DELETE",
@@ -109,7 +154,7 @@ export async function requestAudioDownload(
   apiToken: string,
   streamVideoId: string,
 ): Promise<StreamAudioDownload> {
-  const response = await fetch(
+  const response = await streamFetch(
     `${STREAM_API_BASE}/${accountId}/stream/${streamVideoId}/downloads/audio`,
     {
       method: "POST",
@@ -142,7 +187,7 @@ export async function getAudioDownload(
   apiToken: string,
   streamVideoId: string,
 ): Promise<StreamAudioDownload | null> {
-  const response = await fetch(
+  const response = await streamFetch(
     `${STREAM_API_BASE}/${accountId}/stream/${streamVideoId}/downloads`,
     {
       headers: {

--- a/src/lib/transcripts.ts
+++ b/src/lib/transcripts.ts
@@ -107,6 +107,11 @@ export async function queueTranscriptForVideo(
     return;
   }
 
+  const workflow = env.TRANSCRIPT_WORKFLOW;
+  // If the workflow binding is missing we can't drive the row forward, so
+  // don't materialize a "queued" row that will sit there forever.
+  if (!workflow) return;
+
   const workflowInstanceId = `transcript-${transcriptId}`;
 
   if (existing[0]) {
@@ -130,9 +135,6 @@ export async function queueTranscriptForVideo(
       updatedAt: now,
     });
   }
-
-  const workflow = env.TRANSCRIPT_WORKFLOW;
-  if (!workflow) return;
 
   try {
     await workflow.create({

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,13 +1,29 @@
 import { defineMiddleware } from "astro:middleware";
 import { env } from "cloudflare:workers";
-import { createAuth } from "./lib/auth";
+import { createAuth, type Auth } from "./lib/auth";
 import { getCanonicalBaseUrl, getSafeReturnUrl } from "./lib/urls";
+
+let cachedAuth: Auth | null = null;
+let cachedAuthDb: D1Database | null = null;
+function getAuth(): Auth {
+  if (cachedAuth && cachedAuthDb === env.DB) return cachedAuth;
+  cachedAuth = createAuth(env.DB, {
+    BETTER_AUTH_SECRET: env.BETTER_AUTH_SECRET,
+    BETTER_AUTH_URL: env.BETTER_AUTH_URL,
+    EMAIL: env.EMAIL,
+    OTP_EMAIL_FROM: env.OTP_EMAIL_FROM,
+    SEND_REAL_EMAILS: env.SEND_REAL_EMAILS,
+  });
+  cachedAuthDb = env.DB;
+  return cachedAuth;
+}
 
 // Extend Astro locals type
 declare global {
   namespace App {
     interface Locals {
       user: { id: string; email: string; name: string; image?: string | null } | null;
+      cfContext?: ExecutionContext;
     }
   }
 }
@@ -47,13 +63,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
     }
   }
 
-  const auth = createAuth(env.DB, {
-    BETTER_AUTH_SECRET: env.BETTER_AUTH_SECRET,
-    BETTER_AUTH_URL: env.BETTER_AUTH_URL,
-    EMAIL: env.EMAIL,
-    OTP_EMAIL_FROM: env.OTP_EMAIL_FROM,
-    SEND_REAL_EMAILS: env.SEND_REAL_EMAILS,
-  });
+  const auth = getAuth();
 
   try {
     const session = await auth.api.getSession({

--- a/src/pages/api/share/[token]/comments.ts
+++ b/src/pages/api/share/[token]/comments.ts
@@ -250,7 +250,6 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
       baseUrl: getCanonicalBaseUrl(env),
     },
     env,
-    waitUntil,
   ).catch((err) => {
     console.error("Failed to create share comment notification", err);
   });

--- a/src/pages/api/share/[token]/comments.ts
+++ b/src/pages/api/share/[token]/comments.ts
@@ -5,6 +5,7 @@ import { shareLinks, comments, projects, users, videos } from "../../../../db/sc
 import { eq, asc, gt, and, inArray } from "drizzle-orm";
 import { broadcastNewComment } from "../../../../lib/broadcast";
 import { addReactionSummaries } from "../../../../lib/comments";
+import { getWaitUntil } from "../../../../lib/ctx";
 import { createCommentNotifications } from "../../../../lib/notifications";
 import { sendEmail } from "../../../../lib/send-email";
 import { anonymousCommentSchema, commentSchema } from "../../../../lib/validation";
@@ -222,24 +223,6 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 
   const displayName = sessionUser?.name ?? newComment.authorDisplayName ?? "Anonymous";
 
-  try {
-    await createCommentNotifications(db, {
-      commentId,
-      videoId,
-      actorUserId: sessionUser?.id ?? null,
-      actorDisplayName: displayName,
-      text: newComment.text,
-      parentCommentId: newComment.parentId,
-      phase: newComment.phase,
-    }, {
-      send: (msg) => sendEmail(env, msg),
-      from: env.OTP_EMAIL_FROM,
-      baseUrl: getCanonicalBaseUrl(env),
-    }, env);
-  } catch (err) {
-    console.error("Failed to create share comment notification", err);
-  }
-
   const responseComment = {
     ...newComment,
     annotation: annotation || null,
@@ -249,7 +232,37 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
     reactions: [],
   };
 
-  await broadcastNewComment(env, videoId, responseComment);
+  const waitUntil = getWaitUntil(locals);
+  const notificationsPromise = createCommentNotifications(
+    db,
+    {
+      commentId,
+      videoId,
+      actorUserId: sessionUser?.id ?? null,
+      actorDisplayName: displayName,
+      text: newComment.text,
+      parentCommentId: newComment.parentId,
+      phase: newComment.phase,
+    },
+    {
+      send: (msg) => sendEmail(env, msg),
+      from: env.OTP_EMAIL_FROM,
+      baseUrl: getCanonicalBaseUrl(env),
+    },
+    env,
+    waitUntil,
+  ).catch((err) => {
+    console.error("Failed to create share comment notification", err);
+  });
+
+  const broadcastPromise = broadcastNewComment(env, videoId, responseComment);
+
+  if (waitUntil) {
+    waitUntil(notificationsPromise);
+    waitUntil(broadcastPromise);
+  } else {
+    await Promise.all([notificationsPromise, broadcastPromise]);
+  }
 
   return new Response(JSON.stringify({ comment: responseComment }), {
     status: 201,

--- a/src/pages/api/videos/[id]/status.ts
+++ b/src/pages/api/videos/[id]/status.ts
@@ -3,8 +3,6 @@ import { env } from "cloudflare:workers";
 import { createDb } from "../../../../db";
 import { videos } from "../../../../db/schema";
 import { eq } from "drizzle-orm";
-import { getVideoInfo } from "../../../../lib/stream";
-import { queueTranscriptForVideo } from "../../../../lib/transcripts";
 import { verifySpaceAccess } from "../../../../lib/spaces";
 
 export const GET: APIRoute = async ({ params, locals }) => {
@@ -25,7 +23,13 @@ export const GET: APIRoute = async ({ params, locals }) => {
 
   const db = createDb(env.DB);
   const result = await db
-    .select()
+    .select({
+      status: videos.status,
+      thumbnailUrl: videos.thumbnailUrl,
+      duration: videos.duration,
+      streamPlaybackUrl: videos.streamPlaybackUrl,
+      spaceId: videos.spaceId,
+    })
     .from(videos)
     .where(eq(videos.id, id))
     .limit(1);
@@ -39,82 +43,12 @@ export const GET: APIRoute = async ({ params, locals }) => {
 
   const video = result[0];
 
-  // Verify user has space access
   const statusRole = await verifySpaceAccess(db, locals.user.id, video.spaceId);
   if (!statusRole) {
     return new Response(JSON.stringify({ error: "Forbidden" }), {
       status: 403,
       headers: { "Content-Type": "application/json" },
     });
-  }
-
-  // If still processing and we have a Stream video ID, check Stream API directly
-  // This handles the case where the webhook can't reach us (e.g. local dev)
-  if (video.status === "processing" && video.streamVideoId) {
-    try {
-      const info = await getVideoInfo(
-        env.STREAM_ACCOUNT_ID,
-        env.STREAM_API_TOKEN,
-        video.streamVideoId,
-      );
-
-      if (info.readyToStream && info.status.state === "ready") {
-        const now = new Date().toISOString();
-        // Update DB with the real data from Stream
-        await db
-          .update(videos)
-          .set({
-            status: "ready",
-            duration: info.duration,
-            thumbnailUrl: info.thumbnail,
-            streamPlaybackUrl: info.playback.hls,
-            updatedAt: now,
-          })
-          .where(eq(videos.id, id));
-
-        await queueTranscriptForVideo(env, db, {
-          ...video,
-          status: "ready",
-          duration: info.duration,
-          thumbnailUrl: info.thumbnail,
-          streamPlaybackUrl: info.playback.hls,
-          updatedAt: now,
-        });
-
-        return new Response(
-          JSON.stringify({
-            status: "ready",
-            thumbnailUrl: info.thumbnail,
-            duration: info.duration,
-            streamPlaybackUrl: info.playback.hls,
-          }),
-          { headers: { "Content-Type": "application/json" } },
-        );
-      }
-
-      if (info.status.state === "error") {
-        await db
-          .update(videos)
-          .set({
-            status: "failed",
-            updatedAt: new Date().toISOString(),
-          })
-          .where(eq(videos.id, id));
-
-        return new Response(
-          JSON.stringify({
-            status: "failed",
-            thumbnailUrl: null,
-            duration: null,
-            streamPlaybackUrl: null,
-          }),
-          { headers: { "Content-Type": "application/json" } },
-        );
-      }
-    } catch (e) {
-      // Stream API check failed — fall through and return DB status
-      console.error("Stream API status check failed:", e);
-    }
   }
 
   return new Response(

--- a/src/pages/api/webhooks/stream.ts
+++ b/src/pages/api/webhooks/stream.ts
@@ -101,7 +101,7 @@ async function verifyWebhookSignature(
   return { valid: true, parsed };
 }
 
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async ({ request, locals }) => {
   const body = await request.text();
   const signature = request.headers.get("Webhook-Signature");
 
@@ -161,7 +161,7 @@ export const POST: APIRoute = async ({ request }) => {
       })
       .where(eq(videos.id, video.id));
 
-    await queueTranscriptForVideo(env, db, {
+    const queuePromise = queueTranscriptForVideo(env, db, {
       ...video,
       status: "ready",
       duration: payload.duration,
@@ -169,6 +169,12 @@ export const POST: APIRoute = async ({ request }) => {
       streamPlaybackUrl: payload.playback.hls,
       updatedAt: now,
     });
+
+    if (locals.cfContext) {
+      locals.cfContext.waitUntil(queuePromise);
+    } else {
+      await queuePromise;
+    }
   } else if (payload.status.state === "error") {
     await db
       .update(videos)

--- a/src/workflows/TranscriptWorkflow.ts
+++ b/src/workflows/TranscriptWorkflow.ts
@@ -92,70 +92,108 @@ export class TranscriptWorkflow extends WorkflowEntrypoint<Env, TranscriptWorkfl
         },
       );
 
-      const transcribed = await step.do("transcribe audio", { timeout: "10 minutes" }, async () => {
-        await db
-          .update(transcripts)
-          .set({ status: "transcribing", updatedAt: now() })
-          .where(eq(transcripts.id, transcriptId));
+      const transcribed = await step.do(
+        "transcribe audio",
+        {
+          timeout: "10 minutes",
+          retries: { limit: 3, delay: "30 seconds", backoff: "exponential" },
+        },
+        async () => {
+          await db
+            .update(transcripts)
+            .set({ status: "transcribing", updatedAt: now() })
+            .where(eq(transcripts.id, transcriptId));
 
-        const audioResponse = await fetch(audioUrl);
-        if (!audioResponse.ok) throw new Error(`Audio fetch failed: ${audioResponse.status}`);
+          const audioResponse = await fetch(audioUrl, {
+            signal: AbortSignal.timeout(60_000),
+          });
+          if (!audioResponse.ok) throw new Error(`Audio fetch failed: ${audioResponse.status}`);
 
-        const audioBuffer = await audioResponse.arrayBuffer();
-        const audioBytes = new Uint8Array(audioBuffer);
-        const response = await this.env.AI.run("@cf/openai/whisper", {
-          audio: Array.from(audioBytes),
-        }) as WhisperResponse;
+          const audioBuffer = await audioResponse.arrayBuffer();
+          const audioBytes = new Uint8Array(audioBuffer);
+          const response = await this.env.AI.run("@cf/openai/whisper", {
+            audio: Array.from(audioBytes),
+          }) as WhisperResponse;
 
-        if (!response.text) throw new Error("Workers AI did not return transcript text");
+          if (!response.text) throw new Error("Workers AI did not return transcript text");
 
-        await db
-          .update(transcripts)
-          .set({
-            rawText: response.text,
-            vtt: response.vtt || null,
-            wordCount: response.word_count || null,
-            status: "ready_raw_only",
-            updatedAt: now(),
-          })
-          .where(eq(transcripts.id, transcriptId));
+          await db
+            .update(transcripts)
+            .set({
+              rawText: response.text,
+              vtt: response.vtt || null,
+              wordCount: response.word_count || null,
+              status: "ready_raw_only",
+              updatedAt: now(),
+            })
+            .where(eq(transcripts.id, transcriptId));
 
-        return { text: response.text };
-      });
+          return { text: response.text };
+        },
+      );
 
-      await step.do("clean transcript", { timeout: "5 minutes" }, async () => {
+      await step.do("mark cleaning", async () => {
         await db
           .update(transcripts)
           .set({ status: "cleaning", updatedAt: now() })
           .where(eq(transcripts.id, transcriptId));
+      });
 
-        try {
-          const response = await this.env.AI.run(this.env.TRANSCRIPT_CLEANUP_MODEL, {
-            messages: [{ role: "user", content: getCleanupPrompt(transcribed.text) }],
-          }) as TextGenerationResponse;
+      let cleaned: string | null = null;
+      let cleanupError: unknown = null;
 
-          const cleaned = response.response?.trim();
+      try {
+        cleaned = await step.do(
+          "clean transcript ai call",
+          {
+            timeout: "5 minutes",
+            retries: { limit: 3, delay: "10 seconds" },
+          },
+          async () => {
+            const response = (await this.env.AI.run(
+              this.env.TRANSCRIPT_CLEANUP_MODEL,
+              {
+                messages: [{ role: "user", content: getCleanupPrompt(transcribed.text) }],
+              },
+            )) as TextGenerationResponse;
+
+            return response.response?.trim() || null;
+          },
+        );
+      } catch (err) {
+        // Retries exhausted. Persist `ready_raw_only` in the next step rather
+        // than failing the whole workflow — the raw transcript is still usable.
+        cleanupError = err;
+      }
+
+      await step.do("persist cleaned transcript", async () => {
+        if (cleaned) {
           await db
             .update(transcripts)
             .set({
-              cleanedText: cleaned || null,
-              status: cleaned ? "ready" : "ready_raw_only",
+              cleanedText: cleaned,
+              status: "ready",
               completedAt: now(),
               updatedAt: now(),
             })
             .where(eq(transcripts.id, transcriptId));
-        } catch (cleanupError) {
-          // Cleanup failure is non-fatal -- raw transcript is still usable.
-          await db
-            .update(transcripts)
-            .set({
-              status: "ready_raw_only",
-              errorMessage: cleanupError instanceof Error ? cleanupError.message : "Transcript cleanup failed",
-              completedAt: now(),
-              updatedAt: now(),
-            })
-            .where(eq(transcripts.id, transcriptId));
+          return;
         }
+
+        await db
+          .update(transcripts)
+          .set({
+            status: "ready_raw_only",
+            errorMessage:
+              cleanupError instanceof Error
+                ? cleanupError.message
+                : cleanupError
+                ? "Transcript cleanup failed"
+                : null,
+            completedAt: now(),
+            updatedAt: now(),
+          })
+          .where(eq(transcripts.id, transcriptId));
       });
     } catch (err) {
       await step.do("mark failed", async () => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,6 +4,10 @@
   "main": "./src/worker.ts",
   "account_id": "4426cbeacb457b1ca1b865d6c36ced0d",
   "compatibility_date": "2026-04-21",
+  // better-auth pulls in node:async_hooks and tus-js-client pulls in
+  // node:fs/http/stream/etc. Removing nodejs_compat causes Vite to surface
+  // these as build warnings and the Worker fails at runtime. Keep the flag
+  // until upstream packages are workerd-native.
   "compatibility_flags": ["nodejs_compat"],
   "assets": {
     "binding": "ASSETS",


### PR DESCRIPTION
## Summary

- Move fire-and-forget broadcast, email, and workflow creation into `ctx.waitUntil` so user-facing requests no longer block on DO RPC, email sends, or workflow scheduling
- Harden external Stream API and audio fetches with timeouts and retries
- Split the transcript cleanup step so transient AI failures retry instead of permanently producing `ready_raw_only`
- Add DO ping/pong auto-response plus debounced presence broadcasts

## Changes

- **`src/lib/notifications.ts`** — `createCommentNotifications` and `createTargetedApprovalRequestNotifications` now always run their broadcast + email fan-out inline; callers own the deferral via `waitUntil(notificationsPromise)`. Broadcast and email blocks have separate try/catches, so a broadcast failure no longer blocks email send (and vice versa). Also: `getUnreadNotificationCount` uses `count()` aggregate; `getNotificationsForUser` takes `limit` (default 50) and `cursor`.
- **`src/actions/index.ts`** — every broadcast and notification call site (comment.create, comment.reply, comment.toggleReaction, approve, unapprove, video.move, video.uploadVersion, requestApprovals, space.invite, notification.markReadByContext, and the project-phase change action) now uses `ctx.waitUntil` via a new `getWaitUntil` helper
- **`src/lib/ctx.ts`** — new helper that pulls `cfContext.waitUntil` off `Astro.locals` and returns `undefined` when missing; defines and exports the `WaitUntil` type
- **`src/middleware.ts`** — expose `cfContext` in `App.Locals` typing and memoize the `createAuth` instance at module scope (keyed on the D1 binding)
- **`src/pages/api/webhooks/stream.ts`** — `queueTranscriptForVideo` is now fired via `waitUntil` instead of blocking the webhook response
- **`src/pages/api/share/[token]/comments.ts`** — share-link comment creation defers broadcast + notification fan-out via `waitUntil`
- **`src/lib/stream.ts`** — new `streamFetch` helper wraps every Stream API call with `AbortSignal.timeout(15s)` and a 3-attempt retry on 5xx with linear backoff
- **`src/workflows/TranscriptWorkflow.ts`** — 60s timeout on the audio fetch; Whisper step gets `retries: { limit: 3, delay: "30 seconds", backoff: "exponential" }`; cleanup is split into `clean transcript ai call` (with retries) and `persist cleaned transcript` (writes `ready` if cleaned, `ready_raw_only` only after retries are exhausted)
- **`src/pages/api/videos/[id]/status.ts`** — now read-only; no writes to `videos`, no workflow creation. The webhook owns transitions
- **`src/lib/transcripts.ts`** — moved the `TRANSCRIPT_WORKFLOW` binding check above the queued-row insert so a missing binding does not leave orphaned `queued` rows
- **`src/durable-objects/UserNotifications.ts`, `src/durable-objects/VideoRoom.ts`** — `setWebSocketAutoResponse(new WebSocketRequestResponsePair("ping", "pong"))` in the constructor so client heartbeats never wake a hibernating DO. `VideoRoom` presence broadcasts now coalesce via a 100ms alarm (`schedulePresenceBroadcast()`) so rapid join/leave bursts produce one fan-out per quiet window
- **`src/hooks/useStreamPlayer.ts`** — replaced the 50ms `setInterval` poll with `script.onload`/`error` listeners on the existing `embed.cloudflarestream.com` script tag, with a single timeout fallback
- **`wrangler.jsonc`** — experimented with removing `nodejs_compat` per the issue. Build surfaces warnings that `better-auth` imports `node:async_hooks` and `tus-js-client` imports `node:fs/http/stream`, so the flag is restored with an inline comment

## Notable behavior change

The broadcast and email fan-out paths in `createCommentNotifications` / `createTargetedApprovalRequestNotifications` now have independent error handling. Previously a thrown broadcast error would short-circuit and prevent the email from sending. Now both run regardless of the other's outcome — the two paths are genuinely independent and shouldn't be coupled.

## Testing

`pnpm build` passes (Wrangler types + Astro build, no warnings). See test plan in the issue / chat.

Closes #140