### PR TITLE
perf(latency): move fan-out to ctx.waitUntil + Stream API timeouts/retries (PR A of 3 for #140)

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -752,6 +752,7 @@ export const server = {
               baseUrl: getCanonicalBaseUrl(env),
             },
             env,
+            context.locals.cfContext,
           );
         } catch (err) {
           console.error("Failed to dispatch targeted approval-request notifications", err);
@@ -1371,6 +1372,7 @@ export const server = {
               baseUrl: getCanonicalBaseUrl(env),
             },
             env,
+            context.locals.cfContext,
           );
         } catch (err) {
           console.error("Failed to create comment notification", err);
@@ -1385,7 +1387,9 @@ export const server = {
           reactions: [],
         };
 
-        await broadcastNewComment(env, videoId, responseComment);
+        context.locals.cfContext.waitUntil(
+          broadcastNewComment(env, videoId, responseComment),
+        );
 
         return { comment: responseComment };
       },
@@ -1599,6 +1603,7 @@ export const server = {
               baseUrl: getCanonicalBaseUrl(env),
             },
             env,
+            context.locals.cfContext,
           );
         } catch (err) {
           console.error("Failed to create reply notification", err);
@@ -1611,7 +1616,9 @@ export const server = {
           reactions: [],
         };
 
-        await broadcastNewComment(env, parent[0].videoId, responseComment);
+        context.locals.cfContext.waitUntil(
+          broadcastNewComment(env, parent[0].videoId, responseComment),
+        );
 
         return { comment: responseComment };
       },
@@ -1671,13 +1678,15 @@ export const server = {
           name: user.name,
         });
 
-        await broadcastCommentReactions(env, comment[0].videoId, {
-          commentId,
-          reactions: reactions.map((reaction) => ({
-            ...reaction,
-            reactedByMe: false,
-          })),
-        });
+        context.locals.cfContext.waitUntil(
+          broadcastCommentReactions(env, comment[0].videoId, {
+            commentId,
+            reactions: reactions.map((reaction) => ({
+              ...reaction,
+              reactedByMe: false,
+            })),
+          }),
+        );
 
         return { commentId, reactions };
       },
@@ -1954,13 +1963,15 @@ export const server = {
         // their open tabs so the header badge increments — pending invites
         // count toward the unread badge (see Layout.astro).
         if (existingUser.length > 0) {
-          await broadcastNotification(env, existingUser[0].id, {
-            kind: "invite",
-            id: invite.id,
-            title: `${user.name} invited you to ${space[0].name}`,
-            href: "/notifications",
-            createdAt: new Date().toISOString(),
-          });
+          context.locals.cfContext.waitUntil(
+            broadcastNotification(env, existingUser[0].id, {
+              kind: "invite",
+              id: invite.id,
+              title: `${user.name} invited you to ${space[0].name}`,
+              href: "/notifications",
+              createdAt: new Date().toISOString(),
+            }),
+          );
         }
 
         const created = await db
@@ -2158,7 +2169,9 @@ export const server = {
         const ids = await markNotificationsReadByVideoTab(db, user.id, videoId, tab);
 
         if (ids.length > 0) {
-          await broadcastNotificationsRead(env, user.id, ids);
+          context.locals.cfContext.waitUntil(
+            broadcastNotificationsRead(env, user.id, ids),
+          );
         }
 
         return { ids, count: ids.length };

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -153,34 +153,34 @@ export async function createCommentNotifications(
   await db.insert(notifications).values(rows);
 
   const fanOut = async () => {
-    if (realtimeEnv) {
-      const createdAt = new Date().toISOString();
-      const broadcastResults = await Promise.allSettled(
-        rows.map((row) =>
-          broadcastNotification(realtimeEnv, row.userId, {
-            kind: "notification",
-            id: row.id,
-            type: row.type,
-            title: row.title,
-            href: row.href,
-            createdAt,
-          }),
-        ),
-      );
-      const broadcastFailures = broadcastResults.filter(
-        (r): r is PromiseRejectedResult => r.status === "rejected",
-      );
-      if (broadcastFailures.length > 0) {
-        console.error(
-          `${broadcastFailures.length}/${broadcastResults.length} notification broadcasts failed`,
-          broadcastFailures.map((f) => f.reason),
-        );
-      }
-    }
-
-    if (!emailConfig) return;
-
     try {
+      if (realtimeEnv) {
+        const createdAt = new Date().toISOString();
+        const broadcastResults = await Promise.allSettled(
+          rows.map((row) =>
+            broadcastNotification(realtimeEnv, row.userId, {
+              kind: "notification",
+              id: row.id,
+              type: row.type,
+              title: row.title,
+              href: row.href,
+              createdAt,
+            }),
+          ),
+        );
+        const broadcastFailures = broadcastResults.filter(
+          (r): r is PromiseRejectedResult => r.status === "rejected",
+        );
+        if (broadcastFailures.length > 0) {
+          console.error(
+            `${broadcastFailures.length}/${broadcastResults.length} notification broadcasts failed`,
+            broadcastFailures.map((f) => f.reason),
+          );
+        }
+      }
+
+      if (!emailConfig) return;
+
       const emailRecipients = await db
         .select({ id: users.id, email: users.email })
         .from(users)
@@ -222,7 +222,7 @@ export async function createCommentNotifications(
         );
       }
     } catch (error) {
-      console.error("Failed to send comment notification emails", error);
+      console.error("Comment notification fan-out failed", error);
     }
   };
 
@@ -297,34 +297,34 @@ export async function createTargetedApprovalRequestNotifications(
   await db.insert(notifications).values(rows);
 
   const fanOut = async () => {
-    if (realtimeEnv) {
-      const createdAt = new Date().toISOString();
-      const broadcastResults = await Promise.allSettled(
-        rows.map((row) =>
-          broadcastNotification(realtimeEnv, row.userId, {
-            kind: "notification",
-            id: row.id,
-            type: row.type,
-            title: row.title,
-            href: row.href,
-            createdAt,
-          }),
-        ),
-      );
-      const broadcastFailures = broadcastResults.filter(
-        (r): r is PromiseRejectedResult => r.status === "rejected",
-      );
-      if (broadcastFailures.length > 0) {
-        console.error(
-          `${broadcastFailures.length}/${broadcastResults.length} approval-request broadcasts failed`,
-          broadcastFailures.map((f) => f.reason),
-        );
-      }
-    }
-
-    if (!emailConfig) return;
-
     try {
+      if (realtimeEnv) {
+        const createdAt = new Date().toISOString();
+        const broadcastResults = await Promise.allSettled(
+          rows.map((row) =>
+            broadcastNotification(realtimeEnv, row.userId, {
+              kind: "notification",
+              id: row.id,
+              type: row.type,
+              title: row.title,
+              href: row.href,
+              createdAt,
+            }),
+          ),
+        );
+        const broadcastFailures = broadcastResults.filter(
+          (r): r is PromiseRejectedResult => r.status === "rejected",
+        );
+        if (broadcastFailures.length > 0) {
+          console.error(
+            `${broadcastFailures.length}/${broadcastResults.length} approval-request broadcasts failed`,
+            broadcastFailures.map((f) => f.reason),
+          );
+        }
+      }
+
+      if (!emailConfig) return;
+
       const emailRecipients = await db
         .select({ id: users.id, email: users.email })
         .from(users)
@@ -366,7 +366,7 @@ export async function createTargetedApprovalRequestNotifications(
         );
       }
     } catch (error) {
-      console.error("Failed to send approval-request emails", error);
+      console.error("Approval-request notification fan-out failed", error);
     }
   };
 

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -88,6 +88,7 @@ export async function createCommentNotifications(
   input: CommentNotificationInput,
   emailConfig?: EmailConfig,
   realtimeEnv?: Env,
+  ctx?: ExecutionContext,
 ): Promise<void> {
   const videoRows = await db
     .select({
@@ -151,69 +152,84 @@ export async function createCommentNotifications(
 
   await db.insert(notifications).values(rows);
 
-  // Real-time fan-out to each recipient's open tabs. Best-effort; failures
-  // are logged inside broadcastNotification and do not block email delivery.
-  if (realtimeEnv) {
-    const createdAt = new Date().toISOString();
-    await Promise.all(
-      rows.map((row) =>
-        broadcastNotification(realtimeEnv, row.userId, {
-          kind: "notification",
-          id: row.id,
-          type: row.type,
-          title: row.title,
-          href: row.href,
-          createdAt,
-        }),
-      ),
-    );
-  }
+  const fanOut = async () => {
+    if (realtimeEnv) {
+      const createdAt = new Date().toISOString();
+      const broadcastResults = await Promise.allSettled(
+        rows.map((row) =>
+          broadcastNotification(realtimeEnv, row.userId, {
+            kind: "notification",
+            id: row.id,
+            type: row.type,
+            title: row.title,
+            href: row.href,
+            createdAt,
+          }),
+        ),
+      );
+      const broadcastFailures = broadcastResults.filter(
+        (r): r is PromiseRejectedResult => r.status === "rejected",
+      );
+      if (broadcastFailures.length > 0) {
+        console.error(
+          `${broadcastFailures.length}/${broadcastResults.length} notification broadcasts failed`,
+          broadcastFailures.map((f) => f.reason),
+        );
+      }
+    }
 
-  if (!emailConfig) return;
+    if (!emailConfig) return;
 
-  try {
-    const emailRecipients = await db
-      .select({ id: users.id, email: users.email })
-      .from(users)
-      .where(
-        and(
-          inArray(users.id, recipientIds),
-          eq(users.emailNotificationsEnabled, true),
+    try {
+      const emailRecipients = await db
+        .select({ id: users.id, email: users.email })
+        .from(users)
+        .where(
+          and(
+            inArray(users.id, recipientIds),
+            eq(users.emailNotificationsEnabled, true),
+          ),
+        );
+
+      if (emailRecipients.length === 0) return;
+
+      const emailContent = buildCommentNotificationEmail({
+        type,
+        actorDisplayName: input.actorDisplayName,
+        videoTitle: video.title,
+        commentSnippet: body,
+        href,
+        baseUrl: emailConfig.baseUrl,
+      });
+
+      const results = await Promise.allSettled(
+        emailRecipients.map((recipient) =>
+          emailConfig.send({
+            to: recipient.email,
+            from: emailConfig.from,
+            subject: emailContent.subject,
+            text: emailContent.text,
+            html: emailContent.html,
+          }),
         ),
       );
 
-    if (emailRecipients.length === 0) return;
-
-    const emailContent = buildCommentNotificationEmail({
-      type,
-      actorDisplayName: input.actorDisplayName,
-      videoTitle: video.title,
-      commentSnippet: body,
-      href,
-      baseUrl: emailConfig.baseUrl,
-    });
-
-    const results = await Promise.allSettled(
-      emailRecipients.map((recipient) =>
-        emailConfig.send({
-          to: recipient.email,
-          from: emailConfig.from,
-          subject: emailContent.subject,
-          text: emailContent.text,
-          html: emailContent.html,
-        }),
-      ),
-    );
-
-    const failures = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
-    if (failures.length > 0) {
-      console.error(
-        `${failures.length}/${results.length} notification emails failed`,
-        failures.map((f) => f.reason),
-      );
+      const failures = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+      if (failures.length > 0) {
+        console.error(
+          `${failures.length}/${results.length} notification emails failed`,
+          failures.map((f) => f.reason),
+        );
+      }
+    } catch (error) {
+      console.error("Failed to send comment notification emails", error);
     }
-  } catch (error) {
-    console.error("Failed to send comment notification emails", error);
+  };
+
+  if (ctx) {
+    ctx.waitUntil(fanOut());
+  } else {
+    await fanOut();
   }
 }
 
@@ -235,6 +251,7 @@ export async function createTargetedApprovalRequestNotifications(
   input: TargetedApprovalRequestInput,
   emailConfig?: EmailConfig,
   realtimeEnv?: Env,
+  ctx?: ExecutionContext,
 ): Promise<void> {
   if (input.requestedUserIds.length === 0) return;
 
@@ -279,67 +296,84 @@ export async function createTargetedApprovalRequestNotifications(
 
   await db.insert(notifications).values(rows);
 
-  if (realtimeEnv) {
-    const createdAt = new Date().toISOString();
-    await Promise.all(
-      rows.map((row) =>
-        broadcastNotification(realtimeEnv, row.userId, {
-          kind: "notification",
-          id: row.id,
-          type: row.type,
-          title: row.title,
-          href: row.href,
-          createdAt,
-        }),
-      ),
-    );
-  }
+  const fanOut = async () => {
+    if (realtimeEnv) {
+      const createdAt = new Date().toISOString();
+      const broadcastResults = await Promise.allSettled(
+        rows.map((row) =>
+          broadcastNotification(realtimeEnv, row.userId, {
+            kind: "notification",
+            id: row.id,
+            type: row.type,
+            title: row.title,
+            href: row.href,
+            createdAt,
+          }),
+        ),
+      );
+      const broadcastFailures = broadcastResults.filter(
+        (r): r is PromiseRejectedResult => r.status === "rejected",
+      );
+      if (broadcastFailures.length > 0) {
+        console.error(
+          `${broadcastFailures.length}/${broadcastResults.length} approval-request broadcasts failed`,
+          broadcastFailures.map((f) => f.reason),
+        );
+      }
+    }
 
-  if (!emailConfig) return;
+    if (!emailConfig) return;
 
-  try {
-    const emailRecipients = await db
-      .select({ id: users.id, email: users.email })
-      .from(users)
-      .where(
-        and(
-          inArray(users.id, recipientIds),
-          eq(users.emailNotificationsEnabled, true),
+    try {
+      const emailRecipients = await db
+        .select({ id: users.id, email: users.email })
+        .from(users)
+        .where(
+          and(
+            inArray(users.id, recipientIds),
+            eq(users.emailNotificationsEnabled, true),
+          ),
+        );
+
+      if (emailRecipients.length === 0) return;
+
+      const emailContent = buildApprovalRequestEmail({
+        actorDisplayName: input.actorDisplayName,
+        videoTitle: video.title,
+        href,
+        baseUrl: emailConfig.baseUrl,
+      });
+
+      const results = await Promise.allSettled(
+        emailRecipients.map((recipient) =>
+          emailConfig.send({
+            to: recipient.email,
+            from: emailConfig.from,
+            subject: emailContent.subject,
+            text: emailContent.text,
+            html: emailContent.html,
+          }),
         ),
       );
 
-    if (emailRecipients.length === 0) return;
-
-    const emailContent = buildApprovalRequestEmail({
-      actorDisplayName: input.actorDisplayName,
-      videoTitle: video.title,
-      href,
-      baseUrl: emailConfig.baseUrl,
-    });
-
-    const results = await Promise.allSettled(
-      emailRecipients.map((recipient) =>
-        emailConfig.send({
-          to: recipient.email,
-          from: emailConfig.from,
-          subject: emailContent.subject,
-          text: emailContent.text,
-          html: emailContent.html,
-        }),
-      ),
-    );
-
-    const failures = results.filter(
-      (r): r is PromiseRejectedResult => r.status === "rejected",
-    );
-    if (failures.length > 0) {
-      console.error(
-        `${failures.length}/${results.length} approval-request emails failed`,
-        failures.map((f) => f.reason),
+      const failures = results.filter(
+        (r): r is PromiseRejectedResult => r.status === "rejected",
       );
+      if (failures.length > 0) {
+        console.error(
+          `${failures.length}/${results.length} approval-request emails failed`,
+          failures.map((f) => f.reason),
+        );
+      }
+    } catch (error) {
+      console.error("Failed to send approval-request emails", error);
     }
-  } catch (error) {
-    console.error("Failed to send approval-request emails", error);
+  };
+
+  if (ctx) {
+    ctx.waitUntil(fanOut());
+  } else {
+    await fanOut();
   }
 }
 

--- a/src/lib/stream.ts
+++ b/src/lib/stream.ts
@@ -1,5 +1,56 @@
 const STREAM_API_BASE = "https://api.cloudflare.com/client/v4/accounts";
 
+const STREAM_FETCH_TIMEOUT_MS = 15_000;
+const STREAM_FETCH_MAX_ATTEMPTS = 3;
+const STREAM_FETCH_BACKOFF_MS = 500;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Fetch wrapper for Cloudflare Stream API calls. Adds a 15s abort timeout
+ * and retries 5xx responses up to 3 times with linear backoff. Network and
+ * abort errors are retried with the same policy.
+ */
+async function streamFetch(url: string, init: RequestInit = {}): Promise<Response> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= STREAM_FETCH_MAX_ATTEMPTS; attempt++) {
+    try {
+      const response = await fetch(url, {
+        ...init,
+        signal: AbortSignal.timeout(STREAM_FETCH_TIMEOUT_MS),
+      });
+
+      if (response.status >= 500 && attempt < STREAM_FETCH_MAX_ATTEMPTS) {
+        console.warn(
+          `Stream API ${response.status} on attempt ${attempt}/${STREAM_FETCH_MAX_ATTEMPTS}; retrying`,
+          { url },
+        );
+        await sleep(STREAM_FETCH_BACKOFF_MS * attempt);
+        continue;
+      }
+
+      return response;
+    } catch (error) {
+      lastError = error;
+      if (attempt < STREAM_FETCH_MAX_ATTEMPTS) {
+        console.warn(
+          `Stream API fetch failed on attempt ${attempt}/${STREAM_FETCH_MAX_ATTEMPTS}; retrying`,
+          { url, error: error instanceof Error ? error.message : String(error) },
+        );
+        await sleep(STREAM_FETCH_BACKOFF_MS * attempt);
+        continue;
+      }
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Stream API fetch failed after retries");
+}
+
 interface DirectUploadResult {
   uploadUrl: string;
   streamVideoId: string;
@@ -11,7 +62,7 @@ export async function createDirectUpload(
   fileName: string,
   fileSize: number,
 ): Promise<DirectUploadResult> {
-  const response = await fetch(
+  const response = await streamFetch(
     `${STREAM_API_BASE}/${accountId}/stream?direct_user=true`,
     {
       method: "POST",
@@ -52,7 +103,7 @@ export async function getVideoInfo(
   apiToken: string,
   streamVideoId: string,
 ): Promise<StreamVideoInfo> {
-  const response = await fetch(
+  const response = await streamFetch(
     `${STREAM_API_BASE}/${accountId}/stream/${streamVideoId}`,
     {
       headers: {
@@ -74,7 +125,7 @@ export async function deleteVideo(
   apiToken: string,
   streamVideoId: string,
 ): Promise<void> {
-  const response = await fetch(
+  const response = await streamFetch(
     `${STREAM_API_BASE}/${accountId}/stream/${streamVideoId}`,
     {
       method: "DELETE",
@@ -109,7 +160,7 @@ export async function requestAudioDownload(
   apiToken: string,
   streamVideoId: string,
 ): Promise<StreamAudioDownload> {
-  const response = await fetch(
+  const response = await streamFetch(
     `${STREAM_API_BASE}/${accountId}/stream/${streamVideoId}/downloads/audio`,
     {
       method: "POST",
@@ -142,7 +193,7 @@ export async function getAudioDownload(
   apiToken: string,
   streamVideoId: string,
 ): Promise<StreamAudioDownload | null> {
-  const response = await fetch(
+  const response = await streamFetch(
     `${STREAM_API_BASE}/${accountId}/stream/${streamVideoId}/downloads`,
     {
       headers: {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,6 +8,7 @@ declare global {
   namespace App {
     interface Locals {
       user: { id: string; email: string; name: string; image?: string | null } | null;
+      cfContext: ExecutionContext;
     }
   }
 }

--- a/src/pages/api/webhooks/stream.ts
+++ b/src/pages/api/webhooks/stream.ts
@@ -101,7 +101,7 @@ async function verifyWebhookSignature(
   return { valid: true, parsed };
 }
 
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async ({ request, locals }) => {
   const body = await request.text();
   const signature = request.headers.get("Webhook-Signature");
 
@@ -161,14 +161,16 @@ export const POST: APIRoute = async ({ request }) => {
       })
       .where(eq(videos.id, video.id));
 
-    await queueTranscriptForVideo(env, db, {
-      ...video,
-      status: "ready",
-      duration: payload.duration,
-      thumbnailUrl: payload.thumbnail,
-      streamPlaybackUrl: payload.playback.hls,
-      updatedAt: now,
-    });
+    locals.cfContext.waitUntil(
+      queueTranscriptForVideo(env, db, {
+        ...video,
+        status: "ready",
+        duration: payload.duration,
+        thumbnailUrl: payload.thumbnail,
+        streamPlaybackUrl: payload.playback.hls,
+        updatedAt: now,
+      }),
+    );
   } else if (payload.status.state === "error") {
     await db
       .update(videos)

--- a/src/workflows/TranscriptWorkflow.ts
+++ b/src/workflows/TranscriptWorkflow.ts
@@ -98,7 +98,9 @@ export class TranscriptWorkflow extends WorkflowEntrypoint<Env, TranscriptWorkfl
           .set({ status: "transcribing", updatedAt: now() })
           .where(eq(transcripts.id, transcriptId));
 
-        const audioResponse = await fetch(audioUrl);
+        const audioResponse = await fetch(audioUrl, {
+          signal: AbortSignal.timeout(60_000),
+        });
         if (!audioResponse.ok) throw new Error(`Audio fetch failed: ${audioResponse.status}`);
 
         const audioBuffer = await audioResponse.arrayBuffer();


### PR DESCRIPTION
## Summary

PR **A of 3** addressing #140 (latency + reliability audit).

- Comment/approval/invite actions no longer block on broadcast or email — they hand off to `ctx.waitUntil` and return immediately.
- The Stream webhook returns 200 without waiting for `queueTranscriptForVideo`.
- All Cloudflare Stream API calls now go through a `streamFetch` helper with a 15s abort timeout and 3-attempt linear-backoff retry on 5xx.
- The Whisper audio fetch in `TranscriptWorkflow` gets a 60s abort timeout.

Out of scope for this PR (covered by PR B and PR C):
- Workflow Whisper/cleanup retry + split (PR B)
- `GET /api/videos/[id]/status` read-only (PR B)
- Workflow stub orphan fix in `lib/transcripts.ts` (PR B)
- Notification query fixes, DO auto-response/debounce, middleware memoize, Stream embed loader, `nodejs_compat` cleanup (PR C)

## Changes

- `src/middleware.ts`: declare `cfContext: ExecutionContext` on `App.Locals`.
- `src/lib/notifications.ts`: `createCommentNotifications` and `createTargetedApprovalRequestNotifications` accept an optional `ctx`; broadcast + email fan-out moves into a `fanOut` closure dispatched via `ctx.waitUntil` when provided. D1 insert stays on the request path. Broadcast errors use `Promise.allSettled` so one bad recipient doesn't fail the rest.
- `src/actions/index.ts`: pass `context.locals.cfContext` into the two notification helpers; wrap `broadcastNewComment` (×2), `broadcastCommentReactions`, `broadcastNotification` (invite signal), `broadcastNotificationsRead` in `cfContext.waitUntil`.
- `src/pages/api/webhooks/stream.ts`: `queueTranscriptForVideo` now runs under `locals.cfContext.waitUntil` so the webhook returns 200 fast.
- `src/lib/stream.ts`: new internal `streamFetch` with `AbortSignal.timeout(15_000)` and 3-attempt retry on 5xx (linear 500ms × attempt backoff). All 5 fetch sites (`createDirectUpload`, `getVideoInfo`, `deleteVideo`, `requestAudioDownload`, `getAudioDownload`) routed through it.
- `src/workflows/TranscriptWorkflow.ts`: audio fetch gets `AbortSignal.timeout(60_000)`. (The earlier `[...audioBytes]` spread is already `Array.from(audioBytes)` in current code.)

## Notes on the issue spec vs the codebase

- The issue refers to `Astro.locals.runtime.ctx`. In the current Astro v6 Cloudflare adapter, `ExecutionContext` is exposed as `Astro.locals.cfContext`. Using that here. The `runtime.ctx` getter intentionally throws with a migration hint, so this is the right path.
- The audit's `[...audioBytes]` spread is no longer present — the workflow already uses `Array.from(audioBytes)`. Only the timeout was missing.

## Testing

See test plan in the follow-up message.

Refs #140 (full close happens with PR C once notification queries, DO auto-response, and stub-fix land).