### PR TITLE
fix(transcripts): Workflow retries + read-only GET status + workflow-stub fix (PR B of 3 for #140)

### DIFF
--- a/src/lib/transcripts.ts
+++ b/src/lib/transcripts.ts
@@ -107,6 +107,15 @@ export async function queueTranscriptForVideo(
     return;
   }
 
+  const workflow = env.TRANSCRIPT_WORKFLOW;
+  if (!workflow) {
+    console.warn(
+      "TRANSCRIPT_WORKFLOW binding is missing; skipping transcript queue for video",
+      video.id,
+    );
+    return;
+  }
+
   const workflowInstanceId = `transcript-${transcriptId}`;
 
   if (existing[0]) {
@@ -130,9 +139,6 @@ export async function queueTranscriptForVideo(
       updatedAt: now,
     });
   }
-
-  const workflow = env.TRANSCRIPT_WORKFLOW;
-  if (!workflow) return;
 
   try {
     await workflow.create({

--- a/src/pages/api/videos/[id]/status.ts
+++ b/src/pages/api/videos/[id]/status.ts
@@ -3,8 +3,6 @@ import { env } from "cloudflare:workers";
 import { createDb } from "../../../../db";
 import { videos } from "../../../../db/schema";
 import { eq } from "drizzle-orm";
-import { getVideoInfo } from "../../../../lib/stream";
-import { queueTranscriptForVideo } from "../../../../lib/transcripts";
 import { verifySpaceAccess } from "../../../../lib/spaces";
 
 export const GET: APIRoute = async ({ params, locals }) => {
@@ -25,7 +23,13 @@ export const GET: APIRoute = async ({ params, locals }) => {
 
   const db = createDb(env.DB);
   const result = await db
-    .select()
+    .select({
+      spaceId: videos.spaceId,
+      status: videos.status,
+      thumbnailUrl: videos.thumbnailUrl,
+      duration: videos.duration,
+      streamPlaybackUrl: videos.streamPlaybackUrl,
+    })
     .from(videos)
     .where(eq(videos.id, id))
     .limit(1);
@@ -39,82 +43,12 @@ export const GET: APIRoute = async ({ params, locals }) => {
 
   const video = result[0];
 
-  // Verify user has space access
-  const statusRole = await verifySpaceAccess(db, locals.user.id, video.spaceId);
-  if (!statusRole) {
+  const role = await verifySpaceAccess(db, locals.user.id, video.spaceId);
+  if (!role) {
     return new Response(JSON.stringify({ error: "Forbidden" }), {
       status: 403,
       headers: { "Content-Type": "application/json" },
     });
-  }
-
-  // If still processing and we have a Stream video ID, check Stream API directly
-  // This handles the case where the webhook can't reach us (e.g. local dev)
-  if (video.status === "processing" && video.streamVideoId) {
-    try {
-      const info = await getVideoInfo(
-        env.STREAM_ACCOUNT_ID,
-        env.STREAM_API_TOKEN,
-        video.streamVideoId,
-      );
-
-      if (info.readyToStream && info.status.state === "ready") {
-        const now = new Date().toISOString();
-        // Update DB with the real data from Stream
-        await db
-          .update(videos)
-          .set({
-            status: "ready",
-            duration: info.duration,
-            thumbnailUrl: info.thumbnail,
-            streamPlaybackUrl: info.playback.hls,
-            updatedAt: now,
-          })
-          .where(eq(videos.id, id));
-
-        await queueTranscriptForVideo(env, db, {
-          ...video,
-          status: "ready",
-          duration: info.duration,
-          thumbnailUrl: info.thumbnail,
-          streamPlaybackUrl: info.playback.hls,
-          updatedAt: now,
-        });
-
-        return new Response(
-          JSON.stringify({
-            status: "ready",
-            thumbnailUrl: info.thumbnail,
-            duration: info.duration,
-            streamPlaybackUrl: info.playback.hls,
-          }),
-          { headers: { "Content-Type": "application/json" } },
-        );
-      }
-
-      if (info.status.state === "error") {
-        await db
-          .update(videos)
-          .set({
-            status: "failed",
-            updatedAt: new Date().toISOString(),
-          })
-          .where(eq(videos.id, id));
-
-        return new Response(
-          JSON.stringify({
-            status: "failed",
-            thumbnailUrl: null,
-            duration: null,
-            streamPlaybackUrl: null,
-          }),
-          { headers: { "Content-Type": "application/json" } },
-        );
-      }
-    } catch (e) {
-      // Stream API check failed — fall through and return DB status
-      console.error("Stream API status check failed:", e);
-    }
   }
 
   return new Response(

--- a/src/workflows/TranscriptWorkflow.ts
+++ b/src/workflows/TranscriptWorkflow.ts
@@ -92,70 +92,83 @@ export class TranscriptWorkflow extends WorkflowEntrypoint<Env, TranscriptWorkfl
         },
       );
 
-      const transcribed = await step.do("transcribe audio", { timeout: "10 minutes" }, async () => {
-        await db
-          .update(transcripts)
-          .set({ status: "transcribing", updatedAt: now() })
-          .where(eq(transcripts.id, transcriptId));
+      const transcribed = await step.do(
+        "transcribe audio",
+        {
+          timeout: "10 minutes",
+          retries: { limit: 3, delay: "30 seconds", backoff: "exponential" },
+        },
+        async () => {
+          await db
+            .update(transcripts)
+            .set({ status: "transcribing", updatedAt: now() })
+            .where(eq(transcripts.id, transcriptId));
 
-        const audioResponse = await fetch(audioUrl);
-        if (!audioResponse.ok) throw new Error(`Audio fetch failed: ${audioResponse.status}`);
+          const audioResponse = await fetch(audioUrl);
+          if (!audioResponse.ok) throw new Error(`Audio fetch failed: ${audioResponse.status}`);
 
-        const audioBuffer = await audioResponse.arrayBuffer();
-        const audioBytes = new Uint8Array(audioBuffer);
-        const response = await this.env.AI.run("@cf/openai/whisper", {
-          audio: Array.from(audioBytes),
-        }) as WhisperResponse;
+          const audioBuffer = await audioResponse.arrayBuffer();
+          const audioBytes = new Uint8Array(audioBuffer);
+          const response = await this.env.AI.run("@cf/openai/whisper", {
+            audio: Array.from(audioBytes),
+          }) as WhisperResponse;
 
-        if (!response.text) throw new Error("Workers AI did not return transcript text");
+          if (!response.text) throw new Error("Workers AI did not return transcript text");
 
-        await db
-          .update(transcripts)
-          .set({
-            rawText: response.text,
-            vtt: response.vtt || null,
-            wordCount: response.word_count || null,
-            status: "ready_raw_only",
-            updatedAt: now(),
-          })
-          .where(eq(transcripts.id, transcriptId));
+          await db
+            .update(transcripts)
+            .set({
+              rawText: response.text,
+              vtt: response.vtt || null,
+              wordCount: response.word_count || null,
+              status: "ready_raw_only",
+              updatedAt: now(),
+            })
+            .where(eq(transcripts.id, transcriptId));
 
-        return { text: response.text };
-      });
+          return { text: response.text };
+        },
+      );
 
-      await step.do("clean transcript", { timeout: "5 minutes" }, async () => {
+      await step.do("mark cleaning", async () => {
         await db
           .update(transcripts)
           .set({ status: "cleaning", updatedAt: now() })
           .where(eq(transcripts.id, transcriptId));
+      });
 
-        try {
-          const response = await this.env.AI.run(this.env.TRANSCRIPT_CLEANUP_MODEL, {
-            messages: [{ role: "user", content: getCleanupPrompt(transcribed.text) }],
-          }) as TextGenerationResponse;
+      let cleanedText: string | null = null;
+      let cleanupErrorMessage: string | null = null;
+      try {
+        cleanedText = await step.do(
+          "clean transcript ai call",
+          {
+            timeout: "5 minutes",
+            retries: { limit: 3, delay: "10 seconds" },
+          },
+          async () => {
+            const response = await this.env.AI.run(this.env.TRANSCRIPT_CLEANUP_MODEL, {
+              messages: [{ role: "user", content: getCleanupPrompt(transcribed.text) }],
+            }) as TextGenerationResponse;
+            const cleaned = response.response?.trim();
+            return cleaned || null;
+          },
+        );
+      } catch (err) {
+        cleanupErrorMessage = err instanceof Error ? err.message : "Transcript cleanup failed";
+      }
 
-          const cleaned = response.response?.trim();
-          await db
-            .update(transcripts)
-            .set({
-              cleanedText: cleaned || null,
-              status: cleaned ? "ready" : "ready_raw_only",
-              completedAt: now(),
-              updatedAt: now(),
-            })
-            .where(eq(transcripts.id, transcriptId));
-        } catch (cleanupError) {
-          // Cleanup failure is non-fatal -- raw transcript is still usable.
-          await db
-            .update(transcripts)
-            .set({
-              status: "ready_raw_only",
-              errorMessage: cleanupError instanceof Error ? cleanupError.message : "Transcript cleanup failed",
-              completedAt: now(),
-              updatedAt: now(),
-            })
-            .where(eq(transcripts.id, transcriptId));
-        }
+      await step.do("persist cleaned transcript", async () => {
+        await db
+          .update(transcripts)
+          .set({
+            cleanedText,
+            status: cleanedText ? "ready" : "ready_raw_only",
+            errorMessage: cleanupErrorMessage,
+            completedAt: now(),
+            updatedAt: now(),
+          })
+          .where(eq(transcripts.id, transcriptId));
       });
     } catch (err) {
       await step.do("mark failed", async () => {


### PR DESCRIPTION
## Summary

PR **B of 3** addressing #140 (latency + reliability audit). Tightens the transcript pipeline:

- A single transient Workers AI failure no longer permanently fails transcription — the Whisper step now retries (3×, 30s base, exponential).
- The cleanup step is split so the runtime actually retries the AI call instead of having errors swallowed by a try/catch inside the step.
- \`GET /api/videos/[id]/status\` no longer mutates the videos table or creates Workflow instances. The Stream webhook stays the sole owner of state transitions.
- \`queueTranscriptForVideo\` no longer leaves an orphan \`queued\` transcript row when the \`TRANSCRIPT_WORKFLOW\` binding is missing.

Out of scope (covered by PR A — already up as #182 — and PR C):
- PR A: \`ctx.waitUntil\` for fan-out, Stream API timeouts/retries, audio fetch timeout.
- PR C: notification query fixes, DO auto-response/debounce, middleware memoize, Stream embed loader, \`nodejs_compat\` removal attempt.

## Changes

- \`src/workflows/TranscriptWorkflow.ts\`:
  - \`step.do("transcribe audio", ...)\` now passes \`retries: { limit: 3, delay: "30 seconds", backoff: "exponential" }\` alongside the existing 10-minute timeout.
  - The old combined \`"clean transcript"\` step is replaced by:
    1. \`step.do("mark cleaning", ...)\` — D1 status flip.
    2. \`step.do("clean transcript ai call", { timeout: "5 minutes", retries: { limit: 3, delay: "10 seconds" } }, ...)\` — pure AI call, no try/catch, returns the cleaned text or \`null\`.
    3. \`step.do("persist cleaned transcript", ...)\` — writes either the cleaned text (\`status: "ready"\`) or a \`ready_raw_only\` fallback with the cleanup error message after the retries are exhausted.
  - The cleanup step's try/catch lives in the workflow \`run()\` body, around just the AI-call step, so a failure marks status \`ready_raw_only\` (raw is still usable) without short-circuiting the runtime's retry policy on the AI call itself, and without falling into the outer \`mark failed\` handler.

- \`src/pages/api/videos/[id]/status.ts\`: removed the Stream API check and the side-effecting writes to \`videos.status\` / the \`queueTranscriptForVideo\` call. Now returns cached DB state only. Stream webhook → DB → GET status is the only path. If a polling-bootstrap path is ever needed for local dev where the webhook can't reach us, that should be a separate POST endpoint (as the issue notes).

- \`src/lib/transcripts.ts\`: moved \`if (!env.TRANSCRIPT_WORKFLOW) return\` above the \`transcripts\` insert/update so a missing binding no longer leaves an orphan \`queued\` row. Logs a warning when this happens so it's visible in production.

## Testing

\`pnpm build\` passes locally. See manual test plan below.

Refs #140 (full close happens with PR C once notification queries, DO auto-response, and the rest land).