### PR TITLE
feat(home): remove in-page anchor nav from marketing header

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,19 +12,12 @@ if (user) {
   title="Collaborative Video Review"
   description="Quick Cuts is collaborative video review built on Cloudflare. Team spaces, member invites, version stacks, timestamped comments, share links for clients, resumable 5GB uploads, and global HLS playback."
 >
-  <!-- Marketing nav -->
   <header class="sticky top-0 z-50 border-b border-border-default bg-bg-primary/80 backdrop-blur">
     <div class="mx-auto flex h-14 max-w-[1280px] items-center px-6 sm:px-8">
       <a href="/" class="flex items-center gap-2 text-lg font-bold text-text-primary">
         <Logo />
         Quick Cuts
       </a>
-      <nav class="ml-10 hidden items-center gap-6 md:flex">
-        <a href="#features" class="text-sm text-text-secondary transition-colors hover:text-text-primary">Features</a>
-        <a href="#workflow" class="text-sm text-text-secondary transition-colors hover:text-text-primary">Workflow</a>
-        <a href="#stack" class="text-sm text-text-secondary transition-colors hover:text-text-primary">Stack</a>
-        <a href="#faq" class="text-sm text-text-secondary transition-colors hover:text-text-primary">FAQ</a>
-      </nav>
       <div class="ml-auto flex items-center gap-3">
         <a href="/login" class="text-sm text-text-secondary transition-colors hover:text-text-primary">Sign in</a>
         <a


### PR DESCRIPTION
## Summary

- Removes the Features / Workflow / Stack / FAQ anchor links from the homepage marketing header.
- These were hidden below `md`, so mobile users saw only Sign in / Get Started while desktop got the full nav (the asymmetry called out in the audit).
- Option 2 from the issue: drop the anchors on every viewport. The page is short and the rhythm carries via scroll.

## Changes

- `src/pages/index.astro`: delete the `<nav>` block with the four section anchors from the sticky header; remove the now-redundant `<!-- Marketing nav -->` comment.

## Notes

- Section IDs (`#features`, `#workflow`, `#stack`, `#faq`) remain on the page body, so any external deep links continue to work.
- No new components, no new shadow/border vocabulary, no JS — net 7-line deletion.

## Testing

See the local test plan in the issue thread / chat from the implementer.

Closes #161