### PR TITLE
fix(errors): backfill friendlyActionErrorMessage in remaining components (A + B)

### DIFF
--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -3,6 +3,7 @@ import { actions } from "astro:actions";
 import { PHASE_LABELS, type VideoPhase } from "../types";
 import { DatePicker } from "./DatePicker";
 import type { DashboardVideo } from "./dashboard-types";
+import { friendlyActionErrorMessage } from "../lib/errors";
 
 interface CalendarViewProps {
   initialVideos: DashboardVideo[];
@@ -105,7 +106,10 @@ export function CalendarView({ initialVideos, spaceId }: CalendarViewProps) {
         id: video.id,
         targetDate,
       });
-      if (error) throw new Error(error.message || "Failed to update launch date");
+      if (error)
+        throw new Error(
+          friendlyActionErrorMessage(error.message, "Failed to update launch date"),
+        );
     } catch (err) {
       console.error(err);
       setVideos(previous);

--- a/src/components/PhaseDropdown.tsx
+++ b/src/components/PhaseDropdown.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { actions } from "astro:actions";
 import { VIDEO_PHASES, PHASE_LABELS, normalizeVideoPhase, type VideoPhase } from "../types";
 import { Dropdown, type DropdownOption } from "./Dropdown";
+import { friendlyActionErrorMessage } from "../lib/errors";
 
 interface PhaseDropdownProps {
   videoId: string;
@@ -54,7 +55,10 @@ export function PhaseDropdown({
 
     try {
       const { error } = await actions.video.setPhase({ id: videoId, phase });
-      if (error) throw new Error(error.message || "Failed to update phase");
+      if (error)
+        throw new Error(
+          friendlyActionErrorMessage(error.message, "Failed to update phase"),
+        );
       onPhaseChange(phase);
     } catch (err) {
       console.error("Phase update failed:", err);

--- a/src/components/PipelineBoard.tsx
+++ b/src/components/PipelineBoard.tsx
@@ -3,6 +3,7 @@ import { actions } from "astro:actions";
 import { PHASE_LABELS, VIDEO_PHASES, type VideoPhase } from "../types";
 import type { DashboardVideo } from "./dashboard-types";
 import { Dropdown, type DropdownOption } from "./Dropdown";
+import { friendlyActionErrorMessage } from "../lib/errors";
 
 interface PipelineBoardProps {
   initialVideos: DashboardVideo[];
@@ -55,7 +56,10 @@ export function PipelineBoard({ initialVideos, spaceId }: PipelineBoardProps) {
 
     try {
       const { error } = await actions.video.setPhase({ id: video.id, phase });
-      if (error) throw new Error(error.message || "Failed to move project");
+      if (error)
+        throw new Error(
+          friendlyActionErrorMessage(error.message, "Failed to move project"),
+        );
     } catch (err) {
       console.error(err);
       setVideos(previous);

--- a/src/components/ScriptWorkspace.tsx
+++ b/src/components/ScriptWorkspace.tsx
@@ -11,6 +11,7 @@ import { connectVideoRoom, type Viewer } from "../lib/realtime";
 import { PresenceBar } from "./PresenceBar";
 import { PendingCommentHighlight } from "./pendingCommentHighlight";
 import { CommentHighlightDecorations } from "./commentHighlightDecorations";
+import { friendlyActionErrorMessage } from "../lib/errors";
 
 const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] };
 
@@ -323,7 +324,10 @@ export function ScriptWorkspace({
         content,
         plainText,
       });
-      if (error || !data) throw new Error(error?.message || "Failed to save script");
+      if (error || !data)
+        throw new Error(
+          friendlyActionErrorMessage(error?.message, "Failed to save script"),
+        );
       if (data.resolvedCommentIds?.length) {
         const resolvedAt = new Date().toISOString();
         setComments((current) =>
@@ -474,7 +478,10 @@ export function ScriptWorkspace({
           timestamp: null,
           textRange: selectedRange,
         });
-        if (error || !data) throw new Error(error?.message || "Failed to create comment");
+        if (error || !data)
+          throw new Error(
+            friendlyActionErrorMessage(error?.message, "Failed to create comment"),
+          );
         comment = data.comment as Comment;
       }
 
@@ -505,7 +512,10 @@ export function ScriptWorkspace({
         id: comment.id,
         resolved: nextResolved,
       });
-      if (error) throw new Error(error.message || "Failed to resolve comment");
+      if (error)
+        throw new Error(
+          friendlyActionErrorMessage(error.message, "Failed to resolve comment"),
+        );
     } catch (err) {
       console.error(err);
       setComments((current) => current.map((item) => (item.id === comment.id ? comment : item)));
@@ -537,7 +547,10 @@ export function ScriptWorkspace({
           parentId,
           text: replyText.trim(),
         });
-        if (error || !data) throw new Error(error?.message || "Failed to post reply");
+        if (error || !data)
+          throw new Error(
+            friendlyActionErrorMessage(error?.message, "Failed to post reply"),
+          );
         comment = data.comment as Comment;
       }
 

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -62,7 +62,7 @@ export function ToastViewport({ toasts, onDismiss }: ToastViewportProps) {
                 </svg>
               )}
             </span>
-            <span className="min-w-0 flex-1">{toast.message}</span>
+            <span className="min-w-0 flex-1 break-words">{toast.message}</span>
             <button
               type="button"
               onClick={() => onDismiss(toast.id)}

--- a/src/components/VideoCardMenu.tsx
+++ b/src/components/VideoCardMenu.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from "react";
 import { actions } from "astro:actions";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { MoveToFolderDialog } from "./MoveToFolderDialog";
+import { ToastViewport, useToast } from "./Toast";
+import { friendlyActionErrorMessage } from "../lib/errors";
 
 interface Folder {
   id: string;
@@ -30,6 +32,7 @@ export function VideoCardMenu({
   const [moveOpen, setMoveOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const { toasts, showToast, dismissToast } = useToast();
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -67,9 +70,12 @@ export function VideoCardMenu({
         setDeleting(false);
         return;
       }
-      alert(error.message || "Failed to delete video");
+      showToast(
+        friendlyActionErrorMessage(error.message, "Failed to delete video. Please try again."),
+        "error",
+      );
     } catch {
-      alert("Failed to delete video");
+      showToast("Failed to delete video. Please try again.", "error");
     }
     setDeleting(false);
     setConfirmOpen(false);
@@ -83,6 +89,7 @@ export function VideoCardMenu({
 
   return (
     <>
+      <ToastViewport toasts={toasts} onDismiss={dismissToast} />
       <div className="relative" ref={menuRef}>
         <button
           onClick={stopAndToggle}

--- a/src/components/VideoHeader.tsx
+++ b/src/components/VideoHeader.tsx
@@ -3,6 +3,8 @@ import { actions } from "astro:actions";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { UploadVersionModal } from "./UploadVersionModal";
 import { VersionSwitcher } from "./VersionSwitcher";
+import { ToastViewport, useToast } from "./Toast";
+import { friendlyActionErrorMessage } from "../lib/errors";
 
 interface ShareLink {
   id: string;
@@ -44,6 +46,7 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl, spaceId, 
   const [deleting, setDeleting] = useState(false);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const [confirmRevokeOpen, setConfirmRevokeOpen] = useState(false);
+  const { toasts, showToast, dismissToast } = useToast();
   const popoverRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const moreMenuRef = useRef<HTMLDivElement>(null);
@@ -103,9 +106,12 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl, spaceId, 
         window.location.href = data?.redirectVideoId ? `/videos/${data.redirectVideoId}?space=${spaceId}` : `/dashboard?space=${spaceId}`;
         return;
       }
-      alert(error.message || "Failed to delete video");
+      showToast(
+        friendlyActionErrorMessage(error.message, "Failed to delete video. Please try again."),
+        "error",
+      );
     } catch {
-      alert("Failed to delete video");
+      showToast("Failed to delete video. Please try again.", "error");
     }
     setDeleting(false);
     setConfirmDeleteOpen(false);
@@ -167,6 +173,7 @@ export function VideoHeader({ videoId, shareLink: initialLink, appUrl, spaceId, 
 
   return (
     <>
+    <ToastViewport toasts={toasts} onDismiss={dismissToast} />
     <div className="mb-6 flex flex-wrap items-center justify-between gap-2">
       <div className="flex min-w-0 items-center gap-2">
         <a


### PR DESCRIPTION
## Summary

- Continues the #123 → #172 sweep by routing the remaining error-leak sites in groups **A** and **B** of #173 through `friendlyActionErrorMessage`.
- Group **A**: replaces `alert()` modals (which could surface raw SQL / driver messages) in `VideoCardMenu` and `VideoHeader` with toasts, matching the `FolderCardMenu` pattern.
- Group **B**: wraps action-error throw sites in `CalendarView`, `PhaseDropdown`, `PipelineBoard`, and four sites in `ScriptWorkspace`, so raw server errors can't leak even if a downstream catch ever re-displays the thrown message.

Groups **C** and **D** from #173 are intentionally deferred to a follow-up PR per the issue's "Notes" section ("Reasonable to split into 2 PRs by group").

## Changes

- `src/components/VideoCardMenu.tsx`: `alert()` → `useToast` + `friendlyActionErrorMessage`. Adds `ToastViewport`.
- `src/components/VideoHeader.tsx`: `alert()` → `useToast` + `friendlyActionErrorMessage`. Adds `ToastViewport`.
- `src/components/CalendarView.tsx`: wraps `throw new Error(error.message || …)` for `actions.video.update`.
- `src/components/PhaseDropdown.tsx`: wraps `throw new Error(error.message || …)` for `actions.video.setPhase`.
- `src/components/PipelineBoard.tsx`: wraps `throw new Error(error.message || …)` for `actions.video.setPhase`.
- `src/components/ScriptWorkspace.tsx`: wraps four throw sites — `script.update`, `comment.create`, `comment.resolve`, `comment.reply`. (The two `fetch()` paths in share mode at lines ~466 / ~533 are not part of issue #173's checklist and are left untouched.)
- `src/components/Toast.tsx`: adds `break-words` to the message span as a layout safety belt for error text routed through toasts.

## Verification

- `grep -rn "alert(" src/components/` → empty.
- `grep -rEn "throw new Error\(.*\.message *\|\|" src/components/{VideoCardMenu,VideoHeader,CalendarView,PhaseDropdown,PipelineBoard,ScriptWorkspace}.tsx` → empty.
- Remaining `throw new Error(...message || ...)` matches in `src/components/` are exactly the group **C** sites listed in #173 (BrainstormCard, NewBrainstormDialog, NewProjectDialog) — deferred by design.
- `pnpm build` passes.

## Testing

See test plan in the PR thread / comment that follows.

Refs #173