### PR TITLE
fix(share): persist guest name in cookie to stop modal flash on tab switch

### DIFF
--- a/src/components/NamePromptModal.tsx
+++ b/src/components/NamePromptModal.tsx
@@ -46,6 +46,7 @@ export function NamePromptModal({
             onChange={(e) => setName(e.target.value)}
             placeholder="First and last name"
             autoFocus
+            maxLength={100}
             className="w-full rounded-lg border border-border-default bg-bg-input px-4 py-2.5 text-sm text-text-primary placeholder:text-text-tertiary focus:border-accent-primary focus:outline-none"
           />
           <div className="flex gap-3">

--- a/src/components/ShareView.tsx
+++ b/src/components/ShareView.tsx
@@ -47,9 +47,18 @@ interface ShareViewProps {
   pipelineEnabled: boolean;
   initialTranscriptData: TranscriptResponse | null;
   currentUser: ShareViewCurrentUser | null;
+  initialGuestName?: string | null;
 }
 
 const ANON_NAME_KEY = "quickcut_anonymous_name";
+const GUEST_NAME_COOKIE = "qc_guest_name";
+const GUEST_NAME_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+function writeGuestNameCookie(name: string) {
+  if (typeof document === "undefined") return;
+  const encoded = encodeURIComponent(name);
+  document.cookie = `${GUEST_NAME_COOKIE}=${encoded}; Max-Age=${GUEST_NAME_COOKIE_MAX_AGE}; Path=/s/; SameSite=Lax`;
+}
 
 export function ShareView({
   activeTab,
@@ -62,9 +71,11 @@ export function ShareView({
   pipelineEnabled,
   initialTranscriptData,
   currentUser,
+  initialGuestName,
 }: ShareViewProps) {
   const [anonymousName, setAnonymousName] = useState<string | null>(() => {
     if (currentUser) return null;
+    if (initialGuestName) return initialGuestName;
     if (typeof window === "undefined") return null;
     return localStorage.getItem(ANON_NAME_KEY);
   });
@@ -79,6 +90,7 @@ export function ShareView({
 
   const handleNameSubmit = (name: string) => {
     localStorage.setItem(ANON_NAME_KEY, name);
+    writeGuestNameCookie(name);
     setAnonymousName(name);
   };
 

--- a/src/components/ShareView.tsx
+++ b/src/components/ShareView.tsx
@@ -53,11 +53,15 @@ interface ShareViewProps {
 const ANON_NAME_KEY = "quickcut_anonymous_name";
 const GUEST_NAME_COOKIE = "qc_guest_name";
 const GUEST_NAME_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+const GUEST_NAME_MAX_LENGTH = 100;
 
 function writeGuestNameCookie(name: string) {
   if (typeof document === "undefined") return;
-  const encoded = encodeURIComponent(name);
-  document.cookie = `${GUEST_NAME_COOKIE}=${encoded}; Max-Age=${GUEST_NAME_COOKIE_MAX_AGE}; Path=/s/; SameSite=Lax`;
+  const trimmed = name.slice(0, GUEST_NAME_MAX_LENGTH);
+  const encoded = encodeURIComponent(trimmed);
+  const isHttps = typeof location !== "undefined" && location.protocol === "https:";
+  const secure = isHttps ? "; Secure" : "";
+  document.cookie = `${GUEST_NAME_COOKIE}=${encoded}; Max-Age=${GUEST_NAME_COOKIE_MAX_AGE}; Path=/s/; SameSite=Lax${secure}`;
 }
 
 export function ShareView({
@@ -83,15 +87,27 @@ export function ShareView({
   const viewerName = currentUser?.name ?? anonymousName;
   const viewerId = currentUser?.id ?? "";
 
+  // Backfill the cookie for guests who set their name before this fix shipped
+  // (localStorage present, cookie absent). Without this, the next SSR render
+  // would still show the modal and produce a hydration-mismatch flash.
+  useEffect(() => {
+    if (currentUser) return;
+    if (initialGuestName) return;
+    if (typeof window === "undefined") return;
+    const stored = localStorage.getItem(ANON_NAME_KEY);
+    if (stored) writeGuestNameCookie(stored);
+  }, [currentUser, initialGuestName]);
+
   useEffect(() => {
     if (!viewerName) return;
     fetch(`/api/share/${shareToken}/view`, { method: "POST" }).catch(() => {});
   }, [shareToken, viewerName]);
 
   const handleNameSubmit = (name: string) => {
-    localStorage.setItem(ANON_NAME_KEY, name);
-    writeGuestNameCookie(name);
-    setAnonymousName(name);
+    const capped = name.slice(0, GUEST_NAME_MAX_LENGTH);
+    localStorage.setItem(ANON_NAME_KEY, capped);
+    writeGuestNameCookie(capped);
+    setAnonymousName(capped);
   };
 
   if (!currentUser && !anonymousName) {

--- a/src/pages/s/[token].astro
+++ b/src/pages/s/[token].astro
@@ -20,7 +20,18 @@ const currentUser = Astro.locals.user
   ? { id: Astro.locals.user.id, name: Astro.locals.user.name }
   : null;
 
-const initialGuestName = currentUser ? null : (Astro.cookies.get("qc_guest_name")?.value ?? null);
+const initialGuestName = (() => {
+  if (currentUser) return null;
+  const raw = Astro.cookies.get("qc_guest_name")?.value;
+  if (!raw) return null;
+  try {
+    const decoded = decodeURIComponent(raw);
+    const trimmed = decoded.trim().slice(0, 100);
+    return trimmed || null;
+  } catch {
+    return null;
+  }
+})();
 
 const db = createDb(env.DB);
 

--- a/src/pages/s/[token].astro
+++ b/src/pages/s/[token].astro
@@ -20,6 +20,8 @@ const currentUser = Astro.locals.user
   ? { id: Astro.locals.user.id, name: Astro.locals.user.name }
   : null;
 
+const initialGuestName = currentUser ? null : (Astro.cookies.get("qc_guest_name")?.value ?? null);
+
 const db = createDb(env.DB);
 
 // Find share link
@@ -185,6 +187,7 @@ const isPublished = phase === "published";
             pipelineEnabled={videoSpace?.pipelineEnabled || false}
             initialTranscriptData={initialTranscriptData}
             currentUser={currentUser}
+            initialGuestName={initialGuestName}
           />
         )}
 


### PR DESCRIPTION
## Summary

- Persist the anonymous guest name in a `qc_guest_name` cookie alongside the existing `localStorage` entry so the Astro server can read it during SSR.
- Read the cookie in `src/pages/s/[token].astro` and pass it to `<ShareView />` as `initialGuestName`, then seed React state from that prop first.
- Eliminates the brief name-prompt modal flash that occurred on every tab switch between Details / Script / Video on the share view, because the SSR HTML now renders the tab content directly instead of relying on a post-hydration `localStorage` read.

## Changes

- `src/components/ShareView.tsx`: new `initialGuestName` prop, seeded into `useState` ahead of the `localStorage` fallback; `handleNameSubmit` now writes both `localStorage` and a `qc_guest_name` cookie (`Path=/s/`, `SameSite=Lax`, 1-year `Max-Age`).
- `src/pages/s/[token].astro`: read `Astro.cookies.get(\"qc_guest_name\")?.value` for anonymous viewers and forward it to `ShareView`.

No schema changes, no new dependencies, no behavior change for signed-in users.

## Testing

`pnpm build` (typecheck + Astro build) passes locally. See the test plan in the PR conversation for a manual smoke test.

Closes #178